### PR TITLE
Kitty graphics: X/Y sub-cell pixel offset [stacked on #11]

### DIFF
--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -5656,17 +5656,19 @@ void AdaptDispatch::_placeKittyImage(const KittyImage& image, const bool moveCur
 
     const auto columnBegin = origin.x;
     // The destination spans the X offset plus the scaled image, so it can reach one cell
-    // further right than the image alone.
-    const auto spanWidthPx = offsetX + static_cast<til::CoordType>(std::min<int64_t>(targetW, INT32_MAX));
-    const auto columns = static_cast<til::CoordType>(std::min<int64_t>((static_cast<int64_t>(spanWidthPx) + cellWidth - 1) / cellWidth, page.Width()));
+    // further right than the image alone. Keep the span math in 64-bit (targetW/H may be
+    // up to ~INT32_MAX from aspect scaling) and clamp to the page before narrowing, so the
+    // offset addition can't overflow til::CoordType (int32).
+    const int64_t spanWidthPx = static_cast<int64_t>(offsetX) + targetW;
+    const auto columns = static_cast<til::CoordType>(std::min<int64_t>((spanWidthPx + cellWidth - 1) / cellWidth, page.Width()));
     const auto columnEnd = std::min(columnBegin + columns, page.Width());
     if (columnEnd <= columnBegin)
     {
         return;
     }
-    const auto drawWidth = std::min<til::CoordType>(spanWidthPx, (columnEnd - columnBegin) * cellWidth);
-    const auto spanHeightPx = offsetY + static_cast<til::CoordType>(std::min<int64_t>(targetH, INT32_MAX));
-    const auto rowSpan = static_cast<til::CoordType>(std::min<int64_t>((static_cast<int64_t>(spanHeightPx) + cellHeight - 1) / cellHeight, page.Bottom()));
+    const auto drawWidth = static_cast<til::CoordType>(std::min<int64_t>(spanWidthPx, static_cast<int64_t>(columnEnd - columnBegin) * cellWidth));
+    const int64_t spanHeightPx = static_cast<int64_t>(offsetY) + targetH;
+    const auto rowSpan = static_cast<til::CoordType>(std::min<int64_t>((spanHeightPx + cellHeight - 1) / cellHeight, page.Bottom()));
     // Precompute the source column for each drawn destination pixel (nearest-neighbour).
     // Destination columns before the X offset have no source (sentinel -1 = transparent).
     std::vector<til::CoordType> sampleXMap(static_cast<size_t>(drawWidth));
@@ -5703,22 +5705,23 @@ void AdaptDispatch::_placeKittyImage(const KittyImage& image, const bool moveCur
             }
             // Destination rows before the Y offset (and past the image bottom) are blank.
             const auto srcDstY = dstY - offsetY;
-            if (srcDstY >= 0 && srcDstY < targetH)
+            const auto rowInImage = srcDstY >= 0 && srcDstY < targetH;
+            const auto sampleY = rowInImage ? cropY + std::min(cropH - 1, static_cast<til::CoordType>(static_cast<int64_t>(srcDstY) * cropH / targetH)) : 0;
+            const auto srcRowStart = static_cast<size_t>(sampleY) * image.width;
+            // Always write every covered pixel (transparent for the X/Y gutters and past
+            // the image) so a reused slice never shows stale content under these columns.
+            for (auto pixelColumn = 0; pixelColumn < drawWidth; ++pixelColumn)
             {
-                const auto sampleY = cropY + std::min(cropH - 1, static_cast<til::CoordType>(static_cast<int64_t>(srcDstY) * cropH / targetH));
-                const auto srcRowStart = static_cast<size_t>(sampleY) * image.width;
-                for (auto pixelColumn = 0; pixelColumn < drawWidth; ++pixelColumn)
+                RGBQUAD px{};
+                if (rowInImage && sampleXMap[pixelColumn] >= 0)
                 {
-                    if (sampleXMap[pixelColumn] < 0)
-                    {
-                        continue; // transparent X-offset gutter
-                    }
                     const auto srcIndex = srcRowStart + static_cast<size_t>(sampleXMap[pixelColumn]);
                     if (srcIndex < image.pixels.size())
                     {
-                        til::at(dstIterator, pixelColumn) = image.pixels[srcIndex];
+                        px = image.pixels[srcIndex];
                     }
                 }
+                til::at(dstIterator, pixelColumn) = px;
             }
             if (pixelRow + 1 < cellHeight)
             {

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -5022,6 +5022,12 @@ AdaptDispatch::KittyControl AdaptDispatch::_ParseKittyControl(const std::wstring
             case L'h':
                 c.srcH = _ParseKittyUint(value);
                 break;
+            case L'X':
+                c.cellOffsetX = _ParseKittyUint(value);
+                break;
+            case L'Y':
+                c.cellOffsetY = _ParseKittyUint(value);
+                break;
             case L'o':
                 c.compression = value.front();
                 break;
@@ -5258,7 +5264,7 @@ void AdaptDispatch::_ProcessKittyCommand(const KittyControl& command, const std:
                     const auto stored = _kittyImages.find(assignedId);
                     if (stored != _kittyImages.end())
                     {
-                        _placeKittyImage(stored->second, moveCursor, assignedId, command.cols, command.rows, command.srcX, command.srcY, command.srcW, command.srcH);
+                        _placeKittyImage(stored->second, moveCursor, assignedId, command.cols, command.rows, command.srcX, command.srcY, command.srcW, command.srcH, command.cellOffsetX, command.cellOffsetY);
                     }
                 }
             }
@@ -5297,7 +5303,7 @@ void AdaptDispatch::_ProcessKittyCommand(const KittyControl& command, const std:
             }
             else
             {
-                _placeKittyImage(*target, moveCursor, targetId, command.cols, command.rows, command.srcX, command.srcY, command.srcW, command.srcH);
+                _placeKittyImage(*target, moveCursor, targetId, command.cols, command.rows, command.srcX, command.srcY, command.srcW, command.srcH, command.cellOffsetX, command.cellOffsetY);
             }
             break;
         }
@@ -5586,7 +5592,7 @@ std::vector<RGBQUAD> AdaptDispatch::_decodeKittyPixels(const uint32_t format, co
 // aspect) via nearest-neighbour; oversize spans clip. Cursor advances by the span unless
 // moveCursor is false (C=1).
 // Protocol: https://sw.kovidgoyal.net/kitty/graphics-protocol/#controlling-displayed-image-layout
-void AdaptDispatch::_placeKittyImage(const KittyImage& image, const bool moveCursor, const uint32_t imageId, const uint32_t cols, const uint32_t rows, const uint32_t srcX, const uint32_t srcY, const uint32_t srcW, const uint32_t srcH)
+void AdaptDispatch::_placeKittyImage(const KittyImage& image, const bool moveCursor, const uint32_t imageId, const uint32_t cols, const uint32_t rows, const uint32_t srcX, const uint32_t srcY, const uint32_t srcW, const uint32_t srcH, const uint32_t cellOffsetX, const uint32_t cellOffsetY)
 {
     if (image.pixels.empty() || image.width == 0 || image.height == 0)
     {
@@ -5601,6 +5607,11 @@ void AdaptDispatch::_placeKittyImage(const KittyImage& image, const bool moveCur
     const til::size clampedCellSize{ cellWidth, cellHeight };
     const auto imageWidth = static_cast<til::CoordType>(image.width);
     const auto imageHeight = static_cast<til::CoordType>(image.height);
+    // X/Y shift the image within the first cell (a sub-cell pixel offset), clamped to the
+    // cell. The leading offset pixels are left transparent and the image may spill one
+    // extra cell to the right/bottom.
+    const auto offsetX = static_cast<til::CoordType>(std::min<uint32_t>(cellOffsetX, static_cast<uint32_t>(cellWidth - 1)));
+    const auto offsetY = static_cast<til::CoordType>(std::min<uint32_t>(cellOffsetY, static_cast<uint32_t>(cellHeight - 1)));
 
     // Source crop in pixels (x,y,w,h), clamped to the image; w/h=0 (or past the edge)
     // extends to the right/bottom edge.
@@ -5644,20 +5655,24 @@ void AdaptDispatch::_placeKittyImage(const KittyImage& image, const bool moveCur
     const auto targetH = std::max<int64_t>(targetH64, 1);
 
     const auto columnBegin = origin.x;
-    const auto columns = static_cast<til::CoordType>(std::min<int64_t>((targetW + cellWidth - 1) / cellWidth, page.Width()));
+    // The destination spans the X offset plus the scaled image, so it can reach one cell
+    // further right than the image alone.
+    const auto spanWidthPx = offsetX + static_cast<til::CoordType>(std::min<int64_t>(targetW, INT32_MAX));
+    const auto columns = static_cast<til::CoordType>(std::min<int64_t>((static_cast<int64_t>(spanWidthPx) + cellWidth - 1) / cellWidth, page.Width()));
     const auto columnEnd = std::min(columnBegin + columns, page.Width());
     if (columnEnd <= columnBegin)
     {
         return;
     }
-    const auto drawWidth = std::min<til::CoordType>(static_cast<til::CoordType>(std::min<int64_t>(targetW, INT32_MAX)), (columnEnd - columnBegin) * cellWidth);
-    const auto rowSpan = static_cast<til::CoordType>(std::min<int64_t>((targetH + cellHeight - 1) / cellHeight, page.Bottom()));
-    // Precompute the source column for each drawn pixel (nearest-neighbour) so the hot
-    // loop is a table lookup, not a 64-bit divide per pixel.
+    const auto drawWidth = std::min<til::CoordType>(spanWidthPx, (columnEnd - columnBegin) * cellWidth);
+    const auto spanHeightPx = offsetY + static_cast<til::CoordType>(std::min<int64_t>(targetH, INT32_MAX));
+    const auto rowSpan = static_cast<til::CoordType>(std::min<int64_t>((static_cast<int64_t>(spanHeightPx) + cellHeight - 1) / cellHeight, page.Bottom()));
+    // Precompute the source column for each drawn destination pixel (nearest-neighbour).
+    // Destination columns before the X offset have no source (sentinel -1 = transparent).
     std::vector<til::CoordType> sampleXMap(static_cast<size_t>(drawWidth));
     for (auto x = 0; x < drawWidth; ++x)
     {
-        sampleXMap[x] = cropX + std::min(cropW - 1, static_cast<til::CoordType>(static_cast<int64_t>(x) * cropW / targetW));
+        sampleXMap[x] = x < offsetX ? -1 : cropX + std::min(cropW - 1, static_cast<til::CoordType>(static_cast<int64_t>(x - offsetX) * cropW / targetW));
     }
     for (auto row = 0; row < rowSpan; ++row)
     {
@@ -5680,21 +5695,24 @@ void AdaptDispatch::_placeKittyImage(const KittyImage& image, const bool moveCur
         for (auto pixelRow = 0; pixelRow < cellHeight; ++pixelRow)
         {
             const auto dstY = row * cellHeight + pixelRow;
-            // Clear the full owned span first so padding (the last cell's pixels beyond
-            // the scaled image, or rows past targetH) never retains a co-resident image's
-            // stale pixels that this placement now owns.
+            // Clear the full owned span first so gutters and padding never retain a
+            // co-resident image's stale pixels that this placement now owns.
             for (auto pixelColumn = 0; pixelColumn < ownedWidth; ++pixelColumn)
             {
                 til::at(dstIterator, pixelColumn) = RGBQUAD{};
             }
-            if (dstY < targetH)
+            // Destination rows before the Y offset (and past the image bottom) are blank.
+            const auto srcDstY = dstY - offsetY;
+            if (srcDstY >= 0 && srcDstY < targetH)
             {
-                // Nearest-neighbour: map this target row back into the crop, then offset
-                // by the crop origin to index the full image.
-                const auto sampleY = cropY + std::min(cropH - 1, static_cast<til::CoordType>(static_cast<int64_t>(dstY) * cropH / targetH));
+                const auto sampleY = cropY + std::min(cropH - 1, static_cast<til::CoordType>(static_cast<int64_t>(srcDstY) * cropH / targetH));
                 const auto srcRowStart = static_cast<size_t>(sampleY) * image.width;
                 for (auto pixelColumn = 0; pixelColumn < drawWidth; ++pixelColumn)
                 {
+                    if (sampleXMap[pixelColumn] < 0)
+                    {
+                        continue; // transparent X-offset gutter
+                    }
                     const auto srcIndex = srcRowStart + static_cast<size_t>(sampleXMap[pixelColumn]);
                     if (srcIndex < image.pixels.size())
                     {

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -5697,16 +5697,9 @@ void AdaptDispatch::_placeKittyImage(const KittyImage& image, const bool moveCur
         // Tag only the columns this placement covers so a later id-targeted delete
         // erases just these cells, leaving co-resident Sixel (id 0) or other images.
         dstSlice->SetColumnOwner(columnBegin, columnEnd, imageId);
-        const til::CoordType ownedWidth = (columnEnd - columnBegin) * cellWidth;
         for (auto pixelRow = 0; pixelRow < cellHeight; ++pixelRow)
         {
             const auto dstY = row * cellHeight + pixelRow;
-            // Clear the full owned span first so gutters and padding never retain a
-            // co-resident image's stale pixels that this placement now owns.
-            for (auto pixelColumn = 0; pixelColumn < ownedWidth; ++pixelColumn)
-            {
-                til::at(dstIterator, pixelColumn) = RGBQUAD{};
-            }
             // Destination rows before the Y offset (and past the image bottom) are blank.
             const auto srcDstY = dstY - offsetY;
             const auto rowInImage = srcDstY >= 0 && srcDstY < targetH;

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -5655,26 +5655,30 @@ void AdaptDispatch::_placeKittyImage(const KittyImage& image, const bool moveCur
     const auto targetH = std::max<int64_t>(targetH64, 1);
 
     const auto columnBegin = origin.x;
-    // The destination spans the X offset plus the scaled image, so it can reach one cell
-    // further right than the image alone. Keep the span math in 64-bit (targetW/H may be
-    // up to ~INT32_MAX from aspect scaling) and clamp to the page before narrowing, so the
-    // offset addition can't overflow til::CoordType (int32).
-    const int64_t spanWidthPx = static_cast<int64_t>(offsetX) + targetW;
+    // Per the kitty spec, a sub-cell X/Y offset is NOT added to the number of columns/rows:
+    // the placement rectangle (and thus the cursor advance) is sized by the image footprint
+    // alone; the offset merely shifts the content within that footprint, and any overflow is
+    // truncated on the right/bottom edge. Keep the span math in 64-bit (targetW/H may be up to
+    // ~INT32_MAX from aspect scaling) and clamp to the page before narrowing.
+    const int64_t spanWidthPx = targetW;
     const auto columns = static_cast<til::CoordType>(std::min<int64_t>((spanWidthPx + cellWidth - 1) / cellWidth, page.Width()));
     const auto columnEnd = std::min(columnBegin + columns, page.Width());
     if (columnEnd <= columnBegin)
     {
         return;
     }
-    const auto drawWidth = static_cast<til::CoordType>(std::min<int64_t>(spanWidthPx, static_cast<int64_t>(columnEnd - columnBegin) * cellWidth));
-    const int64_t spanHeightPx = static_cast<int64_t>(offsetY) + targetH;
+    // Fill the whole owned footprint, so the X-offset gutter and any right-truncation are drawn.
+    const auto drawWidth = static_cast<til::CoordType>(static_cast<int64_t>(columnEnd - columnBegin) * cellWidth);
+    const int64_t spanHeightPx = targetH;
     const auto rowSpan = static_cast<til::CoordType>(std::min<int64_t>((spanHeightPx + cellHeight - 1) / cellHeight, page.Bottom()));
     // Precompute the source column for each drawn destination pixel (nearest-neighbour).
-    // Destination columns before the X offset have no source (sentinel -1 = transparent).
+    // Columns before the X offset OR past the shifted image's right edge have no source
+    // (sentinel -1 = transparent), so a right-shifted image is truncated, not stretched.
     std::vector<til::CoordType> sampleXMap(static_cast<size_t>(drawWidth));
     for (auto x = 0; x < drawWidth; ++x)
     {
-        sampleXMap[x] = x < offsetX ? -1 : cropX + std::min(cropW - 1, static_cast<til::CoordType>(static_cast<int64_t>(x - offsetX) * cropW / targetW));
+        const auto imgX = x - offsetX;
+        sampleXMap[x] = (imgX < 0 || imgX >= targetW) ? -1 : cropX + std::min(cropW - 1, static_cast<til::CoordType>(static_cast<int64_t>(imgX) * cropW / targetW));
     }
     for (auto row = 0; row < rowSpan; ++row)
     {

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -328,6 +328,8 @@ namespace Microsoft::Console::VirtualTerminal
             uint32_t srcY = 0;    // y=: source crop top edge in pixels
             uint32_t srcW = 0;    // w=: source crop width in pixels (0 = to right edge)
             uint32_t srcH = 0;    // h=: source crop height in pixels (0 = to bottom edge)
+            uint32_t cellOffsetX = 0; // X=: x pixel offset of the image within the first cell
+            uint32_t cellOffsetY = 0; // Y=: y pixel offset of the image within the first cell
             bool moreChunks = false;
             bool mPresent = false;
             bool haveId = false;
@@ -357,7 +359,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _eraseKittyImage(const uint32_t id);
         void _eraseKittyImageRows(const uint32_t imageId);
         void _clearKittyImages() noexcept;
-        void _placeKittyImage(const KittyImage& image, const bool moveCursor, const uint32_t imageId, const uint32_t cols = 0, const uint32_t rows = 0, const uint32_t srcX = 0, const uint32_t srcY = 0, const uint32_t srcW = 0, const uint32_t srcH = 0);
+        void _placeKittyImage(const KittyImage& image, const bool moveCursor, const uint32_t imageId, const uint32_t cols = 0, const uint32_t rows = 0, const uint32_t srcX = 0, const uint32_t srcY = 0, const uint32_t srcW = 0, const uint32_t srcH = 0, const uint32_t cellOffsetX = 0, const uint32_t cellOffsetY = 0);
         void _ReturnOscResponse(const std::wstring_view response) const;
 
         std::vector<uint8_t> _tabStopColumns;

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -5887,6 +5887,22 @@ public:
         VERIFY_ARE_EQUAL(255, static_cast<int>(SlicePixelAt(slice, 2, 0).rgbRed), L"the red pixel is shifted to x=2");
     }
 
+    // Regression: an X/Y offset over a REUSED slice must clear the gutter, not leave the
+    // previous image's pixels showing. Place a red image, then a green one shifted by X=2;
+    // the gutter that was red must become transparent.
+    TEST_METHOD(KittyGraphicsCellOffsetClearsStaleGutter)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 4, 4 };
+        const auto origin = _testGetSet->_textBuffer->GetCursor().GetPosition();
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\"); // red at (0,0)
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,f=24,s=1,v=1,X=2;AP8A\x1b\\"); // green shifted to (2,0)
+        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        VERIFY_ARE_EQUAL(0, static_cast<int>(SlicePixelAt(slice, 0, 0).rgbRed), L"the reused gutter pixel must be cleared, not the old red");
+        VERIFY_ARE_EQUAL(255, static_cast<int>(SlicePixelAt(slice, 2, 0).rgbGreen), L"green sits at the X offset");
+    }
+
     // An APC string with a non-'G' identifier is not Kitty graphics and is ignored.
     TEST_METHOD(NonKittyApcIgnored)
     {

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -5872,6 +5872,21 @@ public:
         VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"huge w clamps to edge, image still renders");
     }
 
+    // X/Y shift the image within the first cell by a sub-cell pixel offset. A 1px red
+    // image in a 4px cell placed with X=2 lands at destination pixel (2,0); the leading
+    // gutter pixels stay transparent.
+    TEST_METHOD(KittyGraphicsCellOffsetShiftsImage)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 4, 4 };
+        const auto origin = _testGetSet->_textBuffer->GetCursor().GetPosition();
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,X=2,Y=0;/wAA\x1b\\"); // 1px red, X offset 2
+        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        VERIFY_ARE_EQUAL(0, static_cast<int>(SlicePixelAt(slice, 0, 0).rgbRed), L"the X-offset gutter pixel (0,0) is transparent");
+        VERIFY_ARE_EQUAL(255, static_cast<int>(SlicePixelAt(slice, 2, 0).rgbRed), L"the red pixel is shifted to x=2");
+    }
+
     // An APC string with a non-'G' identifier is not Kitty graphics and is ignored.
     TEST_METHOD(NonKittyApcIgnored)
     {

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -5903,6 +5903,24 @@ public:
         VERIFY_ARE_EQUAL(255, static_cast<int>(SlicePixelAt(slice, 2, 0).rgbGreen), L"green sits at the X offset");
     }
 
+    // Regression (why): the kitty spec says a sub-cell X/Y offset is NOT added to the number of
+    // columns/rows, and the cursor advances by the image's cell footprint only. The old code used
+    // spanWidthPx = offsetX + targetW, so a 1-cell-wide image with an X offset spilled into a 2nd
+    // column (and advanced the cursor an extra cell). This guards that the offset shifts within the
+    // footprint (right-truncated) without enlarging the placement's owned columns.
+    TEST_METHOD(KittyGraphicsCellOffsetDoesNotEnlargeSpan)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 4, 4 };
+        const auto origin = _testGetSet->_textBuffer->GetCursor().GetPosition();
+        // A 4px-wide image is exactly one 4px cell; X=2 shifts it right by 2px WITHIN that cell.
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=4,v=1,X=2,C=1;/wAA/wAA/wAA/wAA\x1b\\");
+        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(origin.x), L"the image's single cell is owned");
+        VERIFY_ARE_EQUAL(0u, slice->ColumnOwner(origin.x + 1), L"a sub-cell X offset must not extend the placement into a 2nd column");
+    }
+
     // An APC string with a non-'G' identifier is not Kitty graphics and is ignored.
     TEST_METHOD(NonKittyApcIgnored)
     {


### PR DESCRIPTION
Closes #18. Adds the uppercase `X=`/`Y=` placement params — a sub-cell pixel offset of the image within the first cell (clamped to the cell; the image may spill one cell right/bottom; the leading gutter stays transparent). `X=Y=0` is unchanged. 236 adapter Kitty tests green (+CellOffsetShiftsImage). Stacked on #11 geometry.