### PR TITLE
Paint a row's images in z-order around its text

### DIFF
--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -261,9 +261,12 @@ try
 
     for (const auto r : _p.rows)
     {
-        if (r->bitmap.revision != 0 && !r->bitmap.active)
+        for (auto& bitmap : r->bitmaps)
         {
-            r->bitmap = {};
+            if (bitmap.revision != 0 && !bitmap.active)
+            {
+                bitmap = {};
+            }
         }
     }
 
@@ -545,49 +548,105 @@ try
 }
 CATCH_RETURN()
 
-[[nodiscard]] HRESULT AtlasEngine::PaintImageSlice(const ImageSlice& imageSlice, const til::CoordType targetRow, const til::CoordType viewportLeft) noexcept
+[[nodiscard]] HRESULT AtlasEngine::BeginRowImages(const ImageSlice& imageSlice, const til::CoordType targetRow, const til::CoordType viewportLeft, const std::span<const uint8_t> defaultBackgroundMask) noexcept
 try
 {
     const auto y = clamp<til::CoordType>(targetRow, 0, _p.s->viewportCellCount.y - 1);
     const auto row = _p.rows[y];
-    const auto revision = imageSlice.Revision();
     const auto srcWidth = std::max(0, imageSlice.PixelWidth());
     const auto srcCellSize = imageSlice.CellSize();
-    auto& b = row->bitmap;
-
-    // If this row's ImageSlice has changed we need to update our snapshot.
-    // Theoretically another _p.rows[y]->bitmap may have this particular revision already,
-    // but that can only happen if we're scrolling _and_ the entire viewport was invalidated.
-    if (b.revision != revision)
+    if (srcCellSize.width <= 0)
     {
-        const auto srcHeight = std::max(0, srcCellSize.height);
-        const auto pixels = imageSlice.Pixels();
-        const auto expectedSize = gsl::narrow_cast<size_t>(srcWidth) * gsl::narrow_cast<size_t>(srcHeight);
-
-        // Sanity check.
-        if (pixels.size() != expectedSize)
-        {
-            assert(false);
-            return S_OK;
-        }
-
-        if (b.source.size() != pixels.size())
-        {
-            b.source = Buffer<u32, 32>{ pixels.size() };
-        }
-
-        memcpy(b.source.data(), pixels.data(), pixels.size_bytes());
-        b.revision = revision;
-        b.sourceSize.x = srcWidth;
-        b.sourceSize.y = srcHeight;
+        return S_OK;
     }
+    const auto columnCount = srcWidth / srcCellSize.width;
 
-    b.targetOffset = (imageSlice.ColumnOffset() - viewportLeft);
-    b.targetWidth = srcWidth / srcCellSize.width;
-    b.active = true;
+    for (size_t i = 0; i < ImageSlice::RenderPositionCount; i++)
+    {
+        const auto position = static_cast<ImageSlice::RenderPosition>(i);
+        if (!imageSlice.HasPixels(position))
+        {
+            continue;
+        }
+
+        // Snapshots are cached by revision. A masked snapshot is no longer the
+        // slice's own pixels, so it needs a key of its own. Keeping those in the
+        // top half of the space puts them permanently out of reach of the
+        // revision counter, which starts at zero and only ever climbs.
+        auto revision = imageSlice.Revision(position);
+        const auto masked = position == ImageSlice::RenderPosition::BehindBackground &&
+                            defaultBackgroundMask.size() == gsl::narrow_cast<size_t>(columnCount);
+        if (masked)
+        {
+            for (const auto value : defaultBackgroundMask)
+            {
+                revision = (revision ^ value) * 0x100000001b3ull;
+            }
+            revision |= 0x8000000000000000ull;
+        }
+
+        auto& b = til::at(row->bitmaps, i);
+
+        // If this row's ImageSlice has changed we need to update our snapshot.
+        // Theoretically another _p.rows[y]->bitmaps may have this particular revision already,
+        // but that can only happen if we're scrolling _and_ the entire viewport was invalidated.
+        if (b.revision != revision)
+        {
+            const auto srcHeight = std::max(0, srcCellSize.height);
+            const auto pixels = imageSlice.Pixels(position);
+            const auto expectedSize = gsl::narrow_cast<size_t>(srcWidth) * gsl::narrow_cast<size_t>(srcHeight);
+
+            // Sanity check.
+            if (pixels.size() != expectedSize)
+            {
+                assert(false);
+                continue;
+            }
+
+            if (b.source.size() != pixels.size())
+            {
+                b.source = Buffer<u32, 32>{ pixels.size() };
+            }
+
+            memcpy(b.source.data(), pixels.data(), pixels.size_bytes());
+
+            if (masked)
+            {
+                // Content below the background is only visible through cells
+                // whose background is the default one.
+                for (auto column = 0; column < columnCount; column++)
+                {
+                    if (til::at(defaultBackgroundMask, gsl::narrow_cast<size_t>(column)) != 0)
+                    {
+                        continue;
+                    }
+                    for (auto pixelRow = 0; pixelRow < srcHeight; pixelRow++)
+                    {
+                        const auto first = b.source.data() + gsl::narrow_cast<size_t>(pixelRow) * srcWidth + gsl::narrow_cast<size_t>(column) * srcCellSize.width;
+                        std::fill_n(first, srcCellSize.width, 0u);
+                    }
+                }
+            }
+
+            b.revision = revision;
+            b.sourceSize.x = srcWidth;
+            b.sourceSize.y = srcHeight;
+        }
+
+        b.targetOffset = (imageSlice.ColumnOffset() - viewportLeft);
+        b.targetWidth = columnCount;
+        b.active = true;
+    }
     return S_OK;
 }
 CATCH_RETURN()
+
+[[nodiscard]] HRESULT AtlasEngine::EndRowImages() noexcept
+{
+    // Nothing to do: this backend defers all drawing, so the row's snapshots are
+    // placed relative to its text when the frame is actually drawn.
+    return S_OK;
+}
 
 [[nodiscard]] HRESULT AtlasEngine::PaintSelection(const til::rect& rect) noexcept
 {

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -548,7 +548,10 @@ try
 }
 CATCH_RETURN()
 
-[[nodiscard]] HRESULT AtlasEngine::BeginRowImages(const ImageSlice& imageSlice, const til::CoordType targetRow, const til::CoordType viewportLeft, const std::span<const uint8_t> defaultBackgroundMask) noexcept
+// cellBackgrounds is unused here: this engine draws the whole row's backgrounds in
+// its own pass before any of the image quads it appends below, so content between
+// the background and the text already composites over the right color.
+[[nodiscard]] HRESULT AtlasEngine::BeginRowImages(const ImageSlice& imageSlice, const til::CoordType targetRow, const til::CoordType viewportLeft, const std::span<const uint8_t> defaultBackgroundMask, const std::span<const COLORREF> /*cellBackgrounds*/) noexcept
 try
 {
     const auto y = clamp<til::CoordType>(targetRow, 0, _p.s->viewportCellCount.y - 1);

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -43,7 +43,8 @@ namespace Microsoft::Console::Render::Atlas
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
         [[nodiscard]] HRESULT PaintBufferLine(std::span<const Cluster> clusters, til::point coord, bool fTrimLeft) noexcept override;
         [[nodiscard]] HRESULT PaintBufferGridLines(const GridLineSet lines, const COLORREF gridlineColor, const COLORREF underlineColor, const size_t cchLine, const til::point coordTarget) noexcept override;
-        [[nodiscard]] HRESULT PaintImageSlice(const ImageSlice& imageSlice, til::CoordType targetRow, til::CoordType viewportLeft) noexcept override;
+        [[nodiscard]] HRESULT BeginRowImages(const ImageSlice& imageSlice, til::CoordType targetRow, til::CoordType viewportLeft, std::span<const uint8_t> defaultBackgroundMask) noexcept override;
+        [[nodiscard]] HRESULT EndRowImages() noexcept override;
         [[nodiscard]] HRESULT PaintSelection(const til::rect& rect) noexcept override;
         [[nodiscard]] HRESULT PaintCursor(const CursorOptions& options) noexcept override;
         [[nodiscard]] HRESULT UpdateDrawingBrushes(const TextAttribute& textAttributes, const RenderSettings& renderSettings, gsl::not_null<IRenderData*> pData, bool usingSoftFont, bool isSettingDefaultBrushes) noexcept override;

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -43,7 +43,7 @@ namespace Microsoft::Console::Render::Atlas
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
         [[nodiscard]] HRESULT PaintBufferLine(std::span<const Cluster> clusters, til::point coord, bool fTrimLeft) noexcept override;
         [[nodiscard]] HRESULT PaintBufferGridLines(const GridLineSet lines, const COLORREF gridlineColor, const COLORREF underlineColor, const size_t cchLine, const til::point coordTarget) noexcept override;
-        [[nodiscard]] HRESULT BeginRowImages(const ImageSlice& imageSlice, til::CoordType targetRow, til::CoordType viewportLeft, std::span<const uint8_t> defaultBackgroundMask) noexcept override;
+        [[nodiscard]] HRESULT BeginRowImages(const ImageSlice& imageSlice, til::CoordType targetRow, til::CoordType viewportLeft, std::span<const uint8_t> defaultBackgroundMask, std::span<const COLORREF> cellBackgrounds) noexcept override;
         [[nodiscard]] HRESULT EndRowImages() noexcept override;
         [[nodiscard]] HRESULT PaintSelection(const til::rect& rect) noexcept override;
         [[nodiscard]] HRESULT PaintCursor(const CursorOptions& options) noexcept override;

--- a/src/renderer/atlas/BackendD2D.cpp
+++ b/src/renderer/atlas/BackendD2D.cpp
@@ -225,6 +225,15 @@ void BackendD2D::_drawText(RenderingPayload& p)
         auto baselineX = 0.0f;
         auto baselineY = static_cast<f32>(p.s->font->cellSize.y * y + p.s->font->baseline);
 
+        for (size_t i = 0; i < static_cast<size_t>(ImageSlice::RenderPosition::AboveText); i++)
+        {
+            const auto& underlay = til::at(row->bitmaps, i);
+            if (underlay.revision != 0)
+            {
+                _drawBitmap(p, underlay, y);
+            }
+        }
+
         if (row->lineRendition != LineRendition::SingleWidth)
         {
             baselineY = _drawTextPrepareLineRendition(p, row, baselineY);
@@ -322,9 +331,10 @@ void BackendD2D::_drawText(RenderingPayload& p)
             _drawTextResetLineRendition(row);
         }
 
-        if (row->bitmap.revision != 0)
+        const auto& overlay = til::at(row->bitmaps, static_cast<size_t>(ImageSlice::RenderPosition::AboveText));
+        if (overlay.revision != 0)
         {
-            _drawBitmap(p, row, y);
+            _drawBitmap(p, overlay, y);
         }
 
         if (p.invalidatedRows.contains(y))
@@ -809,10 +819,8 @@ void BackendD2D::_drawGridlineRow(const RenderingPayload& p, const ShapedRow* ro
     }
 }
 
-void BackendD2D::_drawBitmap(const RenderingPayload& p, const ShapedRow* row, u16 y) const
+void BackendD2D::_drawBitmap(const RenderingPayload& p, const Bitmap& b, u16 y) const
 {
-    const auto& b = row->bitmap;
-
     // TODO: This could use some caching logic like BackendD3D.
     const D2D1_SIZE_U size{
         gsl::narrow_cast<UINT32>(b.sourceSize.x),

--- a/src/renderer/atlas/BackendD2D.h
+++ b/src/renderer/atlas/BackendD2D.h
@@ -28,7 +28,7 @@ namespace Microsoft::Console::Render::Atlas
         ATLAS_ATTR_COLD void _drawTextResetLineRendition(const ShapedRow* row) const noexcept;
         ATLAS_ATTR_COLD f32r _getGlyphRunDesignBounds(const DWRITE_GLYPH_RUN& glyphRun, f32 baselineX, f32 baselineY);
         ATLAS_ATTR_COLD void _drawGridlineRow(const RenderingPayload& p, const ShapedRow* row, u16 y);
-        ATLAS_ATTR_COLD void _drawBitmap(const RenderingPayload& p, const ShapedRow* row, u16 y) const;
+        ATLAS_ATTR_COLD void _drawBitmap(const RenderingPayload& p, const Bitmap& bitmap, u16 y) const;
         void _drawCursorPart1(const RenderingPayload& p);
         void _drawCursorPart2(const RenderingPayload& p);
         static void _drawCursor(const RenderingPayload& p, ID2D1RenderTarget* renderTarget, D2D1_RECT_F rect, ID2D1Brush* brush) noexcept;

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -1139,6 +1139,15 @@ void BackendD3D::_drawText(RenderingPayload& p)
             static_cast<u8>(row->lineRendition >= LineRendition::DoubleHeightTop ? 2 : 1),
         };
 
+        for (size_t i = 0; i < static_cast<size_t>(ImageSlice::RenderPosition::AboveText); i++)
+        {
+            const auto& underlay = til::at(row->bitmaps, i);
+            if (underlay.revision != 0)
+            {
+                _drawBitmap(p, underlay, y);
+            }
+        }
+
         for (const auto& m : row->mappings)
         {
             auto x = m.glyphsFrom;
@@ -1210,9 +1219,10 @@ void BackendD3D::_drawText(RenderingPayload& p)
             _drawGridlines(p, y);
         }
 
-        if (row->bitmap.revision != 0)
+        const auto& overlay = til::at(row->bitmaps, static_cast<size_t>(ImageSlice::RenderPosition::AboveText));
+        if (overlay.revision != 0)
         {
-            _drawBitmap(p, row, y);
+            _drawBitmap(p, overlay, y);
         }
 
         if (p.invalidatedRows.contains(y))
@@ -1892,9 +1902,8 @@ void BackendD3D::_drawGridlines(const RenderingPayload& p, u16 y)
     }
 }
 
-void BackendD3D::_drawBitmap(const RenderingPayload& p, const ShapedRow* row, u16 y)
+void BackendD3D::_drawBitmap(const RenderingPayload& p, const Bitmap& b, u16 y)
 {
-    const auto& b = row->bitmap;
     auto ab = _glyphAtlasBitmaps.lookup(b.revision);
     if (!ab)
     {

--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -256,7 +256,7 @@ namespace Microsoft::Console::Render::Atlas
         static AtlasGlyphEntry* _drawGlyphAllocateEntry(const ShapedRow& row, AtlasFontFaceEntry& fontFaceEntry, u32 glyphIndex);
         static void _splitDoubleHeightGlyph(const RenderingPayload& p, const ShapedRow& row, AtlasFontFaceEntry& fontFaceEntry, AtlasGlyphEntry* glyphEntry);
         ATLAS_ATTR_COLD void _drawGridlines(const RenderingPayload& p, u16 y);
-        ATLAS_ATTR_COLD void _drawBitmap(const RenderingPayload& p, const ShapedRow* row, u16 y);
+        ATLAS_ATTR_COLD void _drawBitmap(const RenderingPayload& p, const Bitmap& bitmap, u16 y);
         void _drawCursorBackground(const RenderingPayload& p);
         ATLAS_ATTR_COLD void _drawCursorForeground();
         ATLAS_ATTR_COLD size_t _drawCursorForegroundSlowPath(const CursorRect& c, size_t offset);

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -472,7 +472,10 @@ namespace Microsoft::Console::Render::Atlas
             glyphAdvances.clear();
             glyphOffsets.clear();
             colors.clear();
-            bitmap.active = false;
+            for (auto& bitmap : bitmaps)
+            {
+                bitmap.active = false;
+            }
             gridLineRanges.clear();
             lineRendition = LineRendition::SingleWidth;
             dirtyTop = y * cellHeight;
@@ -491,7 +494,7 @@ namespace Microsoft::Console::Render::Atlas
         // Same size as glyphIndices.
         std::vector<u32> colors;
 
-        Bitmap bitmap;
+        std::array<Bitmap, ImageSlice::RenderPositionCount> bitmaps;
         std::vector<GridLineRange> gridLineRanges;
         LineRendition lineRendition = LineRendition::SingleWidth;
         til::CoordType dirtyTop = 0;

--- a/src/renderer/base/RenderEngineBase.cpp
+++ b/src/renderer/base/RenderEngineBase.cpp
@@ -72,7 +72,8 @@ HRESULT RenderEngineBase::PrepareLineTransform(const LineRendition /*lineRenditi
 HRESULT RenderEngineBase::BeginRowImages(const ImageSlice& /*imageSlice*/,
                                          const til::CoordType /*targetRow*/,
                                          const til::CoordType /*viewportLeft*/,
-                                         const std::span<const uint8_t> /*defaultBackgroundMask*/) noexcept
+                                         const std::span<const uint8_t> /*defaultBackgroundMask*/,
+                                         const std::span<const COLORREF> /*cellBackgrounds*/) noexcept
 {
     return S_FALSE;
 }

--- a/src/renderer/base/RenderEngineBase.cpp
+++ b/src/renderer/base/RenderEngineBase.cpp
@@ -69,9 +69,15 @@ HRESULT RenderEngineBase::PrepareLineTransform(const LineRendition /*lineRenditi
     return S_FALSE;
 }
 
-HRESULT RenderEngineBase::PaintImageSlice(const ImageSlice& /*imageSlice*/,
-                                          const til::CoordType /*targetRow*/,
-                                          const til::CoordType /*viewportLeft*/) noexcept
+HRESULT RenderEngineBase::BeginRowImages(const ImageSlice& /*imageSlice*/,
+                                         const til::CoordType /*targetRow*/,
+                                         const til::CoordType /*viewportLeft*/,
+                                         const std::span<const uint8_t> /*defaultBackgroundMask*/) noexcept
+{
+    return S_FALSE;
+}
+
+HRESULT RenderEngineBase::EndRowImages() noexcept
 {
     return S_FALSE;
 }

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -1099,17 +1099,70 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
             // Prepare the appropriate line transform for the current row and viewport offset.
             LOG_IF_FAILED(pEngine->PrepareLineTransform(lineRendition, screenPosition.y, _viewport.Left()));
 
+            // Image content is painted around the text so that it can sit below
+            // it. The engine decides how; all we do is bracket the text.
+            const auto imageSlice = r.GetImageSlice();
+            const auto hasImages = imageSlice && (imageSlice->HasPixels(ImageSlice::RenderPosition::BehindBackground) ||
+                                                  imageSlice->HasPixels(ImageSlice::RenderPosition::BehindText) ||
+                                                  imageSlice->HasPixels(ImageSlice::RenderPosition::AboveText));
+            if (hasImages) [[unlikely]]
+            {
+                LOG_IF_FAILED(pEngine->BeginRowImages(*imageSlice, screenPosition.y, _viewport.Left(), _buildDefaultBackgroundMask(r, *imageSlice)));
+            }
+
+            // Painting text can throw, and an engine left mid-row would keep
+            // suppressing cell backgrounds on every row after it.
+            const auto endRowImages = wil::scope_exit([&]() noexcept {
+                if (hasImages)
+                {
+                    LOG_IF_FAILED(pEngine->EndRowImages());
+                }
+            });
+
             // Ask the helper to paint through this specific line.
             _PaintBufferOutputHelper(pEngine, it, screenPosition);
-
-            // Paint any image content on top of the text.
-            const auto imageSlice = buffer.GetRowByOffset(row).GetImageSlice();
-            if (imageSlice) [[unlikely]]
-            {
-                LOG_IF_FAILED(pEngine->PaintImageSlice(*imageSlice, screenPosition.y, _viewport.Left()));
-            }
         }
     }
+}
+
+// Marks the columns of `imageSlice` whose cell background is the default one,
+// and where content below the background can therefore show through. Returns an
+// empty span when the slice has nothing below the background, which is the case
+// for every image that predates layering.
+std::span<const uint8_t> Renderer::_buildDefaultBackgroundMask(const ROW& r, const ImageSlice& imageSlice)
+{
+    if (!imageSlice.HasPixels(ImageSlice::RenderPosition::BehindBackground))
+    {
+        return {};
+    }
+
+    const auto cellWidth = imageSlice.CellSize().width;
+    if (cellWidth <= 0)
+    {
+        return {};
+    }
+
+    const auto columnCount = gsl::narrow_cast<size_t>(imageSlice.PixelWidth() / cellWidth);
+    // Reused across rows and frames; painting is hot and this would otherwise
+    // be a heap allocation per row per frame. Columns we can't resolve stay 0,
+    // which hides the image rather than letting it bleed through.
+    _backgroundMask.assign(columnCount, uint8_t{ 0 });
+
+    // A slice indexes screen columns, which a non-single-width rendition
+    // doubles; the row's attributes are indexed by buffer column.
+    const auto scale = r.GetLineRendition() != LineRendition::SingleWidth ? 1 : 0;
+    const auto readableColumns = r.GetReadableColumnCount();
+    for (size_t column = 0; column < columnCount; column++)
+    {
+        const auto sliceColumn = imageSlice.ColumnOffset() + gsl::narrow_cast<til::CoordType>(column);
+        const auto bufferColumn = sliceColumn >> scale;
+        if (bufferColumn >= 0 && bufferColumn < readableColumns)
+        {
+            til::at(_backgroundMask, column) = r.GetAttrByColumn(bufferColumn).GetBackground().IsDefault() ? 1 : 0;
+        }
+    }
+
+    return _backgroundMask;
 }
 
 ROW* Renderer::_PaintBufferOutputComposition(TextBuffer& buffer, const ROW& r, const Composition& activeComposition)

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -1107,7 +1107,8 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
                                                   imageSlice->HasPixels(ImageSlice::RenderPosition::AboveText));
             if (hasImages) [[unlikely]]
             {
-                LOG_IF_FAILED(pEngine->BeginRowImages(*imageSlice, screenPosition.y, _viewport.Left(), _buildDefaultBackgroundMask(r, *imageSlice)));
+                _buildImageRowBackgrounds(r, *imageSlice);
+                LOG_IF_FAILED(pEngine->BeginRowImages(*imageSlice, screenPosition.y, _viewport.Left(), _backgroundMask, _backgroundColors));
             }
 
             // Painting text can throw, and an engine left mid-row would keep
@@ -1125,28 +1126,36 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
     }
 }
 
-// Marks the columns of `imageSlice` whose cell background is the default one,
-// and where content below the background can therefore show through. Returns an
-// empty span when the slice has nothing below the background, which is the case
-// for every image that predates layering.
-std::span<const uint8_t> Renderer::_buildDefaultBackgroundMask(const ROW& r, const ImageSlice& imageSlice)
+// Resolves, for each column of `imageSlice`, whether the cell's background is the
+// default one - content below the background only shows through where it is - and
+// what that background's color is, which content above the background has to be
+// composited over. Both are left empty when the slice has nothing to draw beneath
+// the text, which is the case for every image that predates layering.
+void Renderer::_buildImageRowBackgrounds(const ROW& r, const ImageSlice& imageSlice)
 {
-    if (!imageSlice.HasPixels(ImageSlice::RenderPosition::BehindBackground))
+    _backgroundMask.clear();
+    _backgroundColors.clear();
+
+    if (!imageSlice.HasPixels(ImageSlice::RenderPosition::BehindBackground) &&
+        !imageSlice.HasPixels(ImageSlice::RenderPosition::BehindText))
     {
-        return {};
+        return;
     }
 
     const auto cellWidth = imageSlice.CellSize().width;
     if (cellWidth <= 0)
     {
-        return {};
+        return;
     }
 
     const auto columnCount = gsl::narrow_cast<size_t>(imageSlice.PixelWidth() / cellWidth);
     // Reused across rows and frames; painting is hot and this would otherwise
-    // be a heap allocation per row per frame. Columns we can't resolve stay 0,
-    // which hides the image rather than letting it bleed through.
+    // be a heap allocation per row per frame. Columns we can't resolve keep the
+    // default background, which hides content below it rather than letting it
+    // bleed through, and makes the fill above it a no-op.
+    const auto defaultBackground = _renderSettings.GetAttributeColors({}).second;
     _backgroundMask.assign(columnCount, uint8_t{ 0 });
+    _backgroundColors.assign(columnCount, defaultBackground);
 
     // A slice indexes screen columns, which a non-single-width rendition
     // doubles; the row's attributes are indexed by buffer column.
@@ -1158,11 +1167,11 @@ std::span<const uint8_t> Renderer::_buildDefaultBackgroundMask(const ROW& r, con
         const auto bufferColumn = sliceColumn >> scale;
         if (bufferColumn >= 0 && bufferColumn < readableColumns)
         {
-            til::at(_backgroundMask, column) = r.GetAttrByColumn(bufferColumn).GetBackground().IsDefault() ? 1 : 0;
+            const auto attributes = r.GetAttrByColumn(bufferColumn);
+            til::at(_backgroundMask, column) = attributes.GetBackground().IsDefault() ? 1 : 0;
+            til::at(_backgroundColors, column) = _renderSettings.GetAttributeColors(attributes).second;
         }
     }
-
-    return _backgroundMask;
 }
 
 ROW* Renderer::_PaintBufferOutputComposition(TextBuffer& buffer, const ROW& r, const Composition& activeComposition)

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -123,7 +123,7 @@ namespace Microsoft::Console::Render
         void _PaintBufferOutput(_In_ IRenderEngine* const pEngine);
         ROW* _PaintBufferOutputComposition(TextBuffer& buffer, const ROW& r, const Composition& activeComposition);
         void _PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine, TextBufferCellIterator it, const til::point target);
-        std::span<const uint8_t> _buildDefaultBackgroundMask(const ROW& r, const ImageSlice& imageSlice);
+        void _buildImageRowBackgrounds(const ROW& r, const ImageSlice& imageSlice);
         void _PaintBufferOutputGridLineHelper(_In_ IRenderEngine* const pEngine, const TextAttribute textAttribute, const size_t cchLine, const til::point coordTarget);
         bool _isHoveredHyperlink(const TextAttribute& textAttribute) const noexcept;
         void _PaintSelection(_In_ IRenderEngine* const pEngine);
@@ -173,6 +173,7 @@ namespace Microsoft::Console::Render
         std::optional<CompositionCache> _compositionCache;
         std::vector<Cluster> _clusterBuffer;
         std::vector<uint8_t> _backgroundMask;
+        std::vector<COLORREF> _backgroundColors;
         std::function<void()> _pfnBackgroundColorChanged;
         std::function<void()> _pfnFrameColorChanged;
         std::function<void()> _pfnRendererEnteredErrorState;

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -123,6 +123,7 @@ namespace Microsoft::Console::Render
         void _PaintBufferOutput(_In_ IRenderEngine* const pEngine);
         ROW* _PaintBufferOutputComposition(TextBuffer& buffer, const ROW& r, const Composition& activeComposition);
         void _PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine, TextBufferCellIterator it, const til::point target);
+        std::span<const uint8_t> _buildDefaultBackgroundMask(const ROW& r, const ImageSlice& imageSlice);
         void _PaintBufferOutputGridLineHelper(_In_ IRenderEngine* const pEngine, const TextAttribute textAttribute, const size_t cchLine, const til::point coordTarget);
         bool _isHoveredHyperlink(const TextAttribute& textAttribute) const noexcept;
         void _PaintSelection(_In_ IRenderEngine* const pEngine);
@@ -171,6 +172,7 @@ namespace Microsoft::Console::Render
         Microsoft::Console::Types::Viewport _viewport;
         std::optional<CompositionCache> _compositionCache;
         std::vector<Cluster> _clusterBuffer;
+        std::vector<uint8_t> _backgroundMask;
         std::function<void()> _pfnBackgroundColorChanged;
         std::function<void()> _pfnFrameColorChanged;
         std::function<void()> _pfnRendererEnteredErrorState;

--- a/src/renderer/gdi/gdirenderer.hpp
+++ b/src/renderer/gdi/gdirenderer.hpp
@@ -57,7 +57,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT BeginRowImages(const ImageSlice& imageSlice,
                                              til::CoordType targetRow,
                                              til::CoordType viewportLeft,
-                                             std::span<const uint8_t> defaultBackgroundMask) noexcept override;
+                                             std::span<const uint8_t> defaultBackgroundMask,
+                                             std::span<const COLORREF> cellBackgrounds) noexcept override;
         [[nodiscard]] HRESULT EndRowImages() noexcept override;
         [[nodiscard]] HRESULT PaintSelection(const til::rect& rect) noexcept override;
 
@@ -210,6 +211,11 @@ namespace Microsoft::Console::Render
         bool _UnderlayCoversColumn(til::CoordType column) const noexcept;        bool _UnderlayCoversBufferCell(til::CoordType bufferColumn) const noexcept;
         bool _UnderlayCoversAnyOf(til::CoordType columnBegin, til::CoordType columnEnd) const noexcept;
         [[nodiscard]] HRESULT _FillUncoveredRunBackground(const RECT& runRect, til::CoordType fontWidth) noexcept;
+        [[nodiscard]] HRESULT _FillImageRowCellBackgrounds(const ImageSlice& imageSlice,
+                                                           til::CoordType targetRow,
+                                                           til::CoordType viewportLeft,
+                                                           std::span<const uint8_t> defaultBackgroundMask,
+                                                           std::span<const COLORREF> cellBackgrounds) noexcept;
 
         [[nodiscard]] HRESULT _InvalidCombine(const til::rect* const prc) noexcept;
         [[nodiscard]] HRESULT _InvalidOffset(const til::point* const ppt) noexcept;

--- a/src/renderer/gdi/gdirenderer.hpp
+++ b/src/renderer/gdi/gdirenderer.hpp
@@ -178,8 +178,14 @@ namespace Microsoft::Console::Render
         std::pmr::vector<std::pmr::wstring> _polyStrings;
         std::pmr::vector<std::pmr::vector<int>> _polyWidths;
 
-        std::vector<DWORD> _imageMask;
         std::vector<RGBQUAD> _imagePlane;
+        // A DIB section to blend image content from. Declared before the device
+        // context that selects it so that the context is destroyed first and the
+        // bitmap is no longer selected anywhere by the time it goes.
+        wil::unique_hbitmap _hbitmapImageSource;
+        wil::unique_hdc _hdcImageSource;
+        til::size _szImageSource;
+        RGBQUAD* _imageSourceBits = nullptr;
         const ImageSlice* _rowImageSlice = nullptr;
         til::CoordType _rowImageTargetRow = 0;
         til::CoordType _rowImageViewportLeft = 0;
@@ -200,8 +206,8 @@ namespace Microsoft::Console::Render
                                                til::CoordType viewportLeft,
                                                std::span<const uint8_t> defaultBackgroundMask,
                                                bool underText) noexcept;
-        bool _UnderlayCoversColumn(til::CoordType column) const noexcept;
-        bool _UnderlayCoversBufferCell(til::CoordType bufferColumn) const noexcept;
+        [[nodiscard]] HRESULT _PrepareImageSourceSurface(til::size size, _Outptr_result_maybenull_ RGBQUAD** bits) noexcept;
+        bool _UnderlayCoversColumn(til::CoordType column) const noexcept;        bool _UnderlayCoversBufferCell(til::CoordType bufferColumn) const noexcept;
         bool _UnderlayCoversAnyOf(til::CoordType columnBegin, til::CoordType columnEnd) const noexcept;
         [[nodiscard]] HRESULT _FillUncoveredRunBackground(const RECT& runRect, til::CoordType fontWidth) noexcept;
 

--- a/src/renderer/gdi/gdirenderer.hpp
+++ b/src/renderer/gdi/gdirenderer.hpp
@@ -190,6 +190,9 @@ namespace Microsoft::Console::Render
         std::vector<uint8_t> _underlayColumns;
         til::CoordType _underlayColumnOffset = 0;
         int _underlayScale = 0;
+        // The background mode to put back once this row's text has been drawn,
+        // or 0 if we never changed it. See BeginRowImages.
+        int _restoreBkMode = 0;
 
         [[nodiscard]] HRESULT _PaintImagePlane(const ImageSlice& imageSlice,
                                                ImageSlice::RenderPosition position,
@@ -197,7 +200,10 @@ namespace Microsoft::Console::Render
                                                til::CoordType viewportLeft,
                                                std::span<const uint8_t> defaultBackgroundMask,
                                                bool underText) noexcept;
-        bool _UnderlayCoversColumns(til::CoordType columnBegin, til::CoordType columnEnd) const noexcept;
+        bool _UnderlayCoversColumn(til::CoordType column) const noexcept;
+        bool _UnderlayCoversBufferCell(til::CoordType bufferColumn) const noexcept;
+        bool _UnderlayCoversAnyOf(til::CoordType columnBegin, til::CoordType columnEnd) const noexcept;
+        [[nodiscard]] HRESULT _FillUncoveredRunBackground(const RECT& runRect, til::CoordType fontWidth) noexcept;
 
         [[nodiscard]] HRESULT _InvalidCombine(const til::rect* const prc) noexcept;
         [[nodiscard]] HRESULT _InvalidOffset(const til::point* const ppt) noexcept;

--- a/src/renderer/gdi/gdirenderer.hpp
+++ b/src/renderer/gdi/gdirenderer.hpp
@@ -54,9 +54,11 @@ namespace Microsoft::Console::Render
                                                    const COLORREF underlineColor,
                                                    const size_t cchLine,
                                                    const til::point coordTarget) noexcept override;
-        [[nodiscard]] HRESULT PaintImageSlice(const ImageSlice& imageSlice,
-                                              const til::CoordType targetRow,
-                                              const til::CoordType viewportLeft) noexcept override;
+        [[nodiscard]] HRESULT BeginRowImages(const ImageSlice& imageSlice,
+                                             til::CoordType targetRow,
+                                             til::CoordType viewportLeft,
+                                             std::span<const uint8_t> defaultBackgroundMask) noexcept override;
+        [[nodiscard]] HRESULT EndRowImages() noexcept override;
         [[nodiscard]] HRESULT PaintSelection(const til::rect& rect) noexcept override;
 
         [[nodiscard]] HRESULT PaintCursor(const CursorOptions& options) noexcept override;
@@ -177,6 +179,25 @@ namespace Microsoft::Console::Render
         std::pmr::vector<std::pmr::vector<int>> _polyWidths;
 
         std::vector<DWORD> _imageMask;
+        std::vector<RGBQUAD> _imagePlane;
+        const ImageSlice* _rowImageSlice = nullptr;
+        til::CoordType _rowImageTargetRow = 0;
+        til::CoordType _rowImageViewportLeft = 0;
+        // One flag per screen column of the current row's slice, set where
+        // image content will end up visibly below the text. Text over those
+        // columns must not fill its own background or it would paint the
+        // image out. Screen columns, so the line rendition is already applied.
+        std::vector<uint8_t> _underlayColumns;
+        til::CoordType _underlayColumnOffset = 0;
+        int _underlayScale = 0;
+
+        [[nodiscard]] HRESULT _PaintImagePlane(const ImageSlice& imageSlice,
+                                               ImageSlice::RenderPosition position,
+                                               til::CoordType targetRow,
+                                               til::CoordType viewportLeft,
+                                               std::span<const uint8_t> defaultBackgroundMask,
+                                               bool underText) noexcept;
+        bool _UnderlayCoversColumns(til::CoordType columnBegin, til::CoordType columnEnd) const noexcept;
 
         [[nodiscard]] HRESULT _InvalidCombine(const til::rect* const prc) noexcept;
         [[nodiscard]] HRESULT _InvalidOffset(const til::point* const ppt) noexcept;

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -44,6 +44,7 @@ bool GdiEngine::FontHasWesternScript(HDC hdc)
     // state would suppress cell backgrounds on unrelated rows.
     _underlayColumns.clear();
     _rowImageSlice = nullptr;
+    _restoreBkMode = 0;
 
     // Prepare our in-memory bitmap for double-buffered composition.
     RETURN_IF_FAILED(_PrepareMemoryBitmap(_hwndTargetWindow));
@@ -429,18 +430,20 @@ bool GdiEngine::FontHasWesternScript(HDC hdc)
             pPolyTextLine->rcl.left += coordFontSize.width;
         }
 
-        // ETO_OPAQUE fills the cell background, which would paint over image
-        // content this row has sitting below its text. Where the image is
-        // visible under every cell of the run, drop the fill and let the image
-        // be the background. `rcl` is pre-transform, so it is in buffer columns
-        // times the font width; the slice indexes screen columns.
+        // ETO_OPAQUE fills the run's background, which would paint over image
+        // content this row has sitting below its text. It is a single flag for
+        // the whole run, but coverage varies cell by cell, so wherever a run
+        // meets the image at all we drop the flag and fill only the cells the
+        // image does not cover. `rcl` is pre-transform, so it is in buffer
+        // columns times the font width; the slice indexes screen columns.
         if (!_underlayColumns.empty() && coordFontSize.width > 0)
         {
             const auto beginColumn = (pPolyTextLine->rcl.left / coordFontSize.width) << _underlayScale;
             const auto endColumn = (pPolyTextLine->rcl.right / coordFontSize.width) << _underlayScale;
-            if (_UnderlayCoversColumns(beginColumn, endColumn))
+            if (_UnderlayCoversAnyOf(beginColumn, endColumn))
             {
                 WI_ClearFlag(pPolyTextLine->uiFlags, ETO_OPAQUE);
+                LOG_IF_FAILED(_FillUncoveredRunBackground(pPolyTextLine->rcl, coordFontSize.width));
             }
         }
 
@@ -825,6 +828,19 @@ try
     LOG_IF_FAILED(_PaintImagePlane(imageSlice, ImageSlice::RenderPosition::BehindBackground, targetRow, viewportLeft, defaultBackgroundMask, true));
     LOG_IF_FAILED(_PaintImagePlane(imageSlice, ImageSlice::RenderPosition::BehindText, targetRow, viewportLeft, {}, true));
 
+    // Withholding ETO_OPAQUE stops the text filling its background *rectangle*,
+    // but a device context also fills the box behind every individual glyph
+    // when its background mode is OPAQUE, which is GDI's default and is what
+    // the rest of this engine relies on. That fill alone is enough to paint out
+    // everything we just drew, so it has to go too. Runs the image does not
+    // cover keep ETO_OPAQUE, and that fill happens whatever the mode is, so
+    // they are unaffected.
+    if (!_underlayColumns.empty())
+    {
+        const auto previous = SetBkMode(_hdcMemoryContext, TRANSPARENT);
+        _restoreBkMode = previous != TRANSPARENT ? previous : 0;
+    }
+
     LOG_IF_FAILED(PrepareLineTransform(rendition, targetRow, viewportLeft));
 
     _rowImageSlice = &imageSlice;
@@ -835,24 +851,80 @@ try
 }
 CATCH_RETURN();
 
-// Reports whether image content below the text covers every one of these
-// screen columns, in which case the text must not fill its own background.
-bool GdiEngine::_UnderlayCoversColumns(const til::CoordType columnBegin, const til::CoordType columnEnd) const noexcept
+// Reports whether image content below the text covers this screen column.
+bool GdiEngine::_UnderlayCoversColumn(const til::CoordType column) const noexcept
 {
-    if (_underlayColumns.empty() || columnBegin >= columnEnd || columnBegin < _underlayColumnOffset)
+    const auto index = column - _underlayColumnOffset;
+    if (index < 0 || gsl::narrow_cast<size_t>(index) >= _underlayColumns.size())
+    {
+        return false;
+    }
+    return til::at(_underlayColumns, gsl::narrow_cast<size_t>(index)) != 0;
+}
+
+// Reports whether image content covers any part of the buffer cell whose first
+// screen column is this one. Under a double-width rendition one buffer cell
+// spans two screen columns, and a cell only half covered still has to leave the
+// image alone.
+bool GdiEngine::_UnderlayCoversBufferCell(const til::CoordType bufferColumn) const noexcept
+{
+    const auto screenColumn = bufferColumn << _underlayScale;
+    return _UnderlayCoversColumn(screenColumn) ||
+           (_underlayScale != 0 && _UnderlayCoversColumn(screenColumn + 1));
+}
+
+// Reports whether image content below the text covers any of these screen
+// columns, which is what decides whether a run can keep its own background fill.
+bool GdiEngine::_UnderlayCoversAnyOf(const til::CoordType columnBegin, const til::CoordType columnEnd) const noexcept
+{
+    if (_underlayColumns.empty() || columnBegin >= columnEnd)
     {
         return false;
     }
 
     for (auto column = columnBegin; column < columnEnd; column++)
     {
-        const auto index = gsl::narrow_cast<size_t>(column - _underlayColumnOffset);
-        if (index >= _underlayColumns.size() || til::at(_underlayColumns, index) == 0)
+        if (_UnderlayCoversColumn(column))
         {
-            return false;
+            return true;
         }
     }
-    return true;
+    return false;
+}
+
+// Routine Description:
+// - Fills the background of the cells of a run that no image covers, standing in
+//   for the ETO_OPAQUE that had to be dropped so the rest of the run could show
+//   the image through. Uses the device context's current background colour,
+//   which is the one already selected for this run.
+// Arguments:
+// - runRect - the run's rectangle, pre-transform, so measured in buffer columns
+// - fontWidth - the width of one buffer cell in pixels
+// Return Value:
+// - S_OK or E_FAIL if GDI failed.
+[[nodiscard]] HRESULT GdiEngine::_FillUncoveredRunBackground(const RECT& runRect, const til::CoordType fontWidth) noexcept
+{
+    auto spanLeft = runRect.left;
+    for (auto x = runRect.left; x < runRect.right; x += fontWidth)
+    {
+        if (!_UnderlayCoversBufferCell(x / fontWidth))
+        {
+            continue;
+        }
+        if (spanLeft < x)
+        {
+            RECT fill{ spanLeft, runRect.top, x, runRect.bottom };
+            RETURN_HR_IF(E_FAIL, !ExtTextOutW(_hdcMemoryContext, 0, 0, ETO_OPAQUE, &fill, nullptr, 0, nullptr));
+        }
+        spanLeft = x + fontWidth;
+    }
+
+    if (spanLeft < runRect.right)
+    {
+        RECT fill{ spanLeft, runRect.top, runRect.right, runRect.bottom };
+        RETURN_HR_IF(E_FAIL, !ExtTextOutW(_hdcMemoryContext, 0, 0, ETO_OPAQUE, &fill, nullptr, 0, nullptr));
+    }
+    return S_OK;
 }
 
 [[nodiscard]] HRESULT GdiEngine::EndRowImages() noexcept
@@ -861,6 +933,11 @@ try
     // Push the row's text out over whatever was painted below it...
     _underlayColumns.clear();
     LOG_IF_FAILED(_FlushBufferLines());
+    if (_restoreBkMode != 0)
+    {
+        SetBkMode(_hdcMemoryContext, _restoreBkMode);
+        _restoreBkMode = 0;
+    }
 
     // ...and only then put the above-text content on top of all of it.
     if (_rowImageSlice)

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -735,13 +735,9 @@ try
         plane = _imagePlane;
     }
 
-    if (_imageMask.size() < plane.size())
-    {
-        _imageMask.resize(plane.size());
-    }
-
-    // Whatever survives here is what the text has to avoid painting over. It's
-    // recorded after masking, so a cell whose background won stays uncovered.
+    // Whatever survives here is what the text has to avoid painting over. It is
+    // recorded after the background mask has been applied, so a cell whose own
+    // background won stays uncovered.
     if (underText && !_underlayColumns.empty())
     {
         for (auto column = 0; column < columnCount; column++)
@@ -777,27 +773,87 @@ try
 
     auto allOpaque = true;
     auto allTransparent = true;
-    for (size_t i = 0; i < plane.size(); i++)
+    for (const auto& pixel : plane)
     {
-        const auto opaque = til::at(plane, i).rgbReserved != 0;
-        allOpaque &= opaque;
-        allTransparent &= !opaque;
-        til::at(_imageMask, i) = (opaque ? 0 : 0xFFFFFF);
+        allOpaque &= pixel.rgbReserved == 0xff;
+        allTransparent &= pixel.rgbReserved == 0;
+    }
+
+    if (allTransparent)
+    {
+        return S_OK;
     }
 
     if (allOpaque)
     {
         StretchDIBits(_hdcMemoryContext, x, y, dstWidth, dstHeight, 0, 0, srcWidth, srcHeight, plane.data(), &bitmapInfo, DIB_RGB_COLORS, SRCCOPY);
+        return S_OK;
     }
-    else if (!allTransparent)
-    {
-        StretchDIBits(_hdcMemoryContext, x, y, dstWidth, dstHeight, 0, 0, srcWidth, srcHeight, _imageMask.data(), &bitmapInfo, DIB_RGB_COLORS, SRCAND);
-        StretchDIBits(_hdcMemoryContext, x, y, dstWidth, dstHeight, 0, 0, srcWidth, srcHeight, plane.data(), &bitmapInfo, DIB_RGB_COLORS, SRCPAINT);
-    }
+
+    // Anything else has to be blended rather than masked. A mask can only say
+    // "this pixel, or that one", which is all Sixel ever needed because its
+    // pixels are either fully there or not there at all. A pixel that is only
+    // partly opaque has to end up over what the cell already holds, and with
+    // premultiplied planes that is precisely what AC_SRC_ALPHA does.
+    RGBQUAD* bits = nullptr;
+    RETURN_IF_FAILED(_PrepareImageSourceSurface({ srcWidth, srcHeight }, &bits));
+    memcpy(bits, plane.data(), plane.size_bytes());
+
+    constexpr BLENDFUNCTION blend{ .BlendOp = AC_SRC_OVER, .BlendFlags = 0, .SourceConstantAlpha = 255, .AlphaFormat = AC_SRC_ALPHA };
+    RETURN_HR_IF(E_FAIL, !GdiAlphaBlend(_hdcMemoryContext, x, y, dstWidth, dstHeight, _hdcImageSource.get(), 0, 0, srcWidth, srcHeight, blend));
 
     return S_OK;
 }
 CATCH_RETURN();
+
+// Routine Description:
+// - Hands back a device context holding a top-down 32bpp surface of this size,
+//   creating or resizing it as needed, so that image content can be blended from
+//   it. GDI can only blend between device contexts, not from loose pixels.
+// Arguments:
+// - size - the surface size required, in pixels
+// - bits - receives the surface's pixels, laid out top row first
+// Return Value:
+// - S_OK or a GDI failure.
+[[nodiscard]] HRESULT GdiEngine::_PrepareImageSourceSurface(const til::size size, _Outptr_result_maybenull_ RGBQUAD** const bits) noexcept
+{
+    *bits = nullptr;
+    RETURN_HR_IF(E_INVALIDARG, size.width <= 0 || size.height <= 0);
+
+    if (!_hdcImageSource)
+    {
+        _hdcImageSource.reset(CreateCompatibleDC(nullptr));
+        RETURN_LAST_ERROR_IF_NULL(_hdcImageSource.get());
+    }
+
+    if (!_hbitmapImageSource || _szImageSource != size)
+    {
+        const BITMAPINFO info{
+            .bmiHeader = {
+                .biSize = sizeof(BITMAPINFOHEADER),
+                .biWidth = size.width,
+                .biHeight = -size.height,
+                .biPlanes = 1,
+                .biBitCount = 32,
+                .biCompression = BI_RGB,
+            }
+        };
+
+        void* surface = nullptr;
+        wil::unique_hbitmap bitmap{ CreateDIBSection(_hdcImageSource.get(), &info, DIB_RGB_COLORS, &surface, nullptr, 0) };
+        RETURN_LAST_ERROR_IF_NULL(bitmap.get());
+        // Selecting the replacement first is what releases the one being
+        // replaced, which has to happen before it is destroyed below.
+        RETURN_LAST_ERROR_IF_NULL(SelectObject(_hdcImageSource.get(), bitmap.get()));
+
+        _hbitmapImageSource = std::move(bitmap);
+        _szImageSource = size;
+        _imageSourceBits = static_cast<RGBQUAD*>(surface);
+    }
+
+    *bits = _imageSourceBits;
+    return S_OK;
+}
 
 [[nodiscard]] HRESULT GdiEngine::BeginRowImages(const ImageSlice& imageSlice,
                                                 const til::CoordType targetRow,

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -858,7 +858,8 @@ CATCH_RETURN();
 [[nodiscard]] HRESULT GdiEngine::BeginRowImages(const ImageSlice& imageSlice,
                                                 const til::CoordType targetRow,
                                                 const til::CoordType viewportLeft,
-                                                const std::span<const uint8_t> defaultBackgroundMask) noexcept
+                                                const std::span<const uint8_t> defaultBackgroundMask,
+                                                const std::span<const COLORREF> cellBackgrounds) noexcept
 try
 {
     // Text is buffered until something forces it out, so flushing here means
@@ -882,6 +883,11 @@ try
     LOG_IF_FAILED(ResetLineTransform());
 
     LOG_IF_FAILED(_PaintImagePlane(imageSlice, ImageSlice::RenderPosition::BehindBackground, targetRow, viewportLeft, defaultBackgroundMask, true));
+    // Content between the background and the text has to be composited over the
+    // cell's own background, and the text pass will not paint one for any cell
+    // this row's images cover. Lay it down now, in the one window where the plane
+    // below the background is already painted and the plane above it is not.
+    LOG_IF_FAILED(_FillImageRowCellBackgrounds(imageSlice, targetRow, viewportLeft, defaultBackgroundMask, cellBackgrounds));
     LOG_IF_FAILED(_PaintImagePlane(imageSlice, ImageSlice::RenderPosition::BehindText, targetRow, viewportLeft, {}, true));
 
     // Withholding ETO_OPAQUE stops the text filling its background *rectangle*,
@@ -982,6 +988,79 @@ bool GdiEngine::_UnderlayCoversAnyOf(const til::CoordType columnBegin, const til
     }
     return S_OK;
 }
+
+// Routine Description:
+// - Paints each cell of a row's image slice in its own background colour, for the
+//   cells whose background is not the default one. `PaintBackground` has already
+//   covered the frame in the default colour, and the text pass fills the rest --
+//   but it skips every cell an image covers, and it runs after the image is drawn,
+//   so a cell with an explicit background would otherwise composite the image over
+//   the default colour and show the default colour anywhere the image is
+//   transparent. Called with the slice's own untransformed geometry.
+// Arguments:
+// - imageSlice - the row's slice, whose columns these are
+// - targetRow - the screen row the slice paints on
+// - viewportLeft - the leftmost visible column, which the slice is offset from
+// - defaultBackgroundMask - one byte per slice column, non-zero where the cell's
+//   background is the default one and this fill is unnecessary
+// - cellBackgrounds - one color per slice column
+// Return Value:
+// - S_OK, or E_FAIL if GDI failed.
+[[nodiscard]] HRESULT GdiEngine::_FillImageRowCellBackgrounds(const ImageSlice& imageSlice,
+                                                              const til::CoordType targetRow,
+                                                              const til::CoordType viewportLeft,
+                                                              const std::span<const uint8_t> defaultBackgroundMask,
+                                                              const std::span<const COLORREF> cellBackgrounds) noexcept
+try
+{
+    // Only content between the background and the text composites over the cell's
+    // background. The plane below the background is masked to the cells that have
+    // none, and the plane above the text is painted after the text pass has filled
+    // whatever it was going to fill.
+    if (!imageSlice.HasPixels(ImageSlice::RenderPosition::BehindText))
+    {
+        return S_OK;
+    }
+
+    const auto srcCellSize = imageSlice.CellSize();
+    RETURN_HR_IF(S_OK, srcCellSize.width <= 0);
+    const auto columnCount = gsl::narrow_cast<size_t>(imageSlice.PixelWidth() / srcCellSize.width);
+    RETURN_HR_IF(S_OK, cellBackgrounds.size() != columnCount || defaultBackgroundMask.size() != columnCount);
+
+    const auto dstCellSize = _GetFontSize();
+    RETURN_HR_IF(S_OK, dstCellSize.width <= 0 || dstCellSize.height <= 0);
+    const auto top = targetRow * dstCellSize.height;
+    const auto left = (imageSlice.ColumnOffset() - viewportLeft) * dstCellSize.width;
+
+    // Adjacent cells usually share a colour, so they are filled as one rectangle.
+    for (size_t column = 0; column < columnCount;)
+    {
+        if (til::at(defaultBackgroundMask, column) != 0)
+        {
+            column++;
+            continue;
+        }
+        const auto color = til::at(cellBackgrounds, column);
+        auto end = column + 1;
+        while (end < columnCount && til::at(defaultBackgroundMask, end) == 0 && til::at(cellBackgrounds, end) == color)
+        {
+            end++;
+        }
+
+        const RECT fill{
+            left + gsl::narrow_cast<til::CoordType>(column) * dstCellSize.width,
+            top,
+            left + gsl::narrow_cast<til::CoordType>(end) * dstCellSize.width,
+            top + dstCellSize.height,
+        };
+        wil::unique_hbrush brush{ CreateSolidBrush(color) };
+        RETURN_HR_IF_NULL(E_FAIL, brush.get());
+        RETURN_HR_IF(E_FAIL, !FillRect(_hdcMemoryContext, &fill, brush.get()));
+        column = end;
+    }
+    return S_OK;
+}
+CATCH_RETURN();
 
 [[nodiscard]] HRESULT GdiEngine::EndRowImages() noexcept
 try

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -40,6 +40,10 @@ bool GdiEngine::FontHasWesternScript(HDC hdc)
 
     // At the beginning of a new frame, we have 0 lines ready for painting in PolyTextOut
     _cPolyText = 0;
+    // A row that failed mid-paint could have left these set, and stale underlay
+    // state would suppress cell backgrounds on unrelated rows.
+    _underlayColumns.clear();
+    _rowImageSlice = nullptr;
 
     // Prepare our in-memory bitmap for double-buffered composition.
     RETURN_IF_FAILED(_PrepareMemoryBitmap(_hwndTargetWindow));
@@ -425,6 +429,21 @@ bool GdiEngine::FontHasWesternScript(HDC hdc)
             pPolyTextLine->rcl.left += coordFontSize.width;
         }
 
+        // ETO_OPAQUE fills the cell background, which would paint over image
+        // content this row has sitting below its text. Where the image is
+        // visible under every cell of the run, drop the fill and let the image
+        // be the background. `rcl` is pre-transform, so it is in buffer columns
+        // times the font width; the slice indexes screen columns.
+        if (!_underlayColumns.empty() && coordFontSize.width > 0)
+        {
+            const auto beginColumn = (pPolyTextLine->rcl.left / coordFontSize.width) << _underlayScale;
+            const auto endColumn = (pPolyTextLine->rcl.right / coordFontSize.width) << _underlayScale;
+            if (_UnderlayCoversColumns(beginColumn, endColumn))
+            {
+                WI_ClearFlag(pPolyTextLine->uiFlags, ETO_OPAQUE);
+            }
+        }
+
         _cPolyText++;
 
         if (_cPolyText >= s_cPolyTextCache)
@@ -666,28 +685,81 @@ try
 }
 CATCH_RETURN();
 
-[[nodiscard]] HRESULT GdiEngine::PaintImageSlice(const ImageSlice& imageSlice,
+[[nodiscard]] HRESULT GdiEngine::_PaintImagePlane(const ImageSlice& imageSlice,
+                                                 const ImageSlice::RenderPosition position,
                                                  const til::CoordType targetRow,
-                                                 const til::CoordType viewportLeft) noexcept
+                                                 const til::CoordType viewportLeft,
+                                                 const std::span<const uint8_t> defaultBackgroundMask,
+                                                 const bool underText) noexcept
 try
 {
-    LOG_IF_FAILED(_FlushBufferLines());
-    LOG_IF_FAILED(ResetLineTransform());
-
-    const auto& imagePixels = imageSlice.Pixels();
-    if (_imageMask.size() < imagePixels.size())
+    if (!imageSlice.HasPixels(position))
     {
-        _imageMask.resize(imagePixels.size());
+        return S_OK;
     }
 
     const auto srcCellSize = imageSlice.CellSize();
     const auto dstCellSize = _GetFontSize();
+    RETURN_HR_IF(S_OK, srcCellSize.width <= 0 || srcCellSize.height <= 0);
+
     const auto srcWidth = imageSlice.PixelWidth();
     const auto srcHeight = srcCellSize.height;
     const auto dstWidth = srcWidth * dstCellSize.width / srcCellSize.width;
     const auto dstHeight = dstCellSize.height;
     const auto x = (imageSlice.ColumnOffset() - viewportLeft) * dstCellSize.width;
     const auto y = targetRow * dstCellSize.height;
+    const auto columnCount = srcWidth / srcCellSize.width;
+
+    auto plane = imageSlice.Pixels(position);
+    if (defaultBackgroundMask.size() == gsl::narrow_cast<size_t>(columnCount))
+    {
+        // Content below the background is only visible through cells whose
+        // background is the default one. Blanking the rest makes it transparent
+        // to the compositing below, which is exactly what we want.
+        _imagePlane.assign(plane.begin(), plane.end());
+        for (auto column = 0; column < columnCount; column++)
+        {
+            if (til::at(defaultBackgroundMask, gsl::narrow_cast<size_t>(column)) != 0)
+            {
+                continue;
+            }
+            for (auto pixelRow = 0; pixelRow < srcHeight; pixelRow++)
+            {
+                const auto first = _imagePlane.data() + gsl::narrow_cast<size_t>(pixelRow) * srcWidth + gsl::narrow_cast<size_t>(column) * srcCellSize.width;
+                std::fill_n(first, srcCellSize.width, RGBQUAD{});
+            }
+        }
+        plane = _imagePlane;
+    }
+
+    if (_imageMask.size() < plane.size())
+    {
+        _imageMask.resize(plane.size());
+    }
+
+    // Whatever survives here is what the text has to avoid painting over. It's
+    // recorded after masking, so a cell whose background won stays uncovered.
+    if (underText && !_underlayColumns.empty())
+    {
+        for (auto column = 0; column < columnCount; column++)
+        {
+            const auto slot = gsl::narrow_cast<size_t>(column);
+            if (slot >= _underlayColumns.size() || til::at(_underlayColumns, slot) != 0)
+            {
+                continue;
+            }
+            for (auto pixelRow = 0; pixelRow < srcHeight; pixelRow++)
+            {
+                const auto first = plane.data() + gsl::narrow_cast<size_t>(pixelRow) * srcWidth + gsl::narrow_cast<size_t>(column) * srcCellSize.width;
+                const auto opaque = std::any_of(first, first + srcCellSize.width, [](const RGBQUAD& pixel) noexcept { return pixel.rgbReserved != 0; });
+                if (opaque)
+                {
+                    til::at(_underlayColumns, slot) = 1;
+                    break;
+                }
+            }
+        }
+    }
 
     auto bitmapInfo = BITMAPINFO{
         .bmiHeader = {
@@ -702,9 +774,9 @@ try
 
     auto allOpaque = true;
     auto allTransparent = true;
-    for (size_t i = 0; i < imagePixels.size(); i++)
+    for (size_t i = 0; i < plane.size(); i++)
     {
-        const auto opaque = til::at(imagePixels, i).rgbReserved != 0;
+        const auto opaque = til::at(plane, i).rgbReserved != 0;
         allOpaque &= opaque;
         allTransparent &= !opaque;
         til::at(_imageMask, i) = (opaque ? 0 : 0xFFFFFF);
@@ -712,12 +784,92 @@ try
 
     if (allOpaque)
     {
-        StretchDIBits(_hdcMemoryContext, x, y, dstWidth, dstHeight, 0, 0, srcWidth, srcHeight, imagePixels.data(), &bitmapInfo, DIB_RGB_COLORS, SRCCOPY);
+        StretchDIBits(_hdcMemoryContext, x, y, dstWidth, dstHeight, 0, 0, srcWidth, srcHeight, plane.data(), &bitmapInfo, DIB_RGB_COLORS, SRCCOPY);
     }
     else if (!allTransparent)
     {
         StretchDIBits(_hdcMemoryContext, x, y, dstWidth, dstHeight, 0, 0, srcWidth, srcHeight, _imageMask.data(), &bitmapInfo, DIB_RGB_COLORS, SRCAND);
-        StretchDIBits(_hdcMemoryContext, x, y, dstWidth, dstHeight, 0, 0, srcWidth, srcHeight, imagePixels.data(), &bitmapInfo, DIB_RGB_COLORS, SRCPAINT);
+        StretchDIBits(_hdcMemoryContext, x, y, dstWidth, dstHeight, 0, 0, srcWidth, srcHeight, plane.data(), &bitmapInfo, DIB_RGB_COLORS, SRCPAINT);
+    }
+
+    return S_OK;
+}
+CATCH_RETURN();
+
+[[nodiscard]] HRESULT GdiEngine::BeginRowImages(const ImageSlice& imageSlice,
+                                                const til::CoordType targetRow,
+                                                const til::CoordType viewportLeft,
+                                                const std::span<const uint8_t> defaultBackgroundMask) noexcept
+try
+{
+    // Text is buffered until something forces it out, so flushing here means
+    // only this row's text can end up above what we're about to paint.
+    LOG_IF_FAILED(_FlushBufferLines());
+
+    const auto srcCellSize = imageSlice.CellSize();
+    _underlayColumns.clear();
+    _underlayColumnOffset = imageSlice.ColumnOffset();
+    // The rendition is already baked into the slice's own geometry, but the
+    // text's coordinates are not, so runs get scaled up to match.
+    _underlayScale = _currentLineRendition != LineRendition::SingleWidth ? 1 : 0;
+    if (srcCellSize.width > 0)
+    {
+        _underlayColumns.assign(gsl::narrow_cast<size_t>(imageSlice.PixelWidth() / srcCellSize.width), uint8_t{ 0 });
+    }
+
+    // The slice already accounts for line rendition in its own geometry, so it
+    // is painted untransformed. The row's text still needs the transform.
+    const auto rendition = _currentLineRendition;
+    LOG_IF_FAILED(ResetLineTransform());
+
+    LOG_IF_FAILED(_PaintImagePlane(imageSlice, ImageSlice::RenderPosition::BehindBackground, targetRow, viewportLeft, defaultBackgroundMask, true));
+    LOG_IF_FAILED(_PaintImagePlane(imageSlice, ImageSlice::RenderPosition::BehindText, targetRow, viewportLeft, {}, true));
+
+    LOG_IF_FAILED(PrepareLineTransform(rendition, targetRow, viewportLeft));
+
+    _rowImageSlice = &imageSlice;
+    _rowImageTargetRow = targetRow;
+    _rowImageViewportLeft = viewportLeft;
+
+    return S_OK;
+}
+CATCH_RETURN();
+
+// Reports whether image content below the text covers every one of these
+// screen columns, in which case the text must not fill its own background.
+bool GdiEngine::_UnderlayCoversColumns(const til::CoordType columnBegin, const til::CoordType columnEnd) const noexcept
+{
+    if (_underlayColumns.empty() || columnBegin >= columnEnd || columnBegin < _underlayColumnOffset)
+    {
+        return false;
+    }
+
+    for (auto column = columnBegin; column < columnEnd; column++)
+    {
+        const auto index = gsl::narrow_cast<size_t>(column - _underlayColumnOffset);
+        if (index >= _underlayColumns.size() || til::at(_underlayColumns, index) == 0)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] HRESULT GdiEngine::EndRowImages() noexcept
+try
+{
+    // Push the row's text out over whatever was painted below it...
+    _underlayColumns.clear();
+    LOG_IF_FAILED(_FlushBufferLines());
+
+    // ...and only then put the above-text content on top of all of it.
+    if (_rowImageSlice)
+    {
+        const auto rendition = _currentLineRendition;
+        LOG_IF_FAILED(ResetLineTransform());
+        LOG_IF_FAILED(_PaintImagePlane(*_rowImageSlice, ImageSlice::RenderPosition::AboveText, _rowImageTargetRow, _rowImageViewportLeft, {}, false));
+        LOG_IF_FAILED(PrepareLineTransform(rendition, _rowImageTargetRow, _rowImageViewportLeft));
+        _rowImageSlice = nullptr;
     }
 
     return S_OK;

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -80,7 +80,16 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT PaintBackground() noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintBufferLine(std::span<const Cluster> clusters, til::point coord, bool fTrimLeft) noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintBufferGridLines(GridLineSet lines, COLORREF gridlineColor, COLORREF underlineColor, size_t cchLine, til::point coordTarget) noexcept = 0;
-        [[nodiscard]] virtual HRESULT PaintImageSlice(const ImageSlice& imageSlice, til::CoordType targetRow, til::CoordType viewportLeft) noexcept = 0;
+        // A row's image content is painted around its text so that it can appear
+        // beneath it. Text painted between these two calls must end up above
+        // anything BeginRowImages drew and below anything EndRowImages draws.
+        //
+        // defaultBackgroundMask holds one byte per column of the slice, non-zero
+        // where the cell's background is default and content sitting below the
+        // background may therefore show through. It is empty when the slice has
+        // nothing below the background to draw.
+        [[nodiscard]] virtual HRESULT BeginRowImages(const ImageSlice& imageSlice, til::CoordType targetRow, til::CoordType viewportLeft, std::span<const uint8_t> defaultBackgroundMask) noexcept = 0;
+        [[nodiscard]] virtual HRESULT EndRowImages() noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintSelection(const til::rect& rect) noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintCursor(const CursorOptions& options) noexcept = 0;
         [[nodiscard]] virtual HRESULT UpdateDrawingBrushes(const TextAttribute& textAttributes, const RenderSettings& renderSettings, gsl::not_null<IRenderData*> pData, bool usingSoftFont, bool isSettingDefaultBrushes) noexcept = 0;

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -80,19 +80,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT PaintBackground() noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintBufferLine(std::span<const Cluster> clusters, til::point coord, bool fTrimLeft) noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintBufferGridLines(GridLineSet lines, COLORREF gridlineColor, COLORREF underlineColor, size_t cchLine, til::point coordTarget) noexcept = 0;
-        // A row's image content is painted around its text so that it can appear
-        // beneath it. Text painted between these two calls must end up above
-        // anything BeginRowImages drew and below anything EndRowImages draws.
-        //
-        // defaultBackgroundMask holds one byte per column of the slice, non-zero
-        // where the cell's background is default and content sitting below the
-        // background may therefore show through.
-        //
-        // cellBackgrounds holds that column's background color. Content painted
-        // between the background and the text has to be composited over it, so an
-        // engine that suppresses the text pass's background fill must lay the
-        // color down itself first. Both spans are empty when the slice has nothing
-        // to draw beneath the text.
         [[nodiscard]] virtual HRESULT BeginRowImages(const ImageSlice& imageSlice, til::CoordType targetRow, til::CoordType viewportLeft, std::span<const uint8_t> defaultBackgroundMask, std::span<const COLORREF> cellBackgrounds) noexcept = 0;
         [[nodiscard]] virtual HRESULT EndRowImages() noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintSelection(const til::rect& rect) noexcept = 0;

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -86,9 +86,14 @@ namespace Microsoft::Console::Render
         //
         // defaultBackgroundMask holds one byte per column of the slice, non-zero
         // where the cell's background is default and content sitting below the
-        // background may therefore show through. It is empty when the slice has
-        // nothing below the background to draw.
-        [[nodiscard]] virtual HRESULT BeginRowImages(const ImageSlice& imageSlice, til::CoordType targetRow, til::CoordType viewportLeft, std::span<const uint8_t> defaultBackgroundMask) noexcept = 0;
+        // background may therefore show through.
+        //
+        // cellBackgrounds holds that column's background color. Content painted
+        // between the background and the text has to be composited over it, so an
+        // engine that suppresses the text pass's background fill must lay the
+        // color down itself first. Both spans are empty when the slice has nothing
+        // to draw beneath the text.
+        [[nodiscard]] virtual HRESULT BeginRowImages(const ImageSlice& imageSlice, til::CoordType targetRow, til::CoordType viewportLeft, std::span<const uint8_t> defaultBackgroundMask, std::span<const COLORREF> cellBackgrounds) noexcept = 0;
         [[nodiscard]] virtual HRESULT EndRowImages() noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintSelection(const til::rect& rect) noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintCursor(const CursorOptions& options) noexcept = 0;

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -46,7 +46,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT BeginRowImages(const ImageSlice& imageSlice,
                                              til::CoordType targetRow,
                                              til::CoordType viewportLeft,
-                                             std::span<const uint8_t> defaultBackgroundMask) noexcept override;
+                                             std::span<const uint8_t> defaultBackgroundMask,
+                                             std::span<const COLORREF> cellBackgrounds) noexcept override;
         [[nodiscard]] HRESULT EndRowImages() noexcept override;
 
         [[nodiscard]] bool RequiresContinuousRedraw() noexcept override;

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -43,9 +43,11 @@ namespace Microsoft::Console::Render
                                                    const til::CoordType targetRow,
                                                    const til::CoordType viewportLeft) noexcept override;
 
-        [[nodiscard]] HRESULT PaintImageSlice(const ImageSlice& imageSlice,
-                                              const til::CoordType targetRow,
-                                              const til::CoordType viewportLeft) noexcept override;
+        [[nodiscard]] HRESULT BeginRowImages(const ImageSlice& imageSlice,
+                                             til::CoordType targetRow,
+                                             til::CoordType viewportLeft,
+                                             std::span<const uint8_t> defaultBackgroundMask) noexcept override;
+        [[nodiscard]] HRESULT EndRowImages() noexcept override;
 
         [[nodiscard]] bool RequiresContinuousRedraw() noexcept override;
 


### PR DESCRIPTION
| Stack | |
|---|---|
| #54 | Give `ImageSlice` identified, z-ordered layers |
| **&rarr; #55** | **Paint a row's images in z-order around its text** |
| #56 | Route APC strings to the engine by identifier |
| #57 | Add the Kitty graphics protocol to the VT adapter |
| #58 | Add Kitty graphics animation |
| #59 | Add file and shared-memory transmission |

## TL;DR

#54 gave `ImageSlice` three render positions. This teaches the renderer to paint them, so an image can sit *under* a row's text instead of always on top of it. The diff is renderer files only.

![Text stays readable through a z=-1 plane and is hidden under a z=+1 plane](https://github.com/user-attachments/assets/dcf71440-52de-4005-a98b-d984d6b7e75a)

Identical cells, identical text, opposite `z` — the top block's image is painted before the run of text, the bottom block's after it. Real capture from conhost built at this branch.

## Key changes

- **`PaintImageSlice` becomes a bracket:** `BeginRowImages(slice, row, left, defaultBackgroundMask)` and `EndRowImages()`. Both default to `S_FALSE` in `RenderEngineBase`, so the existing "engine doesn't support images" path is preserved.
- **A background mask.** `BehindBackground` means "under the cell background fill", but the renderer draws that fill as part of the text run — so the engine has to know which cells had a *default* background (paint the image, skip the fill) versus an explicit one (fill wins). `_buildDefaultBackgroundMask` computes one byte per column.
- Implemented across all four engines; `AtlasEngine` already draws row backgrounds in its own pass, so it takes the new span and ignores it, with a comment saying why.

## Notes for the rest of the stack

- **Two methods, not three.** The prototype used `PaintImageSlice(position, …)`, which put the *renderer* in charge of when each plane is drawn. That is the engine's business — D3D batches, D2D doesn't, GDI defers text. The renderer now only says "this row's images start here" and "the text is done"; each engine picks its own ordering, and an engine that doesn't care about z can implement one method and ignore the other.
- **The mask is a reusable member** (`Renderer::_backgroundMask`), not a fresh `std::vector` per row per frame like the prototype. Painting is the hot path; it shouldn't allocate.
- **The mask converts screen columns to buffer columns.** `ImageSlice` indexes screen columns and shifts by `<< scale` for any non-single-width rendition, while `ROW::GetAttrByColumn` is buffer-indexed — so a DECDWL row reads the attribute of the cell that is actually there.

## Four bugs the screenshots found

This section used to say the pixel behaviour was "reasoned, not measured". Measuring it broke that claim four times. All are fixed here, and every screenshot in this stack is a capture taken afterwards.

1. **GDI sat at the `OPAQUE` default.** `SetBkMode` appears nowhere in `src/renderer/gdi`, so `PolyTextOutW` filled the box behind every glyph — including spaces — regardless of `ETO_OPAQUE`. A full-width `z=-1` image was painted correctly and then erased by the row of blanks on top of it.
2. **`ETO_OPAQUE` is one flag per run, not per column.** Requiring an image to cover *every* column of a run meant the flag never dropped in practice, so a narrow image never showed at all. Replaced with per-column queries plus `_FillUncoveredRunBackground`.
   **1 and 2 masked each other** — fixing either alone still produced a blank probe, which is how an earlier pass talked itself into "ruled out".
3. **Partial alpha was masked, not blended.** The inherited `SRCAND`/`SRCPAINT` one-bit idiom is right for Sixel's all-or-nothing pixels and cannot express alpha at all — worse, the opacity test was `rgbReserved != 0`, so *any* alpha counted as fully opaque. Planes now go through `GdiAlphaBlend` with `AC_SRC_ALPHA`; they're already premultiplied, which is what that expects.

   ![An RGBA ramp fading to the magenta cell background behind it](https://github.com/user-attachments/assets/fc98bc94-f76e-4256-a809-a1ec79be55e1)

4. **An image erased the cell background it was supposed to sit on.** Withholding `ETO_OPAQUE` from the covered columns stops the *text* erasing the image, but what's left underneath is the default background `PaintBackground` laid over the whole frame — so transparent squares came out black instead of red. Fixed by filling those cells between the background and the text, the one window where the plane below the background is painted and the plane above it is not.

   | before | after |
   |---|---|
   | ![Transparent squares render black over a red background](https://github.com/user-attachments/assets/4b558fec-0914-49c0-944e-a59f60ecf18d) | ![Transparent squares render red, matching the block they sit on](https://github.com/user-attachments/assets/69f9f787-acdb-4a40-b1a1-fb4214104239) |

   This is narrower than it looks, which is why nothing caught it: it needs `z < 0` **and** an explicit SGR background on the same cell. Every sample in this stack had one or the other.

---

**Builds alone.** Built without any PR above it — zero C++ errors.