### PR TITLE
Give ImageSlice identified, z-ordered layers

### DIFF
--- a/src/buffer/out/ImageSlice.cpp
+++ b/src/buffer/out/ImageSlice.cpp
@@ -7,7 +7,96 @@
 #include "Row.hpp"
 #include "textBuffer.hpp"
 
+#include <algorithm>
+
 static std::atomic<uint64_t> s_revision{ 0 };
+
+// A process-wide accounting of identified layer storage. Untagged content is
+// not accounted, because its footprint is already bounded by the dimensions of
+// the text buffer that owns it.
+static std::atomic<size_t> s_layerBytes{ 0 };
+
+namespace
+{
+    // Maps a layer's z-index onto the plane it composites into.
+    constexpr ImageSlice::RenderPosition PositionOf(const int32_t zIndex) noexcept
+    {
+        if (zIndex < ImageSlice::BackgroundZThreshold)
+        {
+            return ImageSlice::RenderPosition::BehindBackground;
+        }
+        return zIndex < 0 ? ImageSlice::RenderPosition::BehindText : ImageSlice::RenderPosition::AboveText;
+    }
+
+    // Moves a plane of pixels into a wider plane, aligned to the new origin.
+    void RelocatePlane(std::vector<RGBQUAD>& plane, const til::CoordType oldPixelWidth, const til::CoordType newPixelWidth, const til::CoordType newPixelOffset, const til::CoordType cellHeight)
+    {
+        if (plane.empty())
+        {
+            return;
+        }
+        auto relocated = std::vector<RGBQUAD>(gsl::narrow_cast<size_t>(newPixelWidth) * cellHeight);
+        auto srcIterator = plane.data();
+        auto dstIterator = std::next(relocated.data(), newPixelOffset);
+        // Because widths are rounded up to multiples of 4, it's possible that
+        // the old width will extend past the right border of the new plane, so
+        // the range that we copy must be clamped to fit.
+        const auto range = std::min(oldPixelWidth, newPixelWidth - newPixelOffset);
+        for (auto y = 0; y < cellHeight; y++)
+        {
+            std::memcpy(dstIterator, srcIterator, gsl::narrow_cast<size_t>(range) * sizeof(RGBQUAD));
+            std::advance(srcIterator, oldPixelWidth);
+            std::advance(dstIterator, newPixelWidth);
+        }
+        plane = std::move(relocated);
+    }
+
+    // Moves per-column coverage flags into a wider range, aligned to the new origin.
+    void RelocateColumns(std::vector<uint8_t>& columns, const size_t newCount, const size_t newOffset)
+    {
+        if (columns.empty())
+        {
+            return;
+        }
+        auto relocated = std::vector<uint8_t>(newCount, 0);
+        const auto count = std::min(columns.size(), newCount - newOffset);
+        std::copy_n(columns.begin(), count, std::next(relocated.begin(), newOffset));
+        columns = std::move(relocated);
+    }
+}
+
+size_t ImageSlice::LayerBytesAvailable() noexcept
+{
+    const auto used = s_layerBytes.load(std::memory_order_relaxed);
+    return used >= MaxLayerBytes ? 0 : MaxLayerBytes - used;
+}
+
+// A copy is made whenever a row is cloned, which happens during scrolling and
+// reflow. That must not be allowed to fail, so the budget is charged for the
+// copy but is deliberately not enforced here.
+ImageSlice::ImageSlice(const ImageSlice& rhs) :
+    _revision{ rhs._revision },
+    _cellSize{ rhs._cellSize },
+    _pixelBuffer{ rhs._pixelBuffer },
+    _columnBegin{ rhs._columnBegin },
+    _columnEnd{ rhs._columnEnd },
+    _pixelWidth{ rhs._pixelWidth },
+    _layers{ rhs._layers }
+{
+    for (const auto& layer : _layers)
+    {
+        _accountedBytes += _layerBytes(layer);
+    }
+    s_layerBytes.fetch_add(_accountedBytes, std::memory_order_relaxed);
+}
+
+ImageSlice::~ImageSlice() noexcept
+{
+    if (_accountedBytes != 0)
+    {
+        s_layerBytes.fetch_sub(_accountedBytes, std::memory_order_relaxed);
+    }
+}
 
 ImageSlice::ImageSlice(const til::size cellSize) noexcept :
     _cellSize{ cellSize }
@@ -16,16 +105,24 @@ ImageSlice::ImageSlice(const til::size cellSize) noexcept :
 
 void ImageSlice::BumpRevision() noexcept
 {
-    // Avoid setting the revision to 0. This allows the renderer to use 0 as a sentinel value.
+    // Reserve one value per render position, so each of a slice's composited
+    // planes has a revision no other slice can also hand out. Renderers cache
+    // uploaded pixels by revision, and would otherwise draw one plane's pixels
+    // when asked for another's.
     do
     {
-        _revision = s_revision.fetch_add(1, std::memory_order_relaxed);
+        _revision = s_revision.fetch_add(RenderPositionCount, std::memory_order_relaxed);
     } while (_revision == 0);
 }
 
 uint64_t ImageSlice::Revision() const noexcept
 {
     return _revision;
+}
+
+uint64_t ImageSlice::Revision(const RenderPosition position) const noexcept
+{
+    return _revision == 0 ? 0 : _revision + static_cast<uint64_t>(position);
 }
 
 til::size ImageSlice::CellSize() const noexcept
@@ -54,43 +151,50 @@ const RGBQUAD* ImageSlice::Pixels(const til::CoordType columnBegin) const noexce
     return &til::at(_pixelBuffer, pixelOffset);
 }
 
+// Widens the slice to cover the requested range, relocating the base plane and
+// every layer so they stay aligned with the new origin.
+void ImageSlice::_ensureRange(const til::CoordType columnBegin, const til::CoordType columnEnd)
+{
+    const auto hasRange = _columnEnd > _columnBegin;
+    if (hasRange && columnBegin >= _columnBegin && columnEnd <= _columnEnd)
+    {
+        return;
+    }
+
+    const auto oldColumnBegin = _columnBegin;
+    const auto oldPixelWidth = _pixelWidth;
+    _columnBegin = hasRange ? std::min(_columnBegin, columnBegin) : columnBegin;
+    _columnEnd = hasRange ? std::max(_columnEnd, columnEnd) : columnEnd;
+    _pixelWidth = (_columnEnd - _columnBegin) * _cellSize.width;
+
+    if (!hasRange)
+    {
+        return;
+    }
+
+    const auto newPixelOffset = (oldColumnBegin - _columnBegin) * _cellSize.width;
+    const auto newColumnOffset = gsl::narrow_cast<size_t>(oldColumnBegin - _columnBegin);
+    const auto newColumnCount = gsl::narrow_cast<size_t>(_columnEnd - _columnBegin);
+
+    RelocatePlane(_pixelBuffer, oldPixelWidth, _pixelWidth, newPixelOffset, _cellSize.height);
+    for (auto& layer : _layers)
+    {
+        const auto before = _layerBytes(layer);
+        RelocatePlane(layer.pixels, oldPixelWidth, _pixelWidth, newPixelOffset, _cellSize.height);
+        RelocateColumns(layer.columns, newColumnCount, newColumnOffset);
+        // This growth is forced by geometry rather than requested by a write,
+        // so it is charged to the budget but not refused.
+        _reserveLayerBytes(_layerBytes(layer) - before);
+    }
+}
+
 RGBQUAD* ImageSlice::MutablePixels(const til::CoordType columnBegin, const til::CoordType columnEnd)
 {
-    // IF the buffer is empty or isn't large enough for the requested range, we'll need to resize it.
+    // If the buffer is empty or isn't large enough for the requested range, we'll need to resize it.
     if (_pixelBuffer.empty() || columnBegin < _columnBegin || columnEnd > _columnEnd)
     {
-        const auto oldColumnBegin = _columnBegin;
-        const auto oldPixelWidth = _pixelWidth;
-        const auto existingData = !_pixelBuffer.empty();
-        _columnBegin = existingData ? std::min(_columnBegin, columnBegin) : columnBegin;
-        _columnEnd = existingData ? std::max(_columnEnd, columnEnd) : columnEnd;
-        _pixelWidth = (_columnEnd - _columnBegin) * _cellSize.width;
-        const auto bufferSize = _pixelWidth * _cellSize.height;
-        if (existingData)
-        {
-            // If there is existing data in the buffer, we need to copy it
-            // across to the appropriate position in the new buffer.
-            auto newPixelBuffer = std::vector<RGBQUAD>(bufferSize);
-            const auto newPixelOffset = (oldColumnBegin - _columnBegin) * _cellSize.width;
-            auto newIterator = std::next(newPixelBuffer.data(), newPixelOffset);
-            auto oldIterator = _pixelBuffer.data();
-            // Because widths are rounded up to multiples of 4, it's possible
-            // that the old width will extend past the right border of the new
-            // buffer, so the range that we copy must be clamped to fit.
-            const auto newPixelRange = std::min(oldPixelWidth, _pixelWidth - newPixelOffset);
-            for (auto i = 0; i < _cellSize.height; i++)
-            {
-                std::memcpy(newIterator, oldIterator, newPixelRange * sizeof(RGBQUAD));
-                std::advance(oldIterator, oldPixelWidth);
-                std::advance(newIterator, _pixelWidth);
-            }
-            _pixelBuffer = std::move(newPixelBuffer);
-        }
-        else
-        {
-            // Otherwise we just initialize the buffer to the correct size.
-            _pixelBuffer.resize(bufferSize);
-        }
+        _ensureRange(columnBegin, columnEnd);
+        _pixelBuffer.resize(gsl::narrow_cast<size_t>(_pixelWidth) * _cellSize.height);
     }
     const auto pixelOffset = (columnBegin - _columnBegin) * _cellSize.width;
     return &til::at(_pixelBuffer, pixelOffset);
@@ -173,16 +277,30 @@ bool ImageSlice::_copyCells(const ImageSlice& srcSlice, const til::CoordType src
 
     if (dstWriteBegin < dstWriteEnd)
     {
-        auto dstIterator = MutablePixels(dstWriteBegin, dstWriteEnd);
-        auto srcIterator = srcSlice.Pixels(srcUsedBegin);
-        const auto writeCellCount = dstWriteEnd - dstWriteBegin;
-        const auto writeByteCount = sizeof(RGBQUAD) * writeCellCount * _cellSize.width;
-        for (auto y = 0; y < _cellSize.height; y++)
+        // A slice can hold layers without ever holding untagged content, in
+        // which case there is no base plane to read from. The copy still has to
+        // replace whatever the destination had in that range.
+        if (!srcSlice._pixelBuffer.empty())
         {
-            std::memmove(dstIterator, srcIterator, writeByteCount);
-            std::advance(srcIterator, srcSlice._pixelWidth);
-            std::advance(dstIterator, _pixelWidth);
+            auto dstIterator = MutablePixels(dstWriteBegin, dstWriteEnd);
+            auto srcIterator = srcSlice.Pixels(srcUsedBegin);
+            const auto writeCellCount = dstWriteEnd - dstWriteBegin;
+            const auto writeByteCount = sizeof(RGBQUAD) * writeCellCount * _cellSize.width;
+            for (auto y = 0; y < _cellSize.height; y++)
+            {
+                std::memmove(dstIterator, srcIterator, writeByteCount);
+                std::advance(srcIterator, srcSlice._pixelWidth);
+                std::advance(dstIterator, _pixelWidth);
+            }
         }
+        else
+        {
+            // No base plane in the source means the destination's untagged
+            // pixels in this range are what the copy replaces them with:
+            // nothing. (A self-copy can't reach here with anything to erase.)
+            _eraseBasePlane(dstWriteBegin, dstWriteEnd);
+        }
+        _copyLayers(srcSlice, srcUsedBegin, dstWriteBegin, dstWriteEnd);
     }
 
     // The used destination before and after the written area must be erased.
@@ -257,15 +375,449 @@ bool ImageSlice::_eraseCells(const til::CoordType columnBegin, const til::CoordT
         const auto eraseEnd = std::min(columnEnd, _columnEnd);
         if (eraseBegin < eraseEnd)
         {
-            const auto eraseOffset = (eraseBegin - _columnBegin) * _cellSize.width;
-            const auto eraseLength = (eraseEnd - eraseBegin) * _cellSize.width;
-            auto eraseIterator = std::next(_pixelBuffer.data(), eraseOffset);
-            for (auto y = 0; y < _cellSize.height; y++)
+            _eraseBasePlane(eraseBegin, eraseEnd);
+            for (auto& layer : _layers)
             {
-                std::memset(eraseIterator, 0, eraseLength * sizeof(RGBQUAD));
-                std::advance(eraseIterator, _pixelWidth);
+                _clearLayerColumns(layer, eraseBegin, eraseEnd);
+            }
+            _removeEmptyLayers();
+            _invalidateComposites();
+        }
+        // Erasing a range can retire the last layer, which leaves the slice
+        // with nothing in it at all.
+        return !_hasContent();
+    }
+}
+
+// Zeroes the untagged base plane over a column range, leaving every identified
+// layer untouched. `_eraseCells` erases both; a copy only replaces this part.
+void ImageSlice::_eraseBasePlane(const til::CoordType columnBegin, const til::CoordType columnEnd) noexcept
+{
+    if (_pixelBuffer.empty())
+    {
+        return;
+    }
+
+    const auto eraseBegin = std::max(columnBegin, _columnBegin);
+    const auto eraseEnd = std::min(columnEnd, _columnEnd);
+    if (eraseBegin >= eraseEnd)
+    {
+        return;
+    }
+
+    const auto eraseOffset = (eraseBegin - _columnBegin) * _cellSize.width;
+    const auto eraseLength = (eraseEnd - eraseBegin) * _cellSize.width;
+    auto eraseIterator = std::next(_pixelBuffer.data(), eraseOffset);
+    for (auto y = 0; y < _cellSize.height; y++)
+    {
+        std::memset(eraseIterator, 0, static_cast<size_t>(eraseLength) * sizeof(RGBQUAD));
+        std::advance(eraseIterator, _pixelWidth);
+    }
+    _invalidateComposites();
+}
+
+size_t ImageSlice::_layerBytes(const Layer& layer) noexcept
+{
+    return layer.pixels.size() * sizeof(RGBQUAD) + layer.columns.size();
+}
+
+void ImageSlice::_reserveLayerBytes(const size_t bytes)
+{
+    if (bytes != 0)
+    {
+        _accountedBytes += bytes;
+        s_layerBytes.fetch_add(bytes, std::memory_order_relaxed);
+    }
+}
+
+void ImageSlice::_releaseLayerBytes(const size_t bytes) noexcept
+{
+    if (bytes != 0)
+    {
+        _accountedBytes -= bytes;
+        s_layerBytes.fetch_sub(bytes, std::memory_order_relaxed);
+    }
+}
+
+// A revision of 0 is never handed out by BumpRevision, so it doubles as the
+// "this composite is stale" marker.
+void ImageSlice::_invalidateComposites() noexcept
+{
+    for (auto& composite : _composites)
+    {
+        composite.revision = 0;
+    }
+}
+
+bool ImageSlice::_hasContent() const noexcept
+{
+    return !_pixelBuffer.empty() || !_layers.empty();
+}
+
+void ImageSlice::_clearLayerColumns(Layer& layer, const til::CoordType columnBegin, const til::CoordType columnEnd) noexcept
+{
+    const auto clearBegin = std::max(columnBegin, _columnBegin);
+    const auto clearEnd = std::min(columnEnd, _columnEnd);
+    if (clearBegin >= clearEnd)
+    {
+        return;
+    }
+
+    for (auto column = clearBegin; column < clearEnd; column++)
+    {
+        const auto index = static_cast<size_t>(column - _columnBegin);
+        if (index < layer.columns.size())
+        {
+            til::at(layer.columns, index) = 0;
+        }
+    }
+
+    // The pixels have to go too, or the next composite would resurrect them.
+    if (!layer.pixels.empty())
+    {
+        const auto offset = (clearBegin - _columnBegin) * _cellSize.width;
+        const auto length = (clearEnd - clearBegin) * _cellSize.width;
+        auto iterator = std::next(layer.pixels.data(), offset);
+        for (auto y = 0; y < _cellSize.height; y++)
+        {
+            std::memset(iterator, 0, static_cast<size_t>(length) * sizeof(RGBQUAD));
+            std::advance(iterator, _pixelWidth);
+        }
+    }
+}
+
+// Drops any layer that no longer covers a single cell, returning true if the
+// set of layers changed.
+bool ImageSlice::_removeEmptyLayers()
+{
+    auto removed = false;
+    for (auto it = _layers.begin(); it != _layers.end();)
+    {
+        const auto covered = std::any_of(it->columns.begin(), it->columns.end(), [](const uint8_t flag) { return flag != 0; });
+        if (covered)
+        {
+            ++it;
+        }
+        else
+        {
+            _releaseLayerBytes(_layerBytes(*it));
+            it = _layers.erase(it);
+            removed = true;
+        }
+    }
+    return removed;
+}
+
+ImageSlice::Layer& ImageSlice::_getLayer(const LayerKey key, const int32_t zIndex)
+{
+    const auto existing = std::find_if(_layers.begin(), _layers.end(), [&](const Layer& layer) {
+        return layer.key == key && layer.zIndex == zIndex;
+    });
+    if (existing != _layers.end())
+    {
+        return *existing;
+    }
+    _layers.push_back(Layer{ .key = key, .zIndex = zIndex });
+    return _layers.back();
+}
+
+const ImageSlice::Composite& ImageSlice::_composite(const RenderPosition position) const
+{
+    auto& composite = til::at(_composites, static_cast<size_t>(position));
+    if (composite.revision == _revision && _revision != 0)
+    {
+        return composite;
+    }
+
+    const auto planeSize = static_cast<size_t>(_pixelWidth) * _cellSize.height;
+    composite.pixels.assign(planeSize, RGBQUAD{});
+    composite.hasPixels = false;
+
+    // Untagged content composites above the text, which is where image content
+    // in a row has always been drawn.
+    if (position == RenderPosition::AboveText && !_pixelBuffer.empty())
+    {
+        const auto count = std::min(planeSize, _pixelBuffer.size());
+        std::copy_n(_pixelBuffer.begin(), count, composite.pixels.begin());
+        composite.hasPixels = true;
+    }
+
+    // Layers composite in ascending z, with ties broken by insertion order.
+    auto ordered = std::vector<const Layer*>{};
+    ordered.reserve(_layers.size());
+    for (const auto& layer : _layers)
+    {
+        if (PositionOf(layer.zIndex) == position && !layer.pixels.empty())
+        {
+            ordered.push_back(&layer);
+        }
+    }
+    std::stable_sort(ordered.begin(), ordered.end(), [](const Layer* lhs, const Layer* rhs) { return lhs->zIndex < rhs->zIndex; });
+
+    for (const auto layer : ordered)
+    {
+        const auto count = std::min(planeSize, layer->pixels.size());
+        for (size_t i = 0; i < count; i++)
+        {
+            // A fully transparent pixel leaves whatever is beneath it alone.
+            const auto& pixel = til::at(layer->pixels, i);
+            if (pixel.rgbReserved != 0)
+            {
+                til::at(composite.pixels, i) = pixel;
+                composite.hasPixels = true;
             }
         }
+    }
+
+    composite.revision = _revision;
+    return composite;
+}
+
+std::span<const RGBQUAD> ImageSlice::Pixels(const RenderPosition position) const
+{
+    // Most slices carry no identified layers at all. Hand back the base plane
+    // itself rather than compositing a copy of it every time it changes.
+    if (_layers.empty())
+    {
+        return position == RenderPosition::AboveText ? std::span<const RGBQUAD>{ _pixelBuffer } : std::span<const RGBQUAD>{};
+    }
+    return _composite(position).pixels;
+}
+
+bool ImageSlice::HasPixels(const RenderPosition position) const
+{
+    if (_layers.empty())
+    {
+        return position == RenderPosition::AboveText && !_pixelBuffer.empty();
+    }
+    return _composite(position).hasPixels;
+}
+
+// Returns null if the slice cannot take another layer, either because this one
+// would exceed the per-slice count or the process-wide byte budget.
+RGBQUAD* ImageSlice::MutablePixels(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex)
+{
+    // Content that carries no identity belongs in the base plane.
+    if (key.Untagged())
+    {
+        return MutablePixels(columnBegin, columnEnd);
+    }
+
+    const auto isNewLayer = std::none_of(_layers.begin(), _layers.end(), [&](const Layer& layer) {
+        return layer.key == key && layer.zIndex == zIndex;
+    });
+    if (isNewLayer && _layers.size() >= MaxLayersPerSlice)
+    {
+        return nullptr;
+    }
+
+    _ensureRange(columnBegin, columnEnd);
+
+    const auto planeSize = static_cast<size_t>(_pixelWidth) * _cellSize.height;
+    const auto columnCount = static_cast<size_t>(_columnEnd - _columnBegin);
+    if (isNewLayer && planeSize * sizeof(RGBQUAD) + columnCount > LayerBytesAvailable())
+    {
+        return nullptr;
+    }
+
+    auto& layer = _getLayer(key, zIndex);
+    const auto before = _layerBytes(layer);
+    layer.pixels.resize(planeSize);
+    layer.columns.resize(columnCount, 0);
+    for (auto column = columnBegin; column < columnEnd; column++)
+    {
+        til::at(layer.columns, static_cast<size_t>(column - _columnBegin)) = 1;
+    }
+    _reserveLayerBytes(_layerBytes(layer) - before);
+    _invalidateComposites();
+
+    const auto pixelOffset = (columnBegin - _columnBegin) * _cellSize.width;
+    return &til::at(layer.pixels, pixelOffset);
+}
+
+bool ImageSlice::Contains(const uint32_t imageId) const noexcept
+{
+    return std::any_of(_layers.begin(), _layers.end(), [=](const Layer& layer) { return layer.key.imageId == imageId; });
+}
+
+bool ImageSlice::Contains(const LayerKey key) const noexcept
+{
+    return std::any_of(_layers.begin(), _layers.end(), [=](const Layer& layer) { return layer.key == key; });
+}
+
+bool ImageSlice::LayerCoversColumn(const LayerKey key, const til::CoordType column) const noexcept
+{
+    if (column < _columnBegin || column >= _columnEnd)
+    {
         return false;
     }
+    const auto index = static_cast<size_t>(column - _columnBegin);
+    return std::any_of(_layers.begin(), _layers.end(), [=](const Layer& layer) {
+        return layer.key == key && index < layer.columns.size() && til::at(layer.columns, index) != 0;
+    });
+}
+
+std::vector<ImageSlice::LayerKey> ImageSlice::LayersAtColumn(const til::CoordType column) const
+{
+    auto keys = std::vector<LayerKey>{};
+    if (column < _columnBegin || column >= _columnEnd)
+    {
+        return keys;
+    }
+    const auto index = static_cast<size_t>(column - _columnBegin);
+    for (const auto& layer : _layers)
+    {
+        if (index < layer.columns.size() && til::at(layer.columns, index) != 0)
+        {
+            keys.push_back(layer.key);
+        }
+    }
+    return keys;
+}
+
+std::vector<ImageSlice::LayerKey> ImageSlice::LayersAtZ(const int32_t zIndex) const
+{
+    auto keys = std::vector<LayerKey>{};
+    for (const auto& layer : _layers)
+    {
+        if (layer.zIndex == zIndex)
+        {
+            keys.push_back(layer.key);
+        }
+    }
+    return keys;
+}
+
+// The erase overloads all report true when the slice has been left with no
+// content at all, which tells the caller to drop the slice entirely.
+bool ImageSlice::EraseLayer(const uint32_t imageId)
+{
+    auto erased = false;
+    for (auto it = _layers.begin(); it != _layers.end();)
+    {
+        if (it->key.imageId == imageId)
+        {
+            _releaseLayerBytes(_layerBytes(*it));
+            it = _layers.erase(it);
+            erased = true;
+        }
+        else
+        {
+            ++it;
+        }
+    }
+    if (erased)
+    {
+        _invalidateComposites();
+    }
+    return !_hasContent();
+}
+
+bool ImageSlice::EraseLayer(const LayerKey key)
+{
+    auto erased = false;
+    for (auto it = _layers.begin(); it != _layers.end();)
+    {
+        if (it->key == key)
+        {
+            _releaseLayerBytes(_layerBytes(*it));
+            it = _layers.erase(it);
+            erased = true;
+        }
+        else
+        {
+            ++it;
+        }
+    }
+    if (erased)
+    {
+        _invalidateComposites();
+    }
+    return !_hasContent();
+}
+
+bool ImageSlice::EraseLayer(const uint32_t imageId, const til::CoordType columnBegin, const til::CoordType columnEnd)
+{
+    auto changed = false;
+    for (auto& layer : _layers)
+    {
+        if (layer.key.imageId == imageId)
+        {
+            _clearLayerColumns(layer, columnBegin, columnEnd);
+            changed = true;
+        }
+    }
+    if (changed)
+    {
+        _removeEmptyLayers();
+        _invalidateComposites();
+    }
+    return !_hasContent();
+}
+
+void ImageSlice::_copyLayers(const ImageSlice& srcSlice, const til::CoordType srcColumn, const til::CoordType dstColumnBegin, const til::CoordType dstColumnEnd)
+{
+    if (srcSlice._layers.empty() && _layers.empty())
+    {
+        return;
+    }
+
+    // A row can be copied onto itself, and writing to our own layers would
+    // invalidate the source we're reading from, so take a snapshot first.
+    const auto snapshot = &srcSlice == this ? _layers : std::vector<Layer>{};
+    const auto& srcLayers = &srcSlice == this ? snapshot : srcSlice._layers;
+    const auto srcColumnBegin = srcSlice._columnBegin;
+    const auto srcPixelWidth = srcSlice._pixelWidth;
+    const auto columnCount = dstColumnEnd - dstColumnBegin;
+
+    // A copy replaces the destination range outright, so every layer already
+    // there has to give up those columns before the source is written in.
+    // Otherwise a destination layer with no counterpart in the source would
+    // survive a copy that was meant to overwrite it.
+    for (auto& dstLayer : _layers)
+    {
+        _clearLayerColumns(dstLayer, dstColumnBegin, dstColumnEnd);
+    }
+
+    for (const auto& srcLayer : srcLayers)
+    {
+        if (srcLayer.pixels.empty())
+        {
+            continue;
+        }
+
+        const auto dstPixels = MutablePixels(dstColumnBegin, dstColumnEnd, srcLayer.key, srcLayer.zIndex);
+        if (!dstPixels)
+        {
+            // The budget is exhausted, so this layer simply doesn't survive the copy.
+            continue;
+        }
+
+        auto srcIterator = std::next(srcLayer.pixels.data(), (srcColumn - srcColumnBegin) * _cellSize.width);
+        auto dstIterator = dstPixels;
+        const auto byteCount = sizeof(RGBQUAD) * columnCount * _cellSize.width;
+        for (auto y = 0; y < _cellSize.height; y++)
+        {
+            std::memmove(dstIterator, srcIterator, byteCount);
+            std::advance(srcIterator, srcPixelWidth);
+            std::advance(dstIterator, _pixelWidth);
+        }
+
+        // Coverage has to follow the pixels, otherwise a later targeted erase
+        // would skip the cells we just wrote.
+        auto& dstLayer = _getLayer(srcLayer.key, srcLayer.zIndex);
+        for (auto column = 0; column < columnCount; column++)
+        {
+            const auto srcIndex = static_cast<size_t>(srcColumn - srcColumnBegin + column);
+            const auto dstIndex = static_cast<size_t>(dstColumnBegin - _columnBegin + column);
+            const auto covered = srcIndex < srcLayer.columns.size() && til::at(srcLayer.columns, srcIndex) != 0;
+            if (dstIndex < dstLayer.columns.size())
+            {
+                til::at(dstLayer.columns, dstIndex) = covered ? uint8_t{ 1 } : uint8_t{ 0 };
+            }
+        }
+    }
+
+    _removeEmptyLayers();
+    _invalidateComposites();
 }

--- a/src/buffer/out/ImageSlice.cpp
+++ b/src/buffer/out/ImageSlice.cpp
@@ -71,9 +71,63 @@ size_t ImageSlice::LayerBytesAvailable() noexcept
     return used >= MaxLayerBytes ? 0 : MaxLayerBytes - used;
 }
 
+ImageSlice::BudgetCharge::~BudgetCharge() noexcept
+{
+    Release(_bytes);
+}
+
+ImageSlice::BudgetCharge::BudgetCharge(const BudgetCharge& other) noexcept
+{
+    // The copying slice carries the same layers, so it owes the same amount.
+    Reserve(other._bytes);
+}
+
+ImageSlice::BudgetCharge::BudgetCharge(BudgetCharge&& other) noexcept :
+    _bytes{ std::exchange(other._bytes, 0) }
+{
+}
+
+ImageSlice::BudgetCharge& ImageSlice::BudgetCharge::operator=(BudgetCharge&& other) noexcept
+{
+    if (this != &other)
+    {
+        Release(_bytes);
+        _bytes = std::exchange(other._bytes, 0);
+    }
+    return *this;
+}
+
+void ImageSlice::BudgetCharge::Reserve(const size_t bytes) noexcept
+{
+    if (bytes != 0)
+    {
+        _bytes += bytes;
+        s_layerBytes.fetch_add(bytes, std::memory_order_relaxed);
+    }
+}
+
+void ImageSlice::BudgetCharge::Release(const size_t bytes) noexcept
+{
+    if (bytes != 0)
+    {
+        _bytes -= bytes;
+        s_layerBytes.fetch_sub(bytes, std::memory_order_relaxed);
+    }
+}
+
+size_t ImageSlice::BudgetCharge::Bytes() const noexcept
+{
+    return _bytes;
+}
+
 // A copy is made whenever a row is cloned, which happens during scrolling and
 // reflow. That must not be allowed to fail, so the budget is charged for the
-// copy but is deliberately not enforced here.
+// copy but is deliberately not enforced here. This is the one special member
+// that cannot be defaulted: the composite caches are per-slice scratch and are
+// deliberately not carried across, so the copy starts with them empty.
+// Everything but `_composites`, which is a scratch cache of flattened planes.
+// A copy starts with them empty rather than inheriting the original's, so this
+// one member is why the copy constructor is written out rather than defaulted.
 ImageSlice::ImageSlice(const ImageSlice& rhs) :
     _revision{ rhs._revision },
     _cellSize{ rhs._cellSize },
@@ -81,21 +135,9 @@ ImageSlice::ImageSlice(const ImageSlice& rhs) :
     _columnBegin{ rhs._columnBegin },
     _columnEnd{ rhs._columnEnd },
     _pixelWidth{ rhs._pixelWidth },
-    _layers{ rhs._layers }
+    _layers{ rhs._layers },
+    _charge{ rhs._charge }
 {
-    for (const auto& layer : _layers)
-    {
-        _accountedBytes += _layerBytes(layer);
-    }
-    s_layerBytes.fetch_add(_accountedBytes, std::memory_order_relaxed);
-}
-
-ImageSlice::~ImageSlice() noexcept
-{
-    if (_accountedBytes != 0)
-    {
-        s_layerBytes.fetch_sub(_accountedBytes, std::memory_order_relaxed);
-    }
 }
 
 ImageSlice::ImageSlice(const til::size cellSize) noexcept :
@@ -184,7 +226,7 @@ void ImageSlice::_ensureRange(const til::CoordType columnBegin, const til::Coord
         RelocateColumns(layer.columns, newColumnCount, newColumnOffset);
         // This growth is forced by geometry rather than requested by a write,
         // so it is charged to the budget but not refused.
-        _reserveLayerBytes(_layerBytes(layer) - before);
+        _charge.Reserve(_layerBytes(layer) - before);
     }
 }
 
@@ -421,24 +463,6 @@ size_t ImageSlice::_layerBytes(const Layer& layer) noexcept
     return layer.pixels.size() * sizeof(RGBQUAD) + layer.columns.size();
 }
 
-void ImageSlice::_reserveLayerBytes(const size_t bytes)
-{
-    if (bytes != 0)
-    {
-        _accountedBytes += bytes;
-        s_layerBytes.fetch_add(bytes, std::memory_order_relaxed);
-    }
-}
-
-void ImageSlice::_releaseLayerBytes(const size_t bytes) noexcept
-{
-    if (bytes != 0)
-    {
-        _accountedBytes -= bytes;
-        s_layerBytes.fetch_sub(bytes, std::memory_order_relaxed);
-    }
-}
-
 // A revision of 0 is never handed out by BumpRevision, so it doubles as the
 // "this composite is stale" marker.
 void ImageSlice::_invalidateComposites() noexcept
@@ -500,7 +524,7 @@ bool ImageSlice::_removeEmptyLayers()
         }
         else
         {
-            _releaseLayerBytes(_layerBytes(*it));
+            _charge.Release(_layerBytes(*it));
             it = _layers.erase(it);
             removed = true;
         }
@@ -652,7 +676,7 @@ RGBQUAD* ImageSlice::TryMutablePixels(const til::CoordType columnBegin, const ti
     {
         til::at(layer.columns, static_cast<size_t>(column - _columnBegin)) = 1;
     }
-    _reserveLayerBytes(_layerBytes(layer) - before);
+    _charge.Reserve(_layerBytes(layer) - before);
     _invalidateComposites();
 
     const auto pixelOffset = (columnBegin - _columnBegin) * _cellSize.width;
@@ -721,7 +745,7 @@ bool ImageSlice::EraseLayer(const uint32_t imageId)
     {
         if (it->key.imageId == imageId)
         {
-            _releaseLayerBytes(_layerBytes(*it));
+            _charge.Release(_layerBytes(*it));
             it = _layers.erase(it);
             erased = true;
         }
@@ -744,7 +768,7 @@ bool ImageSlice::EraseLayer(const LayerKey key)
     {
         if (it->key == key)
         {
-            _releaseLayerBytes(_layerBytes(*it));
+            _charge.Release(_layerBytes(*it));
             it = _layers.erase(it);
             erased = true;
         }

--- a/src/buffer/out/ImageSlice.cpp
+++ b/src/buffer/out/ImageSlice.cpp
@@ -552,20 +552,32 @@ const ImageSlice::Composite& ImageSlice::_composite(const RenderPosition positio
             ordered.push_back(&layer);
         }
     }
-    std::stable_sort(ordered.begin(), ordered.end(), [](const Layer* lhs, const Layer* rhs) { return lhs->zIndex < rhs->zIndex; });
+    std::stable_sort(ordered.begin(), ordered.end(), [](const Layer* lhs, const Layer* rhs) {
+        return std::tie(lhs->zIndex, lhs->key.imageId) < std::tie(rhs->zIndex, rhs->key.imageId);
+    });
 
     for (const auto layer : ordered)
     {
         const auto count = std::min(planeSize, layer->pixels.size());
         for (size_t i = 0; i < count; i++)
         {
-            // A fully transparent pixel leaves whatever is beneath it alone.
-            const auto& pixel = til::at(layer->pixels, i);
-            if (pixel.rgbReserved != 0)
-            {
-                til::at(composite.pixels, i) = pixel;
-                composite.hasPixels = true;
-            }
+            // Source-over on premultiplied pixels: dst = src + dst * (1 - srcAlpha).
+            // A fully transparent source leaves what is beneath it untouched, and
+            // a fully opaque one replaces it, without either being a special case.
+            const auto& src = til::at(layer->pixels, i);
+            auto& dst = til::at(composite.pixels, i);
+            const auto inverseAlpha = 255u - src.rgbReserved;
+            const auto over = [inverseAlpha](const BYTE s, const BYTE d) {
+                return static_cast<BYTE>(std::min(255u, static_cast<uint32_t>(s) + (static_cast<uint32_t>(d) * inverseAlpha + 127u) / 255u));
+            };
+            dst.rgbRed = over(src.rgbRed, dst.rgbRed);
+            dst.rgbGreen = over(src.rgbGreen, dst.rgbGreen);
+            dst.rgbBlue = over(src.rgbBlue, dst.rgbBlue);
+            dst.rgbReserved = over(src.rgbReserved, dst.rgbReserved);
+            // Any pixel the compositor produced is content. Whether a colour with
+            // no alpha ends up visible is for the engine that draws it to decide;
+            // treating it as nothing here would drop the row before it gets asked.
+            composite.hasPixels = composite.hasPixels || dst.rgbRed != 0 || dst.rgbGreen != 0 || dst.rgbBlue != 0 || dst.rgbReserved != 0;
         }
     }
 
@@ -593,9 +605,21 @@ bool ImageSlice::HasPixels(const RenderPosition position) const
     return _composite(position).hasPixels;
 }
 
-// Returns null if the slice cannot take another layer, either because this one
-// would exceed the per-slice count or the process-wide byte budget.
+// Throws std::bad_alloc if the slice cannot take another layer, either because
+// this one would exceed the per-slice count or the process-wide byte budget.
+// Callers for whom "it did not fit" is an ordinary outcome -- copying a row that
+// is being scrolled, say -- want TryMutablePixels instead.
 RGBQUAD* ImageSlice::MutablePixels(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex)
+{
+    const auto pixels = TryMutablePixels(columnBegin, columnEnd, key, zIndex);
+    if (!pixels)
+    {
+        throw std::bad_alloc{};
+    }
+    return pixels;
+}
+
+RGBQUAD* ImageSlice::TryMutablePixels(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex)
 {
     // Content that carries no identity belongs in the base plane.
     if (key.Untagged())

--- a/src/buffer/out/ImageSlice.hpp
+++ b/src/buffer/out/ImageSlice.hpp
@@ -12,6 +12,7 @@ Abstract:
 #pragma once
 
 #include "til.h"
+#include <array>
 #include <span>
 #include <vector>
 
@@ -23,11 +24,50 @@ class ImageSlice
 public:
     using Pointer = std::unique_ptr<ImageSlice>;
 
-    ImageSlice(const ImageSlice& rhs) = default;
+    // Where content composites relative to the text and the cell background.
+    // Content written without an identity always composites as AboveText,
+    // which is what image content in a row has always done: on main the
+    // renderer paints a row's images after its text.
+    enum class RenderPosition : uint8_t
+    {
+        BehindBackground, // only visible where the cell background is default
+        BehindText,
+        AboveText,
+    };
+    static constexpr size_t RenderPositionCount = 3;
+
+    // Identifies one layer. A layer is a single image (imageId) placed once
+    // (placementId); placing the same image twice yields two layers that can be
+    // erased independently. An all-zero key denotes the untagged base plane,
+    // which holds content that carries no identity at all.
+    struct LayerKey
+    {
+        uint32_t imageId = 0;
+        uint64_t placementId = 0;
+
+        constexpr bool operator==(const LayerKey&) const noexcept = default;
+        constexpr bool Untagged() const noexcept { return imageId == 0 && placementId == 0; }
+    };
+
+    // Layers below this z composite behind the cell background rather than
+    // merely behind the text.
+    static constexpr int32_t BackgroundZThreshold = INT32_MIN / 2;
+    // A process-wide ceiling on identified layer storage, plus a per-slice
+    // layer count limit, so a stream of images cannot exhaust memory.
+    static constexpr size_t MaxLayerBytes = 320ull * 1024ull * 1024ull;
+    static constexpr size_t MaxLayersPerSlice = 4096;
+    static size_t LayerBytesAvailable() noexcept;
+
+    ImageSlice(const ImageSlice& rhs);
     ImageSlice(const til::size cellSize) noexcept;
+    ImageSlice& operator=(const ImageSlice&) = delete;
+    ~ImageSlice() noexcept;
 
     void BumpRevision() noexcept;
     uint64_t Revision() const noexcept;
+    // A revision unique to one render position of this slice. Renderers cache
+    // uploaded pixels by revision, so each position needs its own value.
+    uint64_t Revision(const RenderPosition position) const noexcept;
 
     til::size CellSize() const noexcept;
     til::CoordType ColumnOffset() const noexcept;
@@ -37,6 +77,22 @@ public:
     const RGBQUAD* Pixels(const til::CoordType columnBegin) const noexcept;
     RGBQUAD* MutablePixels(const til::CoordType columnBegin, const til::CoordType columnEnd);
 
+    // Composited output for one render position, built on demand and cached
+    // until the slice's revision changes.
+    std::span<const RGBQUAD> Pixels(const RenderPosition position) const;
+    bool HasPixels(const RenderPosition position) const;
+
+    // Identified-layer access. The untagged base plane is unaffected by these.
+    RGBQUAD* MutablePixels(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex);
+    bool Contains(const uint32_t imageId) const noexcept;
+    bool Contains(const LayerKey key) const noexcept;
+    bool LayerCoversColumn(const LayerKey key, const til::CoordType column) const noexcept;
+    std::vector<LayerKey> LayersAtColumn(const til::CoordType column) const;
+    std::vector<LayerKey> LayersAtZ(const int32_t zIndex) const;
+    bool EraseLayer(const uint32_t imageId);
+    bool EraseLayer(const LayerKey key);
+    bool EraseLayer(const uint32_t imageId, const til::CoordType columnBegin, const til::CoordType columnEnd);
+
     static void CopyBlock(const TextBuffer& srcBuffer, const til::rect srcRect, TextBuffer& dstBuffer, const til::rect dstRect);
     static void CopyRow(const ROW& srcRow, ROW& dstRow);
     static void CopyCells(const ROW& srcRow, const til::CoordType srcColumn, ROW& dstRow, const til::CoordType dstColumnBegin, const til::CoordType dstColumnEnd);
@@ -45,8 +101,42 @@ public:
     static void EraseCells(ROW& row, const til::CoordType columnBegin, const til::CoordType columnEnd);
 
 private:
+    // One identified plane of pixels. Layers composite in ascending zIndex
+    // order, with ties broken by insertion order.
+    struct Layer
+    {
+        LayerKey key;
+        int32_t zIndex = 0;
+        std::vector<RGBQUAD> pixels;
+        // One flag per column in [_columnBegin, _columnEnd) marking the cells
+        // this layer actually covers, so an erase can target only those cells
+        // without disturbing another layer that overlaps the same range.
+        std::vector<uint8_t> columns;
+    };
+
+    // A lazily built composite for one render position, valid for as long as
+    // its revision matches the slice's.
+    struct Composite
+    {
+        uint64_t revision = 0;
+        std::vector<RGBQUAD> pixels;
+        bool hasPixels = false;
+    };
+
+    void _ensureRange(const til::CoordType columnBegin, const til::CoordType columnEnd);
+    Layer& _getLayer(const LayerKey key, const int32_t zIndex);
+    const Composite& _composite(const RenderPosition position) const;
+    static size_t _layerBytes(const Layer& layer) noexcept;
+    void _reserveLayerBytes(const size_t bytes);
+    void _releaseLayerBytes(const size_t bytes) noexcept;
+    void _invalidateComposites() noexcept;
+    void _clearLayerColumns(Layer& layer, const til::CoordType columnBegin, const til::CoordType columnEnd) noexcept;
+    bool _removeEmptyLayers();
+    bool _hasContent() const noexcept;
     bool _copyCells(const ImageSlice& srcSlice, const til::CoordType srcColumn, const til::CoordType dstColumnBegin, const til::CoordType dstColumnEnd);
+    void _copyLayers(const ImageSlice& srcSlice, const til::CoordType srcColumn, const til::CoordType dstColumnBegin, const til::CoordType dstColumnEnd);
     bool _eraseCells(const til::CoordType columnBegin, const til::CoordType columnEnd);
+    void _eraseBasePlane(const til::CoordType columnBegin, const til::CoordType columnEnd) noexcept;
 
     uint64_t _revision = 0;
     til::size _cellSize;
@@ -54,4 +144,9 @@ private:
     til::CoordType _columnBegin = 0;
     til::CoordType _columnEnd = 0;
     til::CoordType _pixelWidth = 0;
+    // Only allocated once an identified layer is written, so content without
+    // identity costs exactly what it did before layers existed.
+    std::vector<Layer> _layers;
+    mutable std::array<Composite, 3> _composites;
+    size_t _accountedBytes = 0;
 };

--- a/src/buffer/out/ImageSlice.hpp
+++ b/src/buffer/out/ImageSlice.hpp
@@ -84,6 +84,7 @@ public:
 
     // Identified-layer access. The untagged base plane is unaffected by these.
     RGBQUAD* MutablePixels(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex);
+    RGBQUAD* TryMutablePixels(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex);
     bool Contains(const uint32_t imageId) const noexcept;
     bool Contains(const LayerKey key) const noexcept;
     bool LayerCoversColumn(const LayerKey key, const til::CoordType column) const noexcept;

--- a/src/buffer/out/ImageSlice.hpp
+++ b/src/buffer/out/ImageSlice.hpp
@@ -58,10 +58,16 @@ public:
     static constexpr size_t MaxLayersPerSlice = 4096;
     static size_t LayerBytesAvailable() noexcept;
 
-    ImageSlice(const ImageSlice& rhs);
+    // The process-wide layer budget has to be kept in step with each slice's
+    // lifetime, and that bookkeeping was the only thing stopping ImageSlice from
+    // using compiler-generated special members. Holding the charge in a member
+    // that knows how to copy, move and release itself hands them back.
     ImageSlice(const til::size cellSize) noexcept;
+    ImageSlice(const ImageSlice& rhs);
     ImageSlice& operator=(const ImageSlice&) = delete;
-    ~ImageSlice() noexcept;
+    ImageSlice(ImageSlice&&) = default;
+    ImageSlice& operator=(ImageSlice&&) = default;
+    ~ImageSlice() = default;
 
     void BumpRevision() noexcept;
     uint64_t Revision() const noexcept;
@@ -127,9 +133,28 @@ private:
     void _ensureRange(const til::CoordType columnBegin, const til::CoordType columnEnd);
     Layer& _getLayer(const LayerKey key, const int32_t zIndex);
     const Composite& _composite(const RenderPosition position) const;
+    // This slice's share of the process-wide layer budget, released automatically
+    // when the slice goes away. A copy owes what the original owed, because it
+    // carries the same layers; a moved-from slice owes nothing.
+    class BudgetCharge
+    {
+    public:
+        BudgetCharge() = default;
+        ~BudgetCharge() noexcept;
+        BudgetCharge(const BudgetCharge& other) noexcept;
+        BudgetCharge& operator=(const BudgetCharge&) = delete;
+        BudgetCharge(BudgetCharge&& other) noexcept;
+        BudgetCharge& operator=(BudgetCharge&& other) noexcept;
+
+        void Reserve(const size_t bytes) noexcept;
+        void Release(const size_t bytes) noexcept;
+        size_t Bytes() const noexcept;
+
+    private:
+        size_t _bytes = 0;
+    };
+
     static size_t _layerBytes(const Layer& layer) noexcept;
-    void _reserveLayerBytes(const size_t bytes);
-    void _releaseLayerBytes(const size_t bytes) noexcept;
     void _invalidateComposites() noexcept;
     void _clearLayerColumns(Layer& layer, const til::CoordType columnBegin, const til::CoordType columnEnd) noexcept;
     bool _removeEmptyLayers();
@@ -149,5 +174,5 @@ private:
     // identity costs exactly what it did before layers existed.
     std::vector<Layer> _layers;
     mutable std::array<Composite, 3> _composites;
-    size_t _accountedBytes = 0;
+    BudgetCharge _charge;
 };

--- a/src/buffer/out/ut_textbuffer/ImageSliceTests.cpp
+++ b/src/buffer/out/ut_textbuffer/ImageSliceTests.cpp
@@ -29,6 +29,8 @@ class ImageSliceTests
     TEST_METHOD(ErasingAColumnRangeSparesTheRest);
     TEST_METHOD(LayerCountIsCapped);
     TEST_METHOD(LayerBudgetIsReturnedOnDestruction);
+    TEST_METHOD(MovingASliceCarriesItsBudgetShareExactlyOnce);
+    TEST_METHOD(CopyingASliceChargesTheBudgetSeparately);
     TEST_METHOD(EqualZOrdersByImageIdNotWriteOrder);
     TEST_METHOD(LayersCompositeSourceOver);
     TEST_METHOD(RenderPositionRevisionsNeverCollide);
@@ -295,6 +297,55 @@ void ImageSliceTests::LayerBudgetIsReturnedOnDestruction()
         VERIFY_IS_LESS_THAN(ImageSlice::LayerBytesAvailable(), before, L"the layer is charged to the budget");
     }
     VERIFY_ARE_EQUAL(before, ImageSlice::LayerBytesAvailable(), L"and returned when the slice dies");
+}
+
+// A slice owns a share of a process-wide budget, which is the only reason its
+// special members are not all compiler-generated. Moving one must hand that
+// share over rather than duplicating it or dropping it on the floor -- a vector
+// of slices reallocating is enough to exercise this.
+void ImageSliceTests::MovingASliceCarriesItsBudgetShareExactlyOnce()
+{
+    const auto before = ImageSlice::LayerBytesAvailable();
+    {
+        ImageSlice source{ CellSize };
+        Fill(source, source.MutablePixels(0, 16, ImageSlice::LayerKey{ 1, 0 }, 0), 16, Red);
+        const auto afterWrite = ImageSlice::LayerBytesAvailable();
+        VERIFY_IS_LESS_THAN(afterWrite, before, L"sanity: the layer is charged");
+
+        ImageSlice moved{ std::move(source) };
+        VERIFY_ARE_EQUAL(afterWrite, ImageSlice::LayerBytesAvailable(), L"a move must not charge the budget a second time");
+
+        // The moved-from slice still has to be destroyed, and must not refund a
+        // share it no longer owns.
+    }
+    VERIFY_ARE_EQUAL(before, ImageSlice::LayerBytesAvailable(), L"the share is refunded exactly once");
+
+    {
+        ImageSlice source{ CellSize };
+        Fill(source, source.MutablePixels(0, 16, ImageSlice::LayerKey{ 1, 0 }, 0), 16, Red);
+        const auto charged = before - ImageSlice::LayerBytesAvailable();
+
+        ImageSlice target{ CellSize };
+        target = std::move(source);
+        VERIFY_ARE_EQUAL(before - charged, ImageSlice::LayerBytesAvailable(), L"move-assignment must not double-charge either");
+    }
+    VERIFY_ARE_EQUAL(before, ImageSlice::LayerBytesAvailable(), L"and move-assignment refunds exactly once");
+}
+
+// A copy carries the same layers, so it must owe the same amount independently.
+void ImageSliceTests::CopyingASliceChargesTheBudgetSeparately()
+{
+    const auto before = ImageSlice::LayerBytesAvailable();
+    {
+        ImageSlice source{ CellSize };
+        Fill(source, source.MutablePixels(0, 16, ImageSlice::LayerKey{ 1, 0 }, 0), 16, Red);
+        const auto charged = before - ImageSlice::LayerBytesAvailable();
+        VERIFY_IS_GREATER_THAN(charged, size_t{ 0 }, L"sanity: the layer costs something");
+
+        ImageSlice copy{ source };
+        VERIFY_ARE_EQUAL(before - charged * 2, ImageSlice::LayerBytesAvailable(), L"a copy owes its own share");
+    }
+    VERIFY_ARE_EQUAL(before, ImageSlice::LayerBytesAvailable(), L"both shares come back");
 }
 
 // A renderer caches uploaded pixels keyed by revision. Each of a slice's three

--- a/src/buffer/out/ut_textbuffer/ImageSliceTests.cpp
+++ b/src/buffer/out/ut_textbuffer/ImageSliceTests.cpp
@@ -29,6 +29,8 @@ class ImageSliceTests
     TEST_METHOD(ErasingAColumnRangeSparesTheRest);
     TEST_METHOD(LayerCountIsCapped);
     TEST_METHOD(LayerBudgetIsReturnedOnDestruction);
+    TEST_METHOD(EqualZOrdersByImageIdNotWriteOrder);
+    TEST_METHOD(LayersCompositeSourceOver);
     TEST_METHOD(RenderPositionRevisionsNeverCollide);
     TEST_METHOD(UnlayeredContentIsNotCopiedToComposite);
     TEST_METHOD(CopyingReplacesDestinationLayers);
@@ -246,8 +248,42 @@ void ImageSliceTests::LayerCountIsCapped()
         const auto pixels = slice.MutablePixels(0, 1, ImageSlice::LayerKey{ i + 1, 0 }, 0);
         VERIFY_IS_NOT_NULL(pixels);
     }
-    // One past the cap is refused rather than accepted.
-    VERIFY_IS_NULL(slice.MutablePixels(0, 1, ImageSlice::LayerKey{ 0xF0000000, 0 }, 0));
+    // One past the cap is refused rather than accepted. A caller that asked for a
+    // layer it needs gets an exception, because carrying on without the pixels it
+    // was handed is never right; a caller that only wanted the layer if it fit
+    // asks for that explicitly and gets a null it is obliged to check.
+    VERIFY_THROWS(slice.MutablePixels(0, 1, ImageSlice::LayerKey{ 0xF0000000, 0 }, 0), std::bad_alloc);
+    VERIFY_IS_NULL(slice.TryMutablePixels(0, 1, ImageSlice::LayerKey{ 0xF0000000, 0 }, 0));
+}
+
+void ImageSliceTests::EqualZOrdersByImageIdNotWriteOrder()
+{
+    ImageSlice slice{ CellSize };
+    // Written highest-id first, so insertion order and identity order disagree.
+    Fill(slice, slice.MutablePixels(0, 1, ImageSlice::LayerKey{ 2, 20 }, 7), 1, Blue);
+    Fill(slice, slice.MutablePixels(0, 1, ImageSlice::LayerKey{ 1, 10 }, 7), 1, Red);
+
+    const auto pixels = slice.Pixels(ImageSlice::RenderPosition::AboveText);
+    VERIFY_ARE_EQUAL(Packed(Blue), Packed(pixels[0]), L"the higher image id must win at equal z");
+}
+
+void ImageSliceTests::LayersCompositeSourceOver()
+{
+    static constexpr RGBQUAD HalfRed{ 0, 0, 128, 128 };
+    static constexpr RGBQUAD HalfGreen{ 0, 128, 0, 128 };
+
+    ImageSlice slice{ CellSize };
+    Fill(slice, slice.MutablePixels(0, 1, ImageSlice::LayerKey{ 1, 10 }, 0), 1, HalfRed);
+    Fill(slice, slice.MutablePixels(0, 1, ImageSlice::LayerKey{ 2, 20 }, 0), 1, HalfGreen);
+
+    // Premultiplied source-over: dst = src + dst * (1 - srcAlpha). Half-green over
+    // half-red keeps all of the green and just under half of the red, rather than
+    // the top layer simply replacing what is beneath it.
+    const auto pixel = slice.Pixels(ImageSlice::RenderPosition::AboveText)[0];
+    VERIFY_ARE_EQUAL(64, static_cast<int>(pixel.rgbRed));
+    VERIFY_ARE_EQUAL(128, static_cast<int>(pixel.rgbGreen));
+    VERIFY_ARE_EQUAL(0, static_cast<int>(pixel.rgbBlue));
+    VERIFY_ARE_EQUAL(192, static_cast<int>(pixel.rgbReserved));
 }
 
 void ImageSliceTests::LayerBudgetIsReturnedOnDestruction()

--- a/src/buffer/out/ut_textbuffer/ImageSliceTests.cpp
+++ b/src/buffer/out/ut_textbuffer/ImageSliceTests.cpp
@@ -1,0 +1,372 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "precomp.h"
+#include "WexTestClass.h"
+#include "../../inc/consoletaeftemplates.hpp"
+
+#include "../textBuffer.hpp"
+#include "../ImageSlice.hpp"
+#include "../../../renderer/inc/DummyRenderer.hpp"
+
+#include <set>
+
+using namespace WEX::Common;
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+
+class ImageSliceTests
+{
+    TEST_CLASS(ImageSliceTests);
+
+    TEST_METHOD(UntaggedContentAllocatesNoLayers);
+    TEST_METHOD(LayerPixelsSurviveRangeGrowth);
+    TEST_METHOD(HigherZIndexCompositesOnTop);
+    TEST_METHOD(TransparentPixelsDoNotOccludeLowerLayers);
+    TEST_METHOD(ZIndexSelectsRenderPosition);
+    TEST_METHOD(ErasingOneLayerLeavesTheOther);
+    TEST_METHOD(PlacementsOfOneImageEraseIndependently);
+    TEST_METHOD(ErasingAColumnRangeSparesTheRest);
+    TEST_METHOD(LayerCountIsCapped);
+    TEST_METHOD(LayerBudgetIsReturnedOnDestruction);
+    TEST_METHOD(RenderPositionRevisionsNeverCollide);
+    TEST_METHOD(UnlayeredContentIsNotCopiedToComposite);
+    TEST_METHOD(CopyingReplacesDestinationLayers);
+    TEST_METHOD(CopyingFromAnUnlayeredSourceClearsDestinationLayers);
+    TEST_METHOD(CopyingFromALayerOnlySourceClearsDestinationBasePlane);
+
+    static constexpr til::size CellSize{ 4, 2 };
+    static constexpr RGBQUAD Red{ 0, 0, 255, 255 };
+    static constexpr RGBQUAD Blue{ 255, 0, 0, 255 };
+    static constexpr RGBQUAD Clear{ 0, 0, 0, 0 };
+
+    static uint32_t Packed(const RGBQUAD& pixel) noexcept
+    {
+        return static_cast<uint32_t>(pixel.rgbBlue) |
+               (static_cast<uint32_t>(pixel.rgbGreen) << 8) |
+               (static_cast<uint32_t>(pixel.rgbRed) << 16) |
+               (static_cast<uint32_t>(pixel.rgbReserved) << 24);
+    }
+
+    // Fills `columns` worth of cells starting at the given plane pointer. The
+    // pointer must be re-fetched after anything that can widen the slice.
+    static void Fill(ImageSlice& slice, RGBQUAD* start, const til::CoordType columns, const RGBQUAD color)
+    {
+        const auto width = columns * slice.CellSize().width;
+        auto row = start;
+        for (auto y = 0; y < slice.CellSize().height; y++)
+        {
+            for (auto x = 0; x < width; x++)
+            {
+                row[x] = color;
+            }
+            row += slice.PixelWidth();
+        }
+    }
+
+    static uint32_t PixelAt(const std::span<const RGBQUAD> plane, const ImageSlice& slice, const til::CoordType column)
+    {
+        const auto offset = (column - slice.ColumnOffset()) * slice.CellSize().width;
+        return Packed(plane[offset]);
+    }
+
+    static ImageSlice& SliceFor(ROW& row)
+    {
+        auto slice = row.GetMutableImageSlice();
+        if (!slice)
+        {
+            slice = row.SetImageSlice(std::make_unique<ImageSlice>(CellSize));
+        }
+        return *slice;
+    }
+
+    static void FillLayer(ROW& row, const ImageSlice::LayerKey key, const til::CoordType columns, const RGBQUAD color)
+    {
+        auto& slice = SliceFor(row);
+        const auto pixels = slice.MutablePixels(0, columns, key, 0);
+        VERIFY_IS_NOT_NULL(pixels);
+        Fill(slice, pixels, columns, color);
+    }
+
+    static void FillBase(ROW& row, const til::CoordType columns, const RGBQUAD color)
+    {
+        auto& slice = SliceFor(row);
+        const auto pixels = slice.MutablePixels(0, columns);
+        VERIFY_IS_NOT_NULL(pixels);
+        Fill(slice, pixels, columns, color);
+    }
+};
+
+// Content without an identity has to keep costing exactly what it did before
+// layers existed, so nothing here should allocate a layer.
+void ImageSliceTests::UntaggedContentAllocatesNoLayers()
+{
+    ImageSlice slice{ CellSize };
+    Fill(slice, slice.MutablePixels(2, 6), 4, Red);
+    slice.BumpRevision();
+
+    VERIFY_IS_FALSE(slice.Contains(ImageSlice::LayerKey{}));
+    VERIFY_ARE_EQUAL(0u, slice.LayersAtColumn(3).size());
+    VERIFY_ARE_EQUAL(Packed(Red), PixelAt(slice.Pixels(), slice, 2));
+    // Untagged content has always drawn above the text.
+    VERIFY_IS_TRUE(slice.HasPixels(ImageSlice::RenderPosition::AboveText));
+    VERIFY_IS_FALSE(slice.HasPixels(ImageSlice::RenderPosition::BehindText));
+}
+
+// Writing to a column left of an existing layer widens the slice, which moves
+// every plane. The layer's pixels must move with it.
+void ImageSliceTests::LayerPixelsSurviveRangeGrowth()
+{
+    ImageSlice slice{ CellSize };
+    constexpr ImageSlice::LayerKey key{ 7, 0 };
+
+    Fill(slice, slice.MutablePixels(10, 14, key, 0), 4, Red);
+    slice.BumpRevision();
+    VERIFY_ARE_EQUAL(Packed(Red), PixelAt(slice.Pixels(ImageSlice::RenderPosition::AboveText), slice, 10));
+
+    // Grow the slice to the left, which relocates the layer's plane.
+    Fill(slice, slice.MutablePixels(0, 2), 2, Blue);
+    slice.BumpRevision();
+
+    VERIFY_ARE_EQUAL(0, slice.ColumnOffset());
+    VERIFY_ARE_EQUAL(Packed(Red), PixelAt(slice.Pixels(ImageSlice::RenderPosition::AboveText), slice, 10));
+    VERIFY_IS_TRUE(slice.LayerCoversColumn(key, 10));
+    VERIFY_IS_FALSE(slice.LayerCoversColumn(key, 0));
+}
+
+void ImageSliceTests::HigherZIndexCompositesOnTop()
+{
+    ImageSlice slice{ CellSize };
+    constexpr ImageSlice::LayerKey lower{ 1, 0 };
+    constexpr ImageSlice::LayerKey upper{ 2, 0 };
+
+    Fill(slice, slice.MutablePixels(0, 4, lower, 1), 4, Red);
+    Fill(slice, slice.MutablePixels(0, 4, upper, 5), 4, Blue);
+    slice.BumpRevision();
+
+    VERIFY_ARE_EQUAL(Packed(Blue), PixelAt(slice.Pixels(ImageSlice::RenderPosition::AboveText), slice, 0));
+
+    // Erasing the upper layer must reveal the lower one again.
+    slice.EraseLayer(upper);
+    slice.BumpRevision();
+    VERIFY_ARE_EQUAL(Packed(Red), PixelAt(slice.Pixels(ImageSlice::RenderPosition::AboveText), slice, 0));
+}
+
+void ImageSliceTests::TransparentPixelsDoNotOccludeLowerLayers()
+{
+    ImageSlice slice{ CellSize };
+    constexpr ImageSlice::LayerKey lower{ 1, 0 };
+    constexpr ImageSlice::LayerKey upper{ 2, 0 };
+
+    Fill(slice, slice.MutablePixels(0, 4, lower, 1), 4, Red);
+    Fill(slice, slice.MutablePixels(0, 4, upper, 5), 4, Clear);
+    slice.BumpRevision();
+
+    // The upper layer is entirely transparent, so the lower one shows through.
+    VERIFY_ARE_EQUAL(Packed(Red), PixelAt(slice.Pixels(ImageSlice::RenderPosition::AboveText), slice, 0));
+}
+
+void ImageSliceTests::ZIndexSelectsRenderPosition()
+{
+    ImageSlice slice{ CellSize };
+    Fill(slice, slice.MutablePixels(0, 2, ImageSlice::LayerKey{ 1, 0 }, 0), 2, Red);
+    Fill(slice, slice.MutablePixels(0, 2, ImageSlice::LayerKey{ 2, 0 }, -1), 2, Red);
+    Fill(slice, slice.MutablePixels(0, 2, ImageSlice::LayerKey{ 3, 0 }, ImageSlice::BackgroundZThreshold - 1), 2, Red);
+    slice.BumpRevision();
+
+    VERIFY_IS_TRUE(slice.HasPixels(ImageSlice::RenderPosition::AboveText));
+    VERIFY_IS_TRUE(slice.HasPixels(ImageSlice::RenderPosition::BehindText));
+    VERIFY_IS_TRUE(slice.HasPixels(ImageSlice::RenderPosition::BehindBackground));
+}
+
+// The whole point of giving layers an identity: two images can share a row and
+// be deleted independently.
+void ImageSliceTests::ErasingOneLayerLeavesTheOther()
+{
+    ImageSlice slice{ CellSize };
+    constexpr ImageSlice::LayerKey first{ 1, 0 };
+    constexpr ImageSlice::LayerKey second{ 2, 0 };
+
+    Fill(slice, slice.MutablePixels(0, 4, first, 0), 4, Red);
+    Fill(slice, slice.MutablePixels(4, 8, second, 0), 4, Blue);
+    slice.BumpRevision();
+
+    const auto empty = slice.EraseLayer(1u);
+    slice.BumpRevision();
+
+    VERIFY_IS_FALSE(empty, L"the second layer is still present");
+    VERIFY_IS_FALSE(slice.Contains(1u));
+    VERIFY_IS_TRUE(slice.Contains(2u));
+    VERIFY_ARE_EQUAL(Packed(Blue), PixelAt(slice.Pixels(ImageSlice::RenderPosition::AboveText), slice, 4));
+    VERIFY_ARE_EQUAL(Packed(Clear), PixelAt(slice.Pixels(ImageSlice::RenderPosition::AboveText), slice, 0));
+}
+
+void ImageSliceTests::PlacementsOfOneImageEraseIndependently()
+{
+    ImageSlice slice{ CellSize };
+    constexpr ImageSlice::LayerKey placementA{ 9, 100 };
+    constexpr ImageSlice::LayerKey placementB{ 9, 200 };
+
+    Fill(slice, slice.MutablePixels(0, 4, placementA, 0), 4, Red);
+    Fill(slice, slice.MutablePixels(4, 8, placementB, 0), 4, Blue);
+    slice.BumpRevision();
+
+    slice.EraseLayer(placementA);
+    slice.BumpRevision();
+
+    VERIFY_IS_FALSE(slice.Contains(placementA));
+    VERIFY_IS_TRUE(slice.Contains(placementB));
+    // The image itself is still present, just not that placement of it.
+    VERIFY_IS_TRUE(slice.Contains(9u));
+}
+
+void ImageSliceTests::ErasingAColumnRangeSparesTheRest()
+{
+    ImageSlice slice{ CellSize };
+    constexpr ImageSlice::LayerKey key{ 4, 0 };
+
+    Fill(slice, slice.MutablePixels(0, 8, key, 0), 8, Red);
+    slice.BumpRevision();
+
+    slice.EraseLayer(4u, 0, 4);
+    slice.BumpRevision();
+
+    VERIFY_IS_FALSE(slice.LayerCoversColumn(key, 0));
+    VERIFY_IS_TRUE(slice.LayerCoversColumn(key, 4));
+    VERIFY_ARE_EQUAL(Packed(Clear), PixelAt(slice.Pixels(ImageSlice::RenderPosition::AboveText), slice, 0));
+    VERIFY_ARE_EQUAL(Packed(Red), PixelAt(slice.Pixels(ImageSlice::RenderPosition::AboveText), slice, 4));
+}
+
+// A stream of images must not be able to grow a single row without bound.
+void ImageSliceTests::LayerCountIsCapped()
+{
+    ImageSlice slice{ CellSize };
+    for (auto i = 0u; i < ImageSlice::MaxLayersPerSlice; i++)
+    {
+        const auto pixels = slice.MutablePixels(0, 1, ImageSlice::LayerKey{ i + 1, 0 }, 0);
+        VERIFY_IS_NOT_NULL(pixels);
+    }
+    // One past the cap is refused rather than accepted.
+    VERIFY_IS_NULL(slice.MutablePixels(0, 1, ImageSlice::LayerKey{ 0xF0000000, 0 }, 0));
+}
+
+void ImageSliceTests::LayerBudgetIsReturnedOnDestruction()
+{
+    const auto before = ImageSlice::LayerBytesAvailable();
+    {
+        ImageSlice slice{ CellSize };
+        Fill(slice, slice.MutablePixels(0, 16, ImageSlice::LayerKey{ 1, 0 }, 0), 16, Red);
+        VERIFY_IS_LESS_THAN(ImageSlice::LayerBytesAvailable(), before, L"the layer is charged to the budget");
+    }
+    VERIFY_ARE_EQUAL(before, ImageSlice::LayerBytesAvailable(), L"and returned when the slice dies");
+}
+
+// A renderer caches uploaded pixels keyed by revision. Each of a slice's three
+// composited planes is a different image, so every plane of every slice needs a
+// revision no other plane anywhere can also hand out.
+void ImageSliceTests::RenderPositionRevisionsNeverCollide()
+{
+    static constexpr std::array positions{
+        ImageSlice::RenderPosition::BehindBackground,
+        ImageSlice::RenderPosition::BehindText,
+        ImageSlice::RenderPosition::AboveText,
+    };
+
+    std::vector<ImageSlice> slices;
+    std::set<uint64_t> seen;
+    for (auto i = 0; i < 16; i++)
+    {
+        ImageSlice slice{ CellSize };
+        slice.BumpRevision();
+        for (const auto position : positions)
+        {
+            const auto revision = slice.Revision(position);
+            VERIFY_IS_TRUE(revision != 0, L"0 is reserved to mean 'nothing uploaded'");
+            VERIFY_IS_TRUE(seen.insert(revision).second, L"revision was already handed out");
+        }
+    }
+}
+// Content with no identity is the overwhelmingly common case, and it composites
+// to exactly itself. Handing back a copy of it would double both the memory and
+// the work for every image that never uses layers at all.
+void ImageSliceTests::UnlayeredContentIsNotCopiedToComposite()
+{
+    ImageSlice slice{ CellSize };
+    const auto pixels = slice.MutablePixels(0, 4);
+    VERIFY_IS_NOT_NULL(pixels);
+    Fill(slice, pixels, 4, Red);
+
+    const auto base = slice.Pixels();
+    const auto composited = slice.Pixels(ImageSlice::RenderPosition::AboveText);
+    VERIFY_ARE_EQUAL(base.data(), composited.data(), L"the base plane itself should be handed back");
+    VERIFY_IS_TRUE(slice.HasPixels(ImageSlice::RenderPosition::AboveText));
+    VERIFY_IS_FALSE(slice.HasPixels(ImageSlice::RenderPosition::BehindText));
+    VERIFY_IS_FALSE(slice.HasPixels(ImageSlice::RenderPosition::BehindBackground));
+
+    // Once a layer exists there is something to actually composite, so a
+    // separate buffer is expected.
+    const auto layerPixels = slice.MutablePixels(0, 4, ImageSlice::LayerKey{ .imageId = 1, .placementId = 1 }, 0);
+    VERIFY_IS_NOT_NULL(layerPixels);
+    Fill(slice, layerPixels, 4, Blue);
+    VERIFY_ARE_NOT_EQUAL(slice.Pixels().data(), slice.Pixels(ImageSlice::RenderPosition::AboveText).data());
+}
+// A copy has always meant "the destination range now equals the source range".
+// A destination layer with no counterpart in the source must not survive it.
+void ImageSliceTests::CopyingReplacesDestinationLayers()
+{
+    DummyRenderer renderer;
+    TextBuffer buffer{ til::size{ 8, 2 }, TextAttribute{}, 0, false, &renderer };
+    constexpr ImageSlice::LayerKey source{ .imageId = 1, .placementId = 1 };
+    constexpr ImageSlice::LayerKey destination{ .imageId = 2, .placementId = 2 };
+
+    FillLayer(buffer.GetMutableRowByOffset(0), source, 4, Red);
+    FillLayer(buffer.GetMutableRowByOffset(1), destination, 4, Blue);
+
+    ImageSlice::CopyCells(buffer.GetRowByOffset(0), 0, buffer.GetMutableRowByOffset(1), 0, 4);
+
+    const auto slice = buffer.GetRowByOffset(1).GetImageSlice();
+    VERIFY_IS_NOT_NULL(slice);
+    VERIFY_IS_TRUE(slice->Contains(source), L"the source layer should have arrived");
+    VERIFY_IS_FALSE(slice->Contains(destination), L"the overwritten layer should be gone");
+    VERIFY_ARE_EQUAL(Packed(Red), PixelAt(slice->Pixels(ImageSlice::RenderPosition::AboveText), *slice, 0));
+}
+
+// The source having no layers at all is the worst case: nothing iterates, so
+// nothing would clear the destination unless the copy does it up front.
+void ImageSliceTests::CopyingFromAnUnlayeredSourceClearsDestinationLayers()
+{
+    DummyRenderer renderer;
+    TextBuffer buffer{ til::size{ 8, 2 }, TextAttribute{}, 0, false, &renderer };
+    constexpr ImageSlice::LayerKey destination{ .imageId = 2, .placementId = 2 };
+
+    FillBase(buffer.GetMutableRowByOffset(0), 4, Red);
+    FillLayer(buffer.GetMutableRowByOffset(1), destination, 4, Blue);
+
+    ImageSlice::CopyCells(buffer.GetRowByOffset(0), 0, buffer.GetMutableRowByOffset(1), 0, 4);
+
+    const auto slice = buffer.GetRowByOffset(1).GetImageSlice();
+    VERIFY_IS_NOT_NULL(slice);
+    VERIFY_IS_FALSE(slice->Contains(destination), L"a layer must not outlive the copy that overwrote it");
+    VERIFY_ARE_EQUAL(Packed(Red), PixelAt(slice->Pixels(ImageSlice::RenderPosition::AboveText), *slice, 0));
+}
+
+// The mirror image: a slice can hold layers and no untagged content at all, so
+// there is no base plane to copy from. The destination's still has to go.
+void ImageSliceTests::CopyingFromALayerOnlySourceClearsDestinationBasePlane()
+{
+    DummyRenderer renderer;
+    TextBuffer buffer{ til::size{ 8, 2 }, TextAttribute{}, 0, false, &renderer };
+    constexpr ImageSlice::LayerKey source{ .imageId = 1, .placementId = 1 };
+
+    FillLayer(buffer.GetMutableRowByOffset(0), source, 4, Red);
+    FillBase(buffer.GetMutableRowByOffset(1), 4, Blue);
+    VERIFY_IS_TRUE(buffer.GetRowByOffset(0).GetImageSlice()->Pixels().empty(), L"a layer-only slice has no base plane");
+
+    ImageSlice::CopyCells(buffer.GetRowByOffset(0), 0, buffer.GetMutableRowByOffset(1), 0, 4);
+
+    const auto slice = buffer.GetRowByOffset(1).GetImageSlice();
+    VERIFY_IS_NOT_NULL(slice);
+    VERIFY_IS_TRUE(slice->Contains(source));
+    VERIFY_ARE_EQUAL(Packed(Clear), PixelAt(slice->Pixels(), *slice, 0), L"the untagged pixels should have been replaced by nothing");
+    VERIFY_ARE_EQUAL(Packed(Red), PixelAt(slice->Pixels(ImageSlice::RenderPosition::AboveText), *slice, 0));
+}

--- a/src/buffer/out/ut_textbuffer/TextBuffer.Unit.Tests.vcxproj
+++ b/src/buffer/out/ut_textbuffer/TextBuffer.Unit.Tests.vcxproj
@@ -11,6 +11,7 @@
   <Import Project="$(SolutionDir)src\common.build.pre.props" />
   <Import Project="$(SolutionDir)src\common.nugetversions.props" />
   <ItemGroup>
+    <ClCompile Include="ImageSliceTests.cpp" />
     <ClCompile Include="ReflowTests.cpp" />
     <ClCompile Include="TextColorTests.cpp" />
     <ClCompile Include="TextAttributeTests.cpp" />

--- a/src/buffer/out/ut_textbuffer/sources
+++ b/src/buffer/out/ut_textbuffer/sources
@@ -14,6 +14,7 @@ DLLDEF                  =
 
 SOURCES = \
     $(SOURCES) \
+    ImageSliceTests.cpp \
     ReflowTests.cpp \
     TextColorTests.cpp \
     TextAttributeTests.cpp \


### PR DESCRIPTION
| Stack | |
|---|---|
| **&rarr; #54** | **Give `ImageSlice` identified, z-ordered layers** |
| #55 | Paint a row's images in z-order around its text |
| #56 | Route APC strings to the engine by identifier |
| #57 | Add the Kitty graphics protocol to the VT adapter |
| #58 | Add Kitty graphics animation |
| #59 | Add file and shared-memory transmission |

## TL;DR

`ImageSlice` holds one anonymous plane of pixels per row. Whoever wrote last, won — there is no way to say *which* image a pixel came from, and no way to erase one image without erasing whatever overlapped it. This gives a slice optional **identified, z-ordered layers** plus a read API that composites them into three render positions.

**On its own this changes no pixels.** It adds capacity nothing uses yet; existing Sixel content takes the untagged base plane and renders byte-identically.

![Five overlapping layers composited into a single row](https://github.com/user-attachments/assets/0020c67e-6adb-483a-a963-49813d6b9ed4)

## Key changes

- **`RenderPosition`** — `BehindBackground` / `BehindText` / `AboveText`. `Pixels(position)` returns one composited plane; a caller that never mentions a position gets today's behaviour.
- **The existing plane stays as an untagged base plane.** Layers are a second allocation that only exists once someone uses identity. Sixel doesn't, so `Pixels()` and `Pixels(AboveText)` return the same pointer when `_layers` is empty — no copy, no allocation. A test asserts exactly that.
- **Layers are full-width planes plus per-column coverage bytes.** That costs memory, and it is what makes targeted erase correct: deleting one image must not punch a hole in the image underneath it.
- **Composites are cached by slice revision.** `MutablePixels(…, key, z)` throws over budget; `TryMutablePixels` returns `nullptr` for the callers that treat "it didn't fit" as an ordinary outcome.

## Notes for the rest of the stack

- **Compositing is source-over, not overwrite.** Pixels are premultiplied, so `dst = src + dst × (1 − srcAlpha)`. The simpler "any non-zero alpha wins" rule is only correct for fully opaque content — #55's alpha blending depends on this being right.
- **Equal-z ties break on image id, not write order.** Otherwise the same two layers composite differently depending on which arrived first, and differently *again* after a scroll or reflow rebuilds the row from its parts.
- **`BumpRevision` advances by `RenderPositionCount`**, so each plane gets a globally unique revision. #55's `BackendD3D` uses the revision as a bitmap cache key — one revision shared across three planes serves the wrong bitmap.
- **Widening and row-clone are charged but never refused.** Both are forced by geometry or scrolling, where failing is worse than being slightly over budget. The budget exists to stop unbounded growth from *new uploads*, which is the only path an attacker controls.
- **Sixel and Kitty land on separate rows by design.** A slice carries one cell geometry; conhost's Sixel takes its cell size from `SixelParser::CellSizeForLevel` and a Kitty placement takes it from the font. That is the price of not carrying a per-plane scale factor, not an oversight.

## Protocol neutrality

```
$ git grep -i kitty -- src/buffer
(no output)
```

`LayerKey` is two integers the caller assigns meaning to. Usable by Sixel, iTerm2's protocol, or anything else wanting identified overlapping images.

## Tests

17 new in `ImageSliceTests.cpp`, **none of which mention a protocol** — all stimulus is direct `ImageSlice` API calls. Mutation-tested rather than just green; each mutation was run separately and failed only the tests targeting it (restoring insertion-order ties *and* the overwrite blend fails exactly 2 of 30). `TextBuffer.Unit.Tests 32/32`.

## What the layering is for

These two are captures from the tip of the stack — they belong to #55 and #57 and are here only so a reviewer of this PR can see the point.

![Text stays readable through a z=-1 plane and is hidden under a z=+1 plane](https://github.com/user-attachments/assets/dcf71440-52de-4005-a98b-d984d6b7e75a)

![Sixel and Kitty images on one screen](https://github.com/user-attachments/assets/d2e26631-4d52-4434-bc6e-99f253304a2f)

---

**Reviewer note:** `MutablePixels(begin, end, key, z)` returns a pointer to `columnBegin` with row stride `PixelWidth()`, and only `(columnEnd − columnBegin)` columns may be written. Writing full-width through it corrupts the heap. Same contract as the existing 2-arg overload, but easier to get wrong now there's a `z` after it.

**Builds alone.** Rebuilt from a clean checkout and built without any PR above it — `OpenConsole.slnx` Debug|x64, zero C++ errors.