### PR TITLE
XTGETTCAP (DCS +q) support

### DIFF
--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -187,6 +187,7 @@ public:
     virtual StringHandler RestoreTerminalState(const DispatchTypes::ReportFormat format) = 0; // DECRSTS
 
     virtual StringHandler RequestSetting() = 0; // DECRQSS
+    virtual StringHandler RequestTermcap() = 0; // XTGETTCAP (DCS +q)
 
     virtual void RequestPresentationStateReport(const DispatchTypes::PresentationReportFormat format) = 0; // DECRQPSR
     virtual StringHandler RestorePresentationState(const DispatchTypes::PresentationReportFormat format) = 0; // DECRSPS

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -4389,6 +4389,12 @@ void AdaptDispatch::_ReportTermcap(const std::wstring_view hexName)
     // Resolve the capability value. Dynamic caps consult the live TerminalInput
     // state (DECCKM for cursor keys, BackarrowKey for kbs). Never duplicate
     // string tables — we must stay in sync with the input encoder.
+    //
+    // Wire format note (xterm-compatible): per xterm ctlseqs, the response
+    // value is "the value of the corresponding string that xterm would send"
+    // — i.e. the RAW BYTES the terminal would transmit, hex-encoded. So ESC is
+    // 0x1b (one byte), NOT the two-byte sequence "\E" (0x5c 0x45). Parameterized
+    // caps preserve their literal terminfo placeholder bytes (%p1, %d, %s, %?).
     std::string_view value;
     auto known = false;
 
@@ -4418,17 +4424,32 @@ void AdaptDispatch::_ReportTermcap(const std::wstring_view hexName)
         }
         else if (decoded == "Smulx")
         {
-            value = "\\E[4:%p1%dm"sv;
+            // \E[4:%p1%dm  (parameterized colon-separated underline style)
+            value = "\x1b[4:%p1%dm"sv;
             known = true;
         }
         else if (decoded == "Ms")
         {
-            value = "\\E]52;%p1%s;%p2%s\\E\\\\"sv;
+            // \E]52;%p1%s;%p2%s\E\\  (OSC 52 set-clipboard, terminated by ST)
+            value = "\x1b]52;%p1%s;%p2%s\x1b\\"sv;
+            known = true;
+        }
+        else if (decoded == "Ss")
+        {
+            // DECSCUSR set cursor shape: \E[%p1%d q
+            value = "\x1b[%p1%d q"sv;
+            known = true;
+        }
+        else if (decoded == "Se")
+        {
+            // DECSCUSR reset cursor shape to default: \E[2 q
+            value = "\x1b[2 q"sv;
             known = true;
         }
         else if (decoded == "kdch1")
         {
-            value = "\\E[3~"sv;
+            // Plain Delete key: \E[3~
+            value = "\x1b[3~"sv;
             known = true;
         }
         else if (decoded == "kbs")
@@ -4440,16 +4461,41 @@ void AdaptDispatch::_ReportTermcap(const std::wstring_view hexName)
         }
         else if (decoded == "kcuu1" || decoded == "kcud1" || decoded == "kcuf1" || decoded == "kcub1")
         {
-            // CursorKey mode (DECCKM) selects between CSI (\E[) and SS3 (\EO).
+            // CursorKey mode (DECCKM) selects between CSI (ESC[) and SS3 (ESCO).
             const auto app = _terminalInput.GetInputMode(TerminalInput::Mode::CursorKey);
             if (decoded == "kcuu1")
-                value = app ? "\\EOA"sv : "\\E[A"sv;
+                value = app ? "\x1bOA"sv : "\x1b[A"sv;
             else if (decoded == "kcud1")
-                value = app ? "\\EOB"sv : "\\E[B"sv;
+                value = app ? "\x1bOB"sv : "\x1b[B"sv;
             else if (decoded == "kcuf1")
-                value = app ? "\\EOC"sv : "\\E[C"sv;
+                value = app ? "\x1bOC"sv : "\x1b[C"sv;
             else // kcub1
-                value = app ? "\\EOD"sv : "\\E[D"sv;
+                value = app ? "\x1bOD"sv : "\x1b[D"sv;
+            known = true;
+        }
+        else if (decoded == "kDC" || decoded == "kUP" || decoded == "kDN" ||
+                 decoded == "kRIT" || decoded == "kLFT" || decoded == "kHOM" ||
+                 decoded == "kEND")
+        {
+            // Shift-modified navigation keys. Standard xterm-256color form is
+            // CSI <key>;2 <final>, matching what TerminalInput emits via
+            // _formatEncodingHelper (terminalInput.cpp ~line 1117) when only
+            // the SHIFT modifier flag is set: keycode=1 (or 3 for Delete),
+            // modifier=1+CSI_SHIFT=2.
+            if (decoded == "kDC")
+                value = "\x1b[3;2~"sv;
+            else if (decoded == "kUP")
+                value = "\x1b[1;2A"sv;
+            else if (decoded == "kDN")
+                value = "\x1b[1;2B"sv;
+            else if (decoded == "kRIT")
+                value = "\x1b[1;2C"sv;
+            else if (decoded == "kLFT")
+                value = "\x1b[1;2D"sv;
+            else if (decoded == "kHOM")
+                value = "\x1b[1;2H"sv;
+            else // kEND
+                value = "\x1b[1;2F"sv;
             known = true;
         }
     }

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -4273,6 +4273,219 @@ ITermDispatch::StringHandler AdaptDispatch::RequestSetting()
 }
 
 // Method Description:
+// - XTGETTCAP (DCS +q) — Request Terminfo Capability. The client sends one or
+//   more semicolon-separated hex-encoded capability names inside a DCS +q ... ST
+//   frame. For each name we emit an independent DCS response:
+//     DCS 1 + r <hexname> = <hexvalue> ST     (known cap)
+//     DCS 0 + r <hexname> ST                  (unknown / malformed cap)
+//   The request's hex case is echoed verbatim in the response.
+// Security: payload is bounded to 4096 bytes total and 64 hex chars (32 bytes)
+//   per capability name. Oversized inputs cause the handler to return false,
+//   transitioning the state machine to DcsIgnore without emitting further
+//   replies. We never echo attacker-supplied bytes beyond the hex name itself,
+//   and the value side is always drawn from our static table or live input
+//   state (never from the request).
+// Arguments:
+// - None
+// Return Value:
+// - a function to receive the hex-encoded capability names
+ITermDispatch::StringHandler AdaptDispatch::RequestTermcap()
+{
+    return [this, name = std::wstring{}, total = size_t{ 0 }, poisoned = false](const auto ch) mutable -> bool {
+        // ESC indicates start of ST (or abort). Emit the pending name, then tell
+        // the state machine we're done so it can re-dispatch the ESC.
+        if (ch == AsciiChars::ESC)
+        {
+            if (!name.empty() || poisoned)
+            {
+                _ReportTermcap(poisoned ? std::wstring_view{} : std::wstring_view{ name });
+            }
+            name.clear();
+            poisoned = false;
+            return false;
+        }
+
+        // Cap the total payload at 4 KB to defeat DoS. On overflow, abort the
+        // whole DCS string without further replies.
+        if (++total > 4096)
+        {
+            return false;
+        }
+
+        if (ch == L';')
+        {
+            _ReportTermcap(poisoned ? std::wstring_view{} : std::wstring_view{ name });
+            name.clear();
+            poisoned = false;
+            return true;
+        }
+
+        const auto isHex = (ch >= L'0' && ch <= L'9') || // NOTE: inclusive '9' (avoids the 4258 bug)
+                           (ch >= L'A' && ch <= L'F') ||
+                           (ch >= L'a' && ch <= L'f');
+        if (!isHex)
+        {
+            // Malformed: mark this cap as poisoned so we reply miss on terminator.
+            poisoned = true;
+            return true;
+        }
+
+        // Cap the per-name length at 64 hex chars (32 decoded bytes). Exceeding
+        // this poisons the name (miss reply) but keeps parsing alive so we
+        // don't drop siblings after `;`.
+        if (name.size() >= 64)
+        {
+            poisoned = true;
+            return true;
+        }
+
+        name.push_back(gsl::narrow_cast<wchar_t>(ch));
+        return true;
+    };
+}
+
+// Routine Description:
+// - Decodes the given hex-encoded capability name and, if recognized, emits
+//   a DCS reply containing the terminfo value for that cap. Unknown caps
+//   produce a miss reply. Empty or odd-length names are treated as a miss.
+// Arguments:
+// - hexName - the ASCII-hex capability name, case-preserved from the request.
+//             Empty means the request was malformed (reply miss with no name).
+// Return Value:
+// - None
+void AdaptDispatch::_ReportTermcap(const std::wstring_view hexName)
+{
+    using namespace std::string_view_literals;
+
+    // Decode hex -> ASCII. Odd-length or non-ASCII-hex content (shouldn't
+    // happen by construction, but be defensive) produces a miss reply.
+    std::string decoded;
+    decoded.reserve(hexName.size() / 2);
+    auto decodeOk = !hexName.empty() && (hexName.size() % 2 == 0);
+    if (decodeOk)
+    {
+        const auto nibble = [](wchar_t c) -> int {
+            if (c >= L'0' && c <= L'9')
+                return c - L'0';
+            if (c >= L'A' && c <= L'F')
+                return c - L'A' + 10;
+            if (c >= L'a' && c <= L'f')
+                return c - L'a' + 10;
+            return -1;
+        };
+        for (size_t i = 0; i < hexName.size(); i += 2)
+        {
+            const auto hi = nibble(hexName[i]);
+            const auto lo = nibble(hexName[i + 1]);
+            if (hi < 0 || lo < 0)
+            {
+                decodeOk = false;
+                break;
+            }
+            decoded.push_back(gsl::narrow_cast<char>((hi << 4) | lo));
+        }
+    }
+
+    // Resolve the capability value. Dynamic caps consult the live TerminalInput
+    // state (DECCKM for cursor keys, BackarrowKey for kbs). Never duplicate
+    // string tables — we must stay in sync with the input encoder.
+    std::string_view value;
+    auto known = false;
+
+    if (decodeOk)
+    {
+        // Static caps first.
+        if (decoded == "TN")
+        {
+            value = "xterm-256color"sv;
+            known = true;
+        }
+        else if (decoded == "Co" || decoded == "colors")
+        {
+            value = "256"sv;
+            known = true;
+        }
+        else if (decoded == "RGB")
+        {
+            value = "8/8/8"sv;
+            known = true;
+        }
+        else if (decoded == "bce" || decoded == "Tc")
+        {
+            // Boolean caps: present, empty value.
+            value = ""sv;
+            known = true;
+        }
+        else if (decoded == "Smulx")
+        {
+            value = "\\E[4:%p1%dm"sv;
+            known = true;
+        }
+        else if (decoded == "Ms")
+        {
+            value = "\\E]52;%p1%s;%p2%s\\E\\\\"sv;
+            known = true;
+        }
+        else if (decoded == "kdch1")
+        {
+            value = "\\E[3~"sv;
+            known = true;
+        }
+        else if (decoded == "kbs")
+        {
+            // BackarrowKey mode OFF (default) -> DEL (0x7f); ON -> BS (0x08).
+            // Matches the input encoder in terminalInput.cpp (~line 843).
+            value = _terminalInput.GetInputMode(TerminalInput::Mode::BackarrowKey) ? "\x08"sv : "\x7f"sv;
+            known = true;
+        }
+        else if (decoded == "kcuu1" || decoded == "kcud1" || decoded == "kcuf1" || decoded == "kcub1")
+        {
+            // CursorKey mode (DECCKM) selects between CSI (\E[) and SS3 (\EO).
+            const auto app = _terminalInput.GetInputMode(TerminalInput::Mode::CursorKey);
+            if (decoded == "kcuu1")
+                value = app ? "\\EOA"sv : "\\E[A"sv;
+            else if (decoded == "kcud1")
+                value = app ? "\\EOB"sv : "\\E[B"sv;
+            else if (decoded == "kcuf1")
+                value = app ? "\\EOC"sv : "\\E[C"sv;
+            else // kcub1
+                value = app ? "\\EOD"sv : "\\E[D"sv;
+            known = true;
+        }
+    }
+
+    // Hex-encode the value (uppercase hex is xterm convention, but most
+    // clients accept either; we emit lowercase to stay byte-for-byte with the
+    // golden hex tables in the spec).
+    const auto toHex = [](unsigned char b, wchar_t out[2]) {
+        constexpr wchar_t digits[] = L"0123456789abcdef";
+        out[0] = digits[(b >> 4) & 0xF];
+        out[1] = digits[b & 0xF];
+    };
+
+    fmt::basic_memory_buffer<wchar_t, 128> response;
+    if (known)
+    {
+        response.append(L"1+r"sv);
+        response.append(hexName);
+        response.push_back(L'=');
+        wchar_t buf[2];
+        for (const auto c : value)
+        {
+            toHex(gsl::narrow_cast<unsigned char>(c), buf);
+            response.append(std::wstring_view{ buf, 2 });
+        }
+    }
+    else
+    {
+        response.append(L"0+r"sv);
+        response.append(hexName);
+    }
+
+    _ReturnDcsResponse({ response.data(), response.size() });
+}
+
+// Method Description:
 // - Reports the current SGR attributes in response to a DECRQSS query.
 // Arguments:
 // - None

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -188,6 +188,7 @@ namespace Microsoft::Console::VirtualTerminal
         StringHandler RestoreTerminalState(const DispatchTypes::ReportFormat format) override; // DECRSTS
 
         StringHandler RequestSetting() override; // DECRQSS
+        StringHandler RequestTermcap() override; // XTGETTCAP (DCS +q)
 
         void RequestPresentationStateReport(const DispatchTypes::PresentationReportFormat format) override; // DECRQPSR
         StringHandler RestorePresentationState(const DispatchTypes::PresentationReportFormat format) override; // DECRSPS
@@ -294,6 +295,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _ReportDECSCASetting() const;
         void _ReportDECSACESetting() const;
         void _ReportDECACSetting(const VTInt itemNumber) const;
+        void _ReportTermcap(const std::wstring_view hexName);
 
         void _ReportCursorInformation();
         StringHandler _RestoreCursorInformation();

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -178,6 +178,7 @@ public:
     StringHandler RestoreTerminalState(const DispatchTypes::ReportFormat /*format*/) override { return nullptr; }; // DECRSTS
 
     StringHandler RequestSetting() override { return nullptr; }; // DECRQSS
+    StringHandler RequestTermcap() override { return nullptr; }; // XTGETTCAP (DCS +q)
 
     void RequestPresentationStateReport(const DispatchTypes::PresentationReportFormat /*format*/) override {} // DECRQPSR
     StringHandler RestorePresentationState(const DispatchTypes::PresentationReportFormat /*format*/) override { return nullptr; } // DECRSPS

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -2308,27 +2308,13 @@ public:
         _terminalInput.SetInputMode(TerminalInput::Mode::BackarrowKey, false);
     }
 
-    TEST_METHOD(XtgettcapStandaloneReplies)
-    {
-        // Terminal-side (IsConPTY() == false on the TestGetSet mock): a reply
-        // _must_ be emitted. This covers AC-X9 negative expectation's
-        // inverse — any non-PTY instance answers normally.
-        VERIFY_IS_FALSE(_testGetSet->IsConPTY());
-        _testGetSet->PrepData();
-        const auto h = _pDispatch->RequestTermcap();
-        for (auto ch : std::wstring_view{ L"5463" })
-            h(ch);
-        h(L'\033');
-        _testGetSet->ValidateInputEvent(L"\033P1+r5463=\033\\");
-    }
-
     TEST_METHOD(XtgettcapForwardsUnderConPTY)
     {
-        // When ReturnResponse is gated (conhost-in-VtIo simulation), the
-        // handler still consumes bytes cleanly without crashing. The gate is
-        // implemented in the real ConhostInternalGetSet::ReturnResponse at
-        // outputStream.cpp:50-65; our mock approximates by throwing from
-        // ReturnResponse when _returnResponseResult is false, then catching.
+        // R10: under ConPTY (conhost-in-VtIo), ReturnResponse is gated and
+        // must not deliver bytes downstream. The TestGetSet mock approximates
+        // by throwing from ReturnResponse when _returnResponseResult==false.
+        // Regardless of whether the handler tolerates the throw or not, the
+        // observable contract is: zero response bytes captured by the mock.
         _testGetSet->PrepData();
         _testGetSet->_returnResponseResult = false;
         const auto h = _pDispatch->RequestTermcap();
@@ -2340,9 +2326,109 @@ public:
         }
         catch (...)
         {
-            // Expected: mock simulates the "response dropped" path.
+            // The mock raises to simulate the "response dropped" path; the
+            // assertion below is what proves no bytes leaked out.
         }
+        VERIFY_IS_TRUE(_testGetSet->_response.empty());
         _testGetSet->_returnResponseResult = true;
+    }
+
+    TEST_METHOD(XtgettcapMalformedOddHex)
+    {
+        // T4: odd-length hex name ("544") cannot decode; spec requires a
+        // miss reply with the request's hex echoed verbatim, no crash.
+        _testGetSet->PrepData();
+        const auto h = _pDispatch->RequestTermcap();
+        for (auto ch : std::wstring_view{ L"544" })
+            h(ch);
+        h(L'\033');
+        _testGetSet->ValidateInputEvent(L"\033P0+r544\033\\");
+    }
+
+    TEST_METHOD(XtgettcapMalformedNonHex)
+    {
+        // T5: non-hex byte mid-name ("5G") poisons the cap; reply is a miss
+        // with empty echoed name (we do not echo attacker-supplied bytes).
+        _testGetSet->PrepData();
+        const auto h = _pDispatch->RequestTermcap();
+        for (auto ch : std::wstring_view{ L"5G" })
+            h(ch);
+        h(L'\033');
+        _testGetSet->ValidateInputEvent(L"\033P0+r\033\\");
+    }
+
+    TEST_METHOD(XtgettcapCrossRequestNoLeak)
+    {
+        // S3: request A is aborted mid-payload via ESC; request B is fresh.
+        // B's reply must contain only B's bytes — no residual state from A.
+        _testGetSet->PrepData();
+        {
+            const auto hA = _pDispatch->RequestTermcap();
+            // Begin "5463" (Tc) then abort mid-payload after the first nibble.
+            hA(L'5');
+            hA(L'\033');
+        }
+        // After ESC, A produced a miss reply for "5"; clear it before B.
+        _testGetSet->PrepData();
+
+        const auto hB = _pDispatch->RequestTermcap();
+        for (auto ch : std::wstring_view{ L"5463" })
+            hB(ch);
+        hB(L'\033');
+        // B's reply must be exactly the Tc hit — no "5" prefix from A.
+        _testGetSet->ValidateInputEvent(L"\033P1+r5463=\033\\");
+    }
+
+    TEST_METHOD(XtgettcapDECCKMOnRoundtrip)
+    {
+        // Mirrors XtgettcapDECCKMTogglesKcuu1 for the remaining arrow caps.
+        // DECCKM off: kcud1/kcuf1/kcub1 -> "\E[B" / "\E[C" / "\E[D".
+        // DECCKM on : kcud1/kcuf1/kcub1 -> "\EOB" / "\EOC" / "\EOD".
+        struct Case
+        {
+            std::wstring_view hexName;
+            std::wstring_view offResp;
+            std::wstring_view onResp;
+        };
+        const Case cases[] = {
+            // kcud1 = 6b63756431
+            { L"6b63756431",
+              L"\033P1+r6b63756431=5c" L"455b42\033\\",
+              L"\033P1+r6b63756431=5c" L"454f42\033\\" },
+            // kcuf1 = 6b63756631
+            { L"6b63756631",
+              L"\033P1+r6b63756631=5c" L"455b43\033\\",
+              L"\033P1+r6b63756631=5c" L"454f43\033\\" },
+            // kcub1 = 6b63756231
+            { L"6b63756231",
+              L"\033P1+r6b63756231=5c" L"455b44\033\\",
+              L"\033P1+r6b63756231=5c" L"454f44\033\\" },
+        };
+
+        for (const auto& c : cases)
+        {
+            _testGetSet->PrepData();
+            _terminalInput.SetInputMode(TerminalInput::Mode::CursorKey, false);
+            {
+                const auto h = _pDispatch->RequestTermcap();
+                for (auto ch : c.hexName)
+                    h(ch);
+                h(L'\033');
+            }
+            Log::Comment(c.hexName.data());
+            _testGetSet->ValidateInputEvent(c.offResp.data());
+
+            _testGetSet->PrepData();
+            _terminalInput.SetInputMode(TerminalInput::Mode::CursorKey, true);
+            {
+                const auto h = _pDispatch->RequestTermcap();
+                for (auto ch : c.hexName)
+                    h(ch);
+                h(L'\033');
+            }
+            _testGetSet->ValidateInputEvent(c.onResp.data());
+        }
+        _terminalInput.SetInputMode(TerminalInput::Mode::CursorKey, false);
     }
 
     TEST_METHOD(RequestStandardModeTests)

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -2125,18 +2125,21 @@ public:
         _testGetSet->ValidateInputEvent(L"\033P1+r636F6C6F7273=323536\033\\");
     }
 
-    TEST_METHOD(XtgettcapAllTwelveCaps)
+    TEST_METHOD(XtgettcapAllCapabilities)
     {
-        // Drive each of the 12 MVP capabilities and assert exact response bytes.
-        // Values mirror the spec section 4.2 golden table; we recompute them
-        // here by hand (not via production helpers) so the test catches any
-        // silent value drift.
+        // Drive each MVP and shifted-nav capability and assert exact response bytes.
+        //
+        // Wire-format note (xterm): the value side of a +r reply is the
+        // RAW BYTES the terminal would send, hex-encoded. So ESC encodes as
+        // 0x1b (one byte = "1b"), NOT the two-byte terminfo source form
+        // "\E" (0x5c 0x45 = "5c45"). The golden hex below uses raw-byte
+        // encoding; a regression that flips back to source-format encoding
+        // would emit double the ESC bytes per cap and fail this test.
         struct Case
         {
             std::wstring_view hexName; // request case is echoed
             std::wstring_view expectedResponse;
         };
-        // All values pre-hexed from the canonical value strings in the spec.
         const Case cases[] = {
             // TN = "xterm-256color"
             { L"544e", L"\033P1+r544e=78" L"7465726d2d323536636f6c6f72\033\\" },
@@ -2150,21 +2153,40 @@ public:
             { L"626365", L"\033P1+r626365=\033\\" },
             // Tc = "" (boolean)
             { L"5463", L"\033P1+r5463=\033\\" },
-            // Smulx = "\E[4:%p1%dm" -> 11 chars: 5c 45 5b 34 3a 25 70 31 25 64 6d
-            { L"536d756c78", L"\033P1+r536d756c78=5c" L"455b343a2570312564" L"6d\033\\" },
-            // Ms = "\E]52;%p1%s;%p2%s\E\\" -> 21 chars
-            //   5c 45 5d 35 32 3b 25 70 31 25 73 3b 25 70 32 25 73 5c 45 5c 5c
-            { L"4d73", L"\033P1+r4d73=5c" L"455d35323b25703125733b25703225735c" L"455c5c\033\\" },
-            // kdch1 = "\E[3~" -> 5c 45 5b 33 7e  (hex of "kdch1" = 6b64636831)
-            { L"6b64636831", L"\033P1+r6b64636831=5c" L"455b337e\033\\" },
+            // Smulx = ESC [ 4 : % p 1 % d m -> 10 bytes: 1b 5b 34 3a 25 70 31 25 64 6d
+            { L"536d756c78", L"\033P1+r536d756c78=1b" L"5b343a2570312564" L"6d\033\\" },
+            // Ms = ESC ] 5 2 ; % p 1 % s ; % p 2 % s ESC \ -> 18 bytes:
+            //   1b 5d 35 32 3b 25 70 31 25 73 3b 25 70 32 25 73 1b 5c
+            { L"4d73", L"\033P1+r4d73=1b5d35323b25703125733b25703225731b5c\033\\" },
+            // kdch1 = ESC [ 3 ~ -> 4 bytes: 1b 5b 33 7e
+            { L"6b64636831", L"\033P1+r6b64636831=1b" L"5b337e\033\\" },
             // kbs (default: BackarrowKey OFF) -> 0x7f -> "7f"
             { L"6b6273", L"\033P1+r6b6273=7f\033\\" },
-            // kcuu1 (default: DECCKM OFF / normal) -> "\E[A" -> 5c 45 5b 41
-            { L"6b63757531", L"\033P1+r6b63757531=5c" L"455b41\033\\" },
-            // kcud1 / kcuf1 / kcub1
-            { L"6b63756431", L"\033P1+r6b63756431=5c" L"455b42\033\\" },
-            { L"6b63756631", L"\033P1+r6b63756631=5c" L"455b43\033\\" },
-            { L"6b63756231", L"\033P1+r6b63756231=5c" L"455b44\033\\" },
+            // kcuu1 (default: DECCKM OFF / normal) -> ESC [ A -> 1b 5b 41
+            { L"6b63757531", L"\033P1+r6b63757531=1b" L"5b41\033\\" },
+            // kcud1 / kcuf1 / kcub1 (DECCKM off)
+            { L"6b63756431", L"\033P1+r6b63756431=1b" L"5b42\033\\" },
+            { L"6b63756631", L"\033P1+r6b63756631=1b" L"5b43\033\\" },
+            { L"6b63756231", L"\033P1+r6b63756231=1b" L"5b44\033\\" },
+            // I1: new caps — DECSCUSR (Ss/Se) and shifted nav keys.
+            // Ss = ESC [ % p 1 % d SPACE q -> 9 bytes: 1b 5b 25 70 31 25 64 20 71
+            { L"5373", L"\033P1+r5373=1b" L"5b2570312564" L"2071\033\\" },
+            // Se = ESC [ 2 SPACE q -> 5 bytes: 1b 5b 32 20 71
+            { L"5365", L"\033P1+r5365=1b" L"5b322071\033\\" },
+            // kDC (Shift+Delete) = ESC [ 3 ; 2 ~ -> 1b 5b 33 3b 32 7e ; hex("kDC") = 6b4443
+            { L"6b4443", L"\033P1+r6b4443=1b" L"5b333b327e\033\\" },
+            // kUP (Shift+Up)    = ESC [ 1 ; 2 A -> 1b 5b 31 3b 32 41 ; hex("kUP") = 6b5550
+            { L"6b5550", L"\033P1+r6b5550=1b" L"5b313b3241\033\\" },
+            // kDN (Shift+Down)  = ESC [ 1 ; 2 B ; hex("kDN") = 6b444e
+            { L"6b444e", L"\033P1+r6b444e=1b" L"5b313b3242\033\\" },
+            // kRIT (Shift+Right)= ESC [ 1 ; 2 C ; hex("kRIT") = 6b524954
+            { L"6b524954", L"\033P1+r6b524954=1b" L"5b313b3243\033\\" },
+            // kLFT (Shift+Left) = ESC [ 1 ; 2 D ; hex("kLFT") = 6b4c4654
+            { L"6b4c4654", L"\033P1+r6b4c4654=1b" L"5b313b3244\033\\" },
+            // kHOM (Shift+Home) = ESC [ 1 ; 2 H ; hex("kHOM") = 6b484f4d
+            { L"6b484f4d", L"\033P1+r6b484f4d=1b" L"5b313b3248\033\\" },
+            // kEND (Shift+End)  = ESC [ 1 ; 2 F ; hex("kEND") = 6b454e44
+            { L"6b454e44", L"\033P1+r6b454e44=1b" L"5b313b3246\033\\" },
         };
 
         for (const auto& c : cases)
@@ -2179,6 +2201,52 @@ public:
             Log::Comment(c.hexName.data());
             _testGetSet->ValidateInputEvent(c.expectedResponse.data());
         }
+    }
+
+    TEST_METHOD(XtgettcapExplicitEmptyCapRejected)
+    {
+        // I2: well-formed-but-empty cap-name requests must not blow up and
+        // must not emit a stale or attacker-controlled reply.
+        //
+        // Case A — truly empty payload (`DCS +q ST`): no cap names at all.
+        // Per the handler's design, _ReportTermcap is only called when a name
+        // separator (';') or terminator (ESC) is reached AND a name was
+        // accumulated (or the parse was poisoned). With zero bytes between
+        // `+q` and ST there is nothing to report, so we emit zero replies.
+        _testGetSet->PrepData();
+        const auto h = _pDispatch->RequestTermcap();
+        h(L'\033');
+        VERIFY_ARE_EQUAL(std::wstring{}, _testGetSet->_response);
+
+        // Case B — explicit empty between separators (`;;`): each `;` is a
+        // boundary, so the parser sees two empty names. For an empty name we
+        // emit a miss reply with no echoed hex (the handler treats empty
+        // hex as "malformed" — !decodeOk falls through to the unknown
+        // branch which writes `0+r` with the empty name).
+        _testGetSet->PrepData();
+        auto retainScope = _testGetSet->EnableInputRetentionInScope();
+        const auto h2 = _pDispatch->RequestTermcap();
+        for (auto ch : std::wstring_view{ L";;" })
+            h2(ch);
+        h2(L'\033');
+        // First `;` -> miss with empty echoed name. Second `;` -> miss with
+        // empty echoed name. ESC after empty name -> no further reply
+        // (matches Case A: ESC with empty name + !poisoned == no-op).
+        _testGetSet->ValidateInputEvent(L"\033P0+r\033\\\033P0+r\033\\");
+
+        // Case C — non-empty;empty (`5463;`): the known cap reports a hit;
+        // the trailing empty (after `;`, before ESC) is dropped because the
+        // ESC branch only emits a reply when `!name.empty() || poisoned`,
+        // and the `;` already cleared name. This documents the current
+        // (xterm-compatible) behavior; any future change to emit a trailing
+        // miss must update this golden.
+        _testGetSet->PrepData();
+        auto retainScope2 = _testGetSet->EnableInputRetentionInScope();
+        const auto h3 = _pDispatch->RequestTermcap();
+        for (auto ch : std::wstring_view{ L"5463;" })
+            h3(ch);
+        h3(L'\033');
+        _testGetSet->ValidateInputEvent(L"\033P1+r5463=\033\\");
     }
 
     TEST_METHOD(XtgettcapUnknownCap)
@@ -2258,7 +2326,8 @@ public:
 
     TEST_METHOD(XtgettcapDECCKMTogglesKcuu1)
     {
-        // DECCKM off (default) -> \E[A ; DECCKM on -> \EOA.
+        // DECCKM off (default) -> raw ESC [ A ; DECCKM on -> raw ESC O A.
+        // Wire format uses raw ESC (0x1b), not source-form "\E" (0x5c45).
         _testGetSet->PrepData();
         _terminalInput.SetInputMode(TerminalInput::Mode::CursorKey, false);
         {
@@ -2267,7 +2336,7 @@ public:
                 h(ch);
             h(L'\033');
         }
-        _testGetSet->ValidateInputEvent(L"\033P1+r6b63757531=5c" L"455b41\033\\");
+        _testGetSet->ValidateInputEvent(L"\033P1+r6b63757531=1b" L"5b41\033\\");
 
         _testGetSet->PrepData();
         _terminalInput.SetInputMode(TerminalInput::Mode::CursorKey, true);
@@ -2277,8 +2346,8 @@ public:
                 h(ch);
             h(L'\033');
         }
-        // hex("\EOA") = 5c 45 4f 41
-        _testGetSet->ValidateInputEvent(L"\033P1+r6b63757531=5c" L"454f41\033\\");
+        // hex(ESC O A) = 1b 4f 41
+        _testGetSet->ValidateInputEvent(L"\033P1+r6b63757531=1b" L"4f41\033\\");
         _terminalInput.SetInputMode(TerminalInput::Mode::CursorKey, false);
     }
 
@@ -2382,8 +2451,8 @@ public:
     TEST_METHOD(XtgettcapDECCKMOnRoundtrip)
     {
         // Mirrors XtgettcapDECCKMTogglesKcuu1 for the remaining arrow caps.
-        // DECCKM off: kcud1/kcuf1/kcub1 -> "\E[B" / "\E[C" / "\E[D".
-        // DECCKM on : kcud1/kcuf1/kcub1 -> "\EOB" / "\EOC" / "\EOD".
+        // DECCKM off: kcud1/kcuf1/kcub1 -> ESC [ B / ESC [ C / ESC [ D (raw bytes).
+        // DECCKM on : kcud1/kcuf1/kcub1 -> ESC O B / ESC O C / ESC O D (raw bytes).
         struct Case
         {
             std::wstring_view hexName;
@@ -2393,16 +2462,16 @@ public:
         const Case cases[] = {
             // kcud1 = 6b63756431
             { L"6b63756431",
-              L"\033P1+r6b63756431=5c" L"455b42\033\\",
-              L"\033P1+r6b63756431=5c" L"454f42\033\\" },
+              L"\033P1+r6b63756431=1b" L"5b42\033\\",
+              L"\033P1+r6b63756431=1b" L"4f42\033\\" },
             // kcuf1 = 6b63756631
             { L"6b63756631",
-              L"\033P1+r6b63756631=5c" L"455b43\033\\",
-              L"\033P1+r6b63756631=5c" L"454f43\033\\" },
+              L"\033P1+r6b63756631=1b" L"5b43\033\\",
+              L"\033P1+r6b63756631=1b" L"4f43\033\\" },
             // kcub1 = 6b63756231
             { L"6b63756231",
-              L"\033P1+r6b63756231=5c" L"455b44\033\\",
-              L"\033P1+r6b63756231=5c" L"454f44\033\\" },
+              L"\033P1+r6b63756231=1b" L"5b44\033\\",
+              L"\033P1+r6b63756231=1b" L"4f44\033\\" },
         };
 
         for (const auto& c : cases)

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -2078,6 +2078,273 @@ public:
         _testGetSet->ValidateInputEvent(L"\033P0$r\033\\");
     }
 
+    TEST_METHOD(XtgettcapTNCapability)
+    {
+        // Drives RequestTermcap() with the hex-encoded name "TN" (= 0x54 0x4e)
+        // and verifies the full DCS response bytes. Value is the locked TN for
+        // MVP: "xterm-256color".
+        _testGetSet->PrepData();
+        const auto handler = _pDispatch->RequestTermcap();
+        VERIFY_IS_NOT_NULL(handler);
+        for (auto ch : std::wstring_view{ L"544E" })
+        {
+            VERIFY_IS_TRUE(handler(ch));
+        }
+        VERIFY_IS_FALSE(handler(L'\033')); // ST starts
+        // Expected: DCS 1 + r 544E = <hex(xterm-256color)> ST
+        // hex("xterm-256color") = 7874 6572 6d2d 3235 3663 6f6c 6f72
+        _testGetSet->ValidateInputEvent(L"\033P1+r544E=78"
+                                        L"7465726d2d3235366"
+                                        L"36f6c6f72\033\\");
+    }
+
+    TEST_METHOD(XtgettcapColorsCapability)
+    {
+        // "Co" (0x436f) and "colors" (0x636f6c6f7273) both return "256".
+        _testGetSet->PrepData();
+        {
+            const auto handler = _pDispatch->RequestTermcap();
+            for (auto ch : std::wstring_view{ L"436F" })
+            {
+                handler(ch);
+            }
+            handler(L'\033');
+        }
+        // hex("256") = 323536
+        _testGetSet->ValidateInputEvent(L"\033P1+r436F=323536\033\\");
+
+        _testGetSet->PrepData();
+        {
+            const auto handler = _pDispatch->RequestTermcap();
+            for (auto ch : std::wstring_view{ L"636F6C6F7273" })
+            {
+                handler(ch);
+            }
+            handler(L'\033');
+        }
+        _testGetSet->ValidateInputEvent(L"\033P1+r636F6C6F7273=323536\033\\");
+    }
+
+    TEST_METHOD(XtgettcapAllTwelveCaps)
+    {
+        // Drive each of the 12 MVP capabilities and assert exact response bytes.
+        // Values mirror the spec section 4.2 golden table; we recompute them
+        // here by hand (not via production helpers) so the test catches any
+        // silent value drift.
+        struct Case
+        {
+            std::wstring_view hexName; // request case is echoed
+            std::wstring_view expectedResponse;
+        };
+        // All values pre-hexed from the canonical value strings in the spec.
+        const Case cases[] = {
+            // TN = "xterm-256color"
+            { L"544e", L"\033P1+r544e=78" L"7465726d2d323536636f6c6f72\033\\" },
+            // Co = "256"
+            { L"436f", L"\033P1+r436f=323536\033\\" },
+            // colors = "256"
+            { L"636f6c6f7273", L"\033P1+r636f6c6f7273=323536\033\\" },
+            // RGB = "8/8/8" -> 38 2f 38 2f 38
+            { L"524742", L"\033P1+r524742=38" L"2f382f38\033\\" },
+            // bce = "" (boolean)
+            { L"626365", L"\033P1+r626365=\033\\" },
+            // Tc = "" (boolean)
+            { L"5463", L"\033P1+r5463=\033\\" },
+            // Smulx = "\E[4:%p1%dm" -> 11 chars: 5c 45 5b 34 3a 25 70 31 25 64 6d
+            { L"536d756c78", L"\033P1+r536d756c78=5c" L"455b343a2570312564" L"6d\033\\" },
+            // Ms = "\E]52;%p1%s;%p2%s\E\\" -> 21 chars
+            //   5c 45 5d 35 32 3b 25 70 31 25 73 3b 25 70 32 25 73 5c 45 5c 5c
+            { L"4d73", L"\033P1+r4d73=5c" L"455d35323b25703125733b25703225735c" L"455c5c\033\\" },
+            // kdch1 = "\E[3~" -> 5c 45 5b 33 7e  (hex of "kdch1" = 6b64636831)
+            { L"6b64636831", L"\033P1+r6b64636831=5c" L"455b337e\033\\" },
+            // kbs (default: BackarrowKey OFF) -> 0x7f -> "7f"
+            { L"6b6273", L"\033P1+r6b6273=7f\033\\" },
+            // kcuu1 (default: DECCKM OFF / normal) -> "\E[A" -> 5c 45 5b 41
+            { L"6b63757531", L"\033P1+r6b63757531=5c" L"455b41\033\\" },
+            // kcud1 / kcuf1 / kcub1
+            { L"6b63756431", L"\033P1+r6b63756431=5c" L"455b42\033\\" },
+            { L"6b63756631", L"\033P1+r6b63756631=5c" L"455b43\033\\" },
+            { L"6b63756231", L"\033P1+r6b63756231=5c" L"455b44\033\\" },
+        };
+
+        for (const auto& c : cases)
+        {
+            _testGetSet->PrepData();
+            const auto handler = _pDispatch->RequestTermcap();
+            for (auto ch : c.hexName)
+            {
+                handler(ch);
+            }
+            handler(L'\033');
+            Log::Comment(c.hexName.data());
+            _testGetSet->ValidateInputEvent(c.expectedResponse.data());
+        }
+    }
+
+    TEST_METHOD(XtgettcapUnknownCap)
+    {
+        _testGetSet->PrepData();
+        const auto handler = _pDispatch->RequestTermcap();
+        // "ZZ" = 5a 5a — not a known cap. Expect miss reply.
+        for (auto ch : std::wstring_view{ L"5a5a" })
+        {
+            handler(ch);
+        }
+        handler(L'\033');
+        _testGetSet->ValidateInputEvent(L"\033P0+r5a5a\033\\");
+
+        // Case-sensitivity: "tn" (746e) must not match TN.
+        _testGetSet->PrepData();
+        const auto handler2 = _pDispatch->RequestTermcap();
+        for (auto ch : std::wstring_view{ L"746e" })
+        {
+            handler2(ch);
+        }
+        handler2(L'\033');
+        _testGetSet->ValidateInputEvent(L"\033P0+r746e\033\\");
+    }
+
+    TEST_METHOD(XtgettcapOversizePayloadRejected)
+    {
+        // 5000 valid hex chars (> 4 KB cap): handler must stop returning true
+        // before the full payload is consumed, and the oversized request must
+        // not emit a reply.
+        _testGetSet->PrepData();
+        const auto handler = _pDispatch->RequestTermcap();
+        size_t consumed = 0;
+        for (size_t i = 0; i < 5000; ++i)
+        {
+            if (!handler(L'4'))
+            {
+                break;
+            }
+            ++consumed;
+        }
+        // The 4 KB cap enforces we stop well before 5000. No reply for oversize.
+        VERIFY_IS_LESS_THAN(consumed, 5000u);
+        VERIFY_ARE_EQUAL(std::wstring{}, _testGetSet->_response);
+
+        // Per-name overflow (name > 64 hex chars) -> poisoned -> miss reply
+        // (empty name echoed). The handler must not crash.
+        _testGetSet->PrepData();
+        const auto handler2 = _pDispatch->RequestTermcap();
+        for (size_t i = 0; i < 200; ++i)
+        {
+            handler2(L'a');
+        }
+        handler2(L'\033');
+        // Empty-name miss (poisoned name is reported as empty hex).
+        _testGetSet->ValidateInputEvent(L"\033P0+r\033\\");
+    }
+
+    TEST_METHOD(XtgettcapBatchedAndCaseEcho)
+    {
+        // Semi-colon separated batch: known; unknown; known. Each must yield
+        // its own independent DCS frame concatenated in order. Request case
+        // ("744E", mixed) must be echoed verbatim in the response.
+        _testGetSet->PrepData();
+        auto retainScope = _testGetSet->EnableInputRetentionInScope();
+        const auto handler = _pDispatch->RequestTermcap();
+        for (auto ch : std::wstring_view{ L"544E;5A5A;436f" })
+        {
+            handler(ch);
+        }
+        handler(L'\033');
+        _testGetSet->ValidateInputEvent(
+            L"\033P1+r544E=78" L"7465726d2d323536636f6c6f72\033\\"
+            L"\033P0+r5A5A\033\\"
+            L"\033P1+r436f=323536\033\\");
+    }
+
+    TEST_METHOD(XtgettcapDECCKMTogglesKcuu1)
+    {
+        // DECCKM off (default) -> \E[A ; DECCKM on -> \EOA.
+        _testGetSet->PrepData();
+        _terminalInput.SetInputMode(TerminalInput::Mode::CursorKey, false);
+        {
+            const auto h = _pDispatch->RequestTermcap();
+            for (auto ch : std::wstring_view{ L"6b63757531" })
+                h(ch);
+            h(L'\033');
+        }
+        _testGetSet->ValidateInputEvent(L"\033P1+r6b63757531=5c" L"455b41\033\\");
+
+        _testGetSet->PrepData();
+        _terminalInput.SetInputMode(TerminalInput::Mode::CursorKey, true);
+        {
+            const auto h = _pDispatch->RequestTermcap();
+            for (auto ch : std::wstring_view{ L"6b63757531" })
+                h(ch);
+            h(L'\033');
+        }
+        // hex("\EOA") = 5c 45 4f 41
+        _testGetSet->ValidateInputEvent(L"\033P1+r6b63757531=5c" L"454f41\033\\");
+        _terminalInput.SetInputMode(TerminalInput::Mode::CursorKey, false);
+    }
+
+    TEST_METHOD(XtgettcapBackarrowKeyTogglesKbs)
+    {
+        // BackarrowKey off (default) -> DEL (0x7f) -> "7f"
+        // BackarrowKey on            -> BS  (0x08) -> "08"
+        _testGetSet->PrepData();
+        _terminalInput.SetInputMode(TerminalInput::Mode::BackarrowKey, false);
+        {
+            const auto h = _pDispatch->RequestTermcap();
+            for (auto ch : std::wstring_view{ L"6b6273" })
+                h(ch);
+            h(L'\033');
+        }
+        _testGetSet->ValidateInputEvent(L"\033P1+r6b6273=7f\033\\");
+
+        _testGetSet->PrepData();
+        _terminalInput.SetInputMode(TerminalInput::Mode::BackarrowKey, true);
+        {
+            const auto h = _pDispatch->RequestTermcap();
+            for (auto ch : std::wstring_view{ L"6b6273" })
+                h(ch);
+            h(L'\033');
+        }
+        _testGetSet->ValidateInputEvent(L"\033P1+r6b6273=08\033\\");
+        _terminalInput.SetInputMode(TerminalInput::Mode::BackarrowKey, false);
+    }
+
+    TEST_METHOD(XtgettcapStandaloneReplies)
+    {
+        // Terminal-side (IsConPTY() == false on the TestGetSet mock): a reply
+        // _must_ be emitted. This covers AC-X9 negative expectation's
+        // inverse — any non-PTY instance answers normally.
+        VERIFY_IS_FALSE(_testGetSet->IsConPTY());
+        _testGetSet->PrepData();
+        const auto h = _pDispatch->RequestTermcap();
+        for (auto ch : std::wstring_view{ L"5463" })
+            h(ch);
+        h(L'\033');
+        _testGetSet->ValidateInputEvent(L"\033P1+r5463=\033\\");
+    }
+
+    TEST_METHOD(XtgettcapForwardsUnderConPTY)
+    {
+        // When ReturnResponse is gated (conhost-in-VtIo simulation), the
+        // handler still consumes bytes cleanly without crashing. The gate is
+        // implemented in the real ConhostInternalGetSet::ReturnResponse at
+        // outputStream.cpp:50-65; our mock approximates by throwing from
+        // ReturnResponse when _returnResponseResult is false, then catching.
+        _testGetSet->PrepData();
+        _testGetSet->_returnResponseResult = false;
+        const auto h = _pDispatch->RequestTermcap();
+        for (auto ch : std::wstring_view{ L"544e" })
+            h(ch);
+        try
+        {
+            h(L'\033');
+        }
+        catch (...)
+        {
+            // Expected: mock simulates the "response dropped" path.
+        }
+        _testGetSet->_returnResponseResult = true;
+    }
+
     TEST_METHOD(RequestStandardModeTests)
     {
         // The mode numbers below correspond to the ANSIStandardMode values

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -742,6 +742,12 @@ IStateMachineEngine::StringHandler OutputStateMachineEngine::ActionDcsDispatch(c
     case DcsActionCodes::DECRSPS_RestorePresentationState:
         handler = _dispatch->RestorePresentationState(parameters.at(0));
         break;
+    case DcsActionCodes::XTGETTCAP_RequestTermcap:
+        // Guard against Sixel "q" collision; VTID packs the intermediate '+' so
+        // any match here must include it. This asserts the parser's correctness.
+        WI_ASSERT(id == VTID("+q"));
+        handler = _dispatch->RequestTermcap();
+        break;
     default:
         _dispatch->UnknownSequence();
         break;

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -183,6 +183,7 @@ namespace Microsoft::Console::VirtualTerminal
             DECRSTS_RestoreTerminalState = VTID("$p"),
             DECRQSS_RequestSetting = VTID("$q"),
             DECRSPS_RestorePresentationState = VTID("$t"),
+            XTGETTCAP_RequestTermcap = VTID("+q"),
         };
 
         enum Vt52ActionCodes : uint64_t

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -907,6 +907,51 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
     }
 
+    TEST_METHOD(XtgettcapEscAbortResetsAccumulator)
+    {
+        // P3: an ESC mid-DCS aborts the in-flight +q payload. A subsequent
+        // fresh +q request must dispatch with NO residual bytes from the
+        // aborted request. We use a recording dispatch that captures every
+        // character the parser delivers to each StringHandler the dispatch
+        // hands out, then assert the second handler's payload is exactly
+        // the new request's bytes.
+        class RecordingDispatch final : public TermDispatch
+        {
+        public:
+            void Print(const wchar_t) override {}
+            void PrintString(const std::wstring_view) override {}
+            StringHandler RequestTermcap() override
+            {
+                payloads.emplace_back();
+                const auto idx = payloads.size() - 1;
+                return [this, idx](const wchar_t ch) {
+                    payloads[idx].push_back(ch);
+                    // Return false on ESC so the parser can re-dispatch it.
+                    return ch != L'\033';
+                };
+            }
+            std::vector<std::wstring> payloads;
+        };
+
+        auto dispatch = std::make_unique<RecordingDispatch>();
+        auto* raw = dispatch.get();
+        auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
+        StateMachine mach(std::move(engine));
+
+        // Request A: start a +q DCS with payload "544", then abort with a
+        // bare ESC followed by 'P' to start a brand-new DCS (request B).
+        // This exercises the abort-and-restart path inside one byte stream.
+        // Request B's payload is "5463" terminated by ST.
+        mach.ProcessString(L"\x1bP+q544\x1bP+q5463\x1b\\");
+
+        VERIFY_ARE_EQUAL(2u, raw->payloads.size());
+
+        // A's accumulated bytes are "544" plus the abort ESC. B must NOT
+        // contain any of A's bytes — only "5463" plus its terminating ESC.
+        VERIFY_ARE_EQUAL(std::wstring{ L"544\033" }, raw->payloads[0]);
+        VERIFY_ARE_EQUAL(std::wstring{ L"5463\033" }, raw->payloads[1]);
+    }
+
     TEST_METHOD(XtgettcapVsSixelDisambiguation)
     {
         // Risk R3 lockdown: the Sixel VTID is ("q"), ours is ("+q"). The

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -907,6 +907,64 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
     }
 
+    TEST_METHOD(XtgettcapVsSixelDisambiguation)
+    {
+        // Risk R3 lockdown: the Sixel VTID is ("q"), ours is ("+q"). The
+        // dispatch must route each to a distinct handler based on the
+        // intermediate. We use a recording dispatch to observe which path
+        // fired.
+        class RecordingDispatch final : public TermDispatch
+        {
+        public:
+            void Print(const wchar_t) override {}
+            void PrintString(const std::wstring_view) override {}
+            StringHandler DefineSixelImage(const VTInt, const DispatchTypes::SixelBackground, const VTParameter) override
+            {
+                sixelFired = true;
+                return [](const auto) { return true; };
+            }
+            StringHandler RequestTermcap() override
+            {
+                termcapFired = true;
+                return [](const auto) { return true; };
+            }
+            bool sixelFired{ false };
+            bool termcapFired{ false };
+        };
+
+        // Case A: Sixel ("\x1bPq" ... "\x1b\\").
+        {
+            auto dispatch = std::make_unique<RecordingDispatch>();
+            auto* raw = dispatch.get();
+            auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
+            StateMachine mach(std::move(engine));
+            mach.ProcessString(L"\x1bPq#0;2;0;0;0\x1b\\");
+            VERIFY_IS_TRUE(raw->sixelFired);
+            VERIFY_IS_FALSE(raw->termcapFired);
+        }
+        // Case B: XTGETTCAP ("\x1bP+q544e\x1b\\").
+        {
+            auto dispatch = std::make_unique<RecordingDispatch>();
+            auto* raw = dispatch.get();
+            auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
+            StateMachine mach(std::move(engine));
+            mach.ProcessString(L"\x1bP+q544e\x1b\\");
+            VERIFY_IS_FALSE(raw->sixelFired);
+            VERIFY_IS_TRUE(raw->termcapFired);
+        }
+        // Case C: 8-bit DCS form (C1 \x90) with +q.
+        {
+            auto dispatch = std::make_unique<RecordingDispatch>();
+            auto* raw = dispatch.get();
+            auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
+            StateMachine mach(std::move(engine));
+            mach.SetParserMode(StateMachine::Mode::AcceptC1, true);
+            mach.ProcessString(L"\x90+q544e\x9c");
+            VERIFY_IS_TRUE(raw->termcapFired);
+            VERIFY_IS_FALSE(raw->sixelFired);
+        }
+    }
+
     TEST_METHOD(TestDcsIntermediateAndPassThrough)
     {
         auto dispatch = std::make_unique<DummyDispatch>();

--- a/src/terminal/parser/ut_parser/StateMachineTest.cpp
+++ b/src/terminal/parser/ut_parser/StateMachineTest.cpp
@@ -161,6 +161,8 @@ class Microsoft::Console::VirtualTerminal::StateMachineTest
 
     TEST_METHOD(DcsDataStringsReceivedByHandler);
 
+    TEST_METHOD(XtgettcapDcsLifecycle);
+
     TEST_METHOD(VtParameterSubspanTest);
 };
 
@@ -341,6 +343,31 @@ void StateMachineTest::DcsDataStringsReceivedByHandler()
 
     // Verify the control characters were executed (if expected).
     VERIFY_ARE_EQUAL(expectedExecuted, engine.executed);
+}
+
+void StateMachineTest::XtgettcapDcsLifecycle()
+{
+    // Validates state machine traversal for the "+q" DCS path. Feeds a full
+    // XTGETTCAP request one byte at a time and asserts the dispatched VTID is
+    // exactly "+q" (not Sixel's "q"), the data string is forwarded byte-for-
+    // byte, and the terminator returns the machine to Ground.
+    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+    auto& engine{ *enginePtr.get() };
+    StateMachine machine{ std::move(enginePtr) };
+
+    machine.ProcessString(L"\x1bP+q544E;436F\x1b\\");
+
+    VERIFY_ARE_EQUAL(VTID("+q"), engine.dcsId);
+    // The test-engine handler eats every byte including the ESC that leads ST.
+    VERIFY_ARE_EQUAL(L"544E;436F\x1b", engine.dcsDataString);
+
+    // Split write variant: ensure partial bytes accumulate.
+    engine.ResetTestState();
+    machine.ProcessString(L"\x1bP+q54");
+    machine.ProcessString(L"4E");
+    machine.ProcessString(L"\x1b\\");
+    VERIFY_ARE_EQUAL(VTID("+q"), engine.dcsId);
+    VERIFY_ARE_EQUAL(L"544E\x1b", engine.dcsDataString);
 }
 
 void StateMachineTest::VtParameterSubspanTest()


### PR DESCRIPTION
# XTGETTCAP (DCS +q) support

Adds DEC XTGETTCAP terminfo capability query support to the output state machine and AdaptDispatch. Clients (tmux, mosh, Kitty terminfo probe, etc.) send `ESC P + q <hex>(;<hex>)* ESC \` and expect a per-capability DCS reply.

> **Update (cross-review round 2):** I3 wire-format fix, I1 missing-cap implementations, I2 explicit-empty test, and I4 rename applied in commit `5aac3642c`. Capabilities table, wire-format section, and tests below now reflect the actual implementation.

## Wire format

Per xterm: every requested capability gets its own DCS reply.

- Hit:  `ESC P 1 + r <hexname>=<hexvalue> ESC \`
- Miss: `ESC P 0 + r <hexname> ESC \` (echo of the queried name only)

**Value encoding** (xterm ctlseqs): the value field is the **raw bytes the terminal would send**, hex-encoded byte-for-byte. So ESC is `0x1b` (one byte → `1b`), **not** the two-byte terminfo source form `\E` (which would hex-encode as `5c45`). Earlier revisions of this PR used the source form and emitted the literal text `\E[A` on the wire instead of cursor-up; the fix lives in commit `5aac3642c`.

## Capabilities supported (21)

| Cap | Source | Value (raw bytes, hex shown for the dynamic-mode default) |
|---|---|---|
| `TN` | constant | `xterm-256color` (locked decision) |
| `Co` / `colors` | constant | `256` |
| `RGB` | constant | `8/8/8` |
| `bce` | constant boolean | empty value (background color erase) |
| `Tc` | constant boolean | empty value (true-color advertised) |
| `Smulx` | constant | `1b5b343a25703125646d` = `ESC [ 4 : %p1 %d m` |
| `Ms` | constant | `1b5d35323b25703125733b25703225731b5c` = OSC 52 set-clipboard, terminated by ST |
| `Ss` | constant | `1b5b25703125642071` = `ESC [ %p1 %d SPACE q` (DECSCUSR set cursor shape) |
| `Se` | constant | `1b5b322071` = `ESC [ 2 SPACE q` (DECSCUSR reset) |
| `kdch1` | constant | `1b5b337e` = `ESC [ 3 ~` (plain Delete) |
| `kbs` | dynamic | `7f` (default DEL) / `08` (BS when `BackarrowKey` set) |
| `kcuu1` / `kcud1` / `kcuf1` / `kcub1` | dynamic | `1b5b41/42/43/44` (DECCKM off) / `1b4f41/42/43/44` (DECCKM on, app-mode SS3) |
| `kDC` | constant | `1b5b333b327e` = `ESC [ 3 ; 2 ~` (Shift+Delete) |
| `kUP` / `kDN` / `kRIT` / `kLFT` | constant | `1b5b313b324X` (Shift+arrow, X ∈ {A,B,C,D}) |
| `kHOM` / `kEND` | constant | `1b5b313b3248` / `1b5b313b3246` (Shift+Home/End) |

Shifted-nav values mirror what `TerminalInput::_formatEncodingHelper` emits for SHIFT-only modifiers (`terminalInput.cpp` ~line 1117), keeping the report in sync with the encoder.

## Security mitigations

- **R1 reply-as-input injection**: response values come from a constant allowlist or `TerminalInput` mode bits only; never echoes raw request bytes. Miss replies echo only the hex-bounded name.
- **R2 unbounded payload DoS**: 4 KB total cap and 32 B per-cap-name cap. Overflow returns `false` from `StringHandler` so the parser drops into `DcsIgnore`.
- **R3 `+q` vs Sixel `q`**: assertion `WI_ASSERT(id == VTID("+q"))` in dispatch + dedicated parser test.
- **R10 ConPTY split-brain**: host-side `ConhostInternalGetSet::ReturnResponse` already drops conhost replies under VtIo; raw DCS forwarded verbatim by the host VT path; terminal-side replies travel `Terminal::ReturnResponse` → `_pfnWriteInput` → ControlCore → `ConptyConnection::WriteInput`. `XtgettcapForwardsUnderConPTY` asserts no host reply leaks.

## Tests

`src/terminal/adapter/ut_adapter/adapterTest.cpp`:
- `XtgettcapTNCapability`, `XtgettcapColorsCapability`
- `XtgettcapAllCapabilities` (22 golden sub-cases, raw-byte hex per cap; renamed from `XtgettcapAllTwelveCaps`)
- `XtgettcapUnknownCap`, `XtgettcapOversizePayloadRejected`, `XtgettcapBatchedAndCaseEcho`
- `XtgettcapDECCKMTogglesKcuu1`, `XtgettcapDECCKMOnRoundtrip` (kcud1/kcuf1/kcub1)
- `XtgettcapBackarrowKeyTogglesKbs`
- `XtgettcapForwardsUnderConPTY` (R10 split-brain)
- `XtgettcapMalformedOddHex`, `XtgettcapMalformedNonHex`, `XtgettcapCrossRequestNoLeak` (T4 / T5 / S3)
- **`XtgettcapExplicitEmptyCapRejected`** (I2 — covers empty payload, `;;` double-empty, and `5463;` trailing-empty)

`src/terminal/parser/ut_parser/OutputEngineTest.cpp`:
- `XtgettcapVsSixelDisambiguation` (3 sub-cases: 7-bit Sixel, 7-bit +q, 8-bit C1 +q)
- `XtgettcapEscAbortResetsAccumulator` (P3)

`src/terminal/parser/ut_parser/StateMachineTest.cpp`:
- `XtgettcapDcsLifecycle` (single + split write)

All positive tests compare full response byte sequences to hand-derived golden hex strings. No mocks of `RequestTermcap` itself.

## Cross-review summary (3 reviewers)

| Finding | Reviewers | Status |
|---|---|---|
| I1 — declared-but-missing caps (Ss/Se/kDC/kRIT/kLFT/kUP/kDN/kHOM/kEND) | Claude + GPT-5.5 | **Implemented** (commit `5aac3642c`) |
| I2 — no explicit empty-cap-name test | Claude + Gemini | **Test added** |
| I3 — string-cap values used terminfo source form, not raw bytes | Claude (Gemini & GPT-5.5 verified) | **Fixed** (every string cap; golden hex regenerated) |
| I4 — `XtgettcapAllTwelveCaps` misleading (14 cases, soon 22) | Claude | **Renamed** to `XtgettcapAllCapabilities` |

## Deferred (tracked)

- `VtIoTests::XtgettcapPassthroughReachesPipe` (AC-X8): tracked separately.
- Fuzzer harness + corpus (AC-X6): tracked separately.
- Branded `ms-terminal` terminfo entry: tracked separately.
- 8-bit C1 mode (`SendC1`) emits 0x9B introducer; the static cap values reported here are the 7-bit forms in line with `xterm-256color`. Pre-existing limitation, not regressed by this PR.

## Files changed

`src/terminal/parser/OutputStateMachineEngine.hpp` / `.cpp` (DCS dispatch); `src/terminal/adapter/ITermDispatch.hpp`, `termDispatch.hpp`, `adaptDispatch.hpp`, `adaptDispatch.cpp` (handler + 21-cap table); `src/terminal/adapter/ut_adapter/adapterTest.cpp`, `src/terminal/parser/ut_parser/OutputEngineTest.cpp`, `src/terminal/parser/ut_parser/StateMachineTest.cpp` (tests).
