### PR TITLE
Route APC strings to the engine by identifier

### DIFF
--- a/src/terminal/parser/IStateMachineEngine.hpp
+++ b/src/terminal/parser/IStateMachineEngine.hpp
@@ -42,6 +42,7 @@ namespace Microsoft::Console::VirtualTerminal
         virtual bool ActionVt52EscDispatch(const VTID id, const VTParameters parameters) = 0;
         virtual bool ActionCsiDispatch(const VTID id, const VTParameters parameters) = 0;
         virtual StringHandler ActionDcsDispatch(const VTID id, const VTParameters parameters) = 0;
+        virtual StringHandler ActionApcDispatch(const VTID id) = 0;
         virtual bool ActionOscDispatch(const size_t parameter, const std::wstring_view string) = 0;
         virtual bool ActionSs3Dispatch(const wchar_t wch, const VTParameters parameters) = 0;
 

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -552,6 +552,23 @@ IStateMachineEngine::StringHandler InputStateMachineEngine::ActionDcsDispatch(co
 }
 
 // Routine Description:
+// - Triggers the ApcDispatch action to indicate that the listener should handle
+//      an application program command. Returns the handler function that is to
+//      be used to process the subsequent data string characters in the sequence.
+// Arguments:
+// - id - Identifier of the application the string is addressed to.
+// Return Value:
+// - the data string handler function or nullptr if the application is not supported
+IStateMachineEngine::StringHandler InputStateMachineEngine::ActionApcDispatch(const VTID /*id*/) noexcept
+{
+    // The input engine has no use for APC strings. Returning nullptr keeps the
+    // state machine ignoring them, exactly as it did before they were
+    // dispatched. Note that, unlike DCS, no string terminator is expected: an
+    // ignored APC is not buffered for a later flush.
+    return nullptr;
+}
+
+// Routine Description:
 // - Triggers the Ss3Dispatch action to indicate that the listener should handle
 //      a control sequence. These sequences perform various API-type commands
 //      that can include many parameters.

--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -186,6 +186,8 @@ namespace Microsoft::Console::VirtualTerminal
 
         StringHandler ActionDcsDispatch(const VTID id, const VTParameters parameters) noexcept override;
 
+        StringHandler ActionApcDispatch(const VTID id) noexcept override;
+
         bool ActionOscDispatch(const size_t parameter, const std::wstring_view string) noexcept override;
 
         bool ActionSs3Dispatch(const wchar_t wch, const VTParameters parameters) override;

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -753,6 +753,22 @@ IStateMachineEngine::StringHandler OutputStateMachineEngine::ActionDcsDispatch(c
 }
 
 // Routine Description:
+// - Triggers the ApcDispatch action to indicate that the listener should handle
+//      an application program command. Returns the handler function that is to
+//      be used to process the subsequent data string characters in the sequence.
+// Arguments:
+// - id - Identifier of the application the string is addressed to.
+// Return Value:
+// - the data string handler function or nullptr if the application is not supported
+IStateMachineEngine::StringHandler OutputStateMachineEngine::ActionApcDispatch(const VTID /*id*/) noexcept
+{
+    // No APC application is recognised yet. Returning nullptr leaves the state
+    // machine to ignore the string, which is what it did before APC strings
+    // were dispatched at all.
+    return nullptr;
+}
+
+// Routine Description:
 // - Triggers the OscDispatch action to indicate that the listener should handle a control sequence.
 //   These sequences perform various API-type commands that can include many parameters.
 // Arguments:

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -44,6 +44,8 @@ namespace Microsoft::Console::VirtualTerminal
 
         StringHandler ActionDcsDispatch(const VTID id, const VTParameters parameters) override;
 
+        StringHandler ActionApcDispatch(const VTID id) noexcept override;
+
         bool ActionOscDispatch(const size_t parameter, const std::wstring_view string) override;
 
         bool ActionSs3Dispatch(const wchar_t wch, const VTParameters parameters) noexcept override;

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -325,12 +325,15 @@ static constexpr bool _isDcsIndicator(const wchar_t wch) noexcept
 }
 
 // Routine Description:
-// - Determines if a character is valid for a DCS pass through sequence.
+// - Determines if a character is valid for a data string that is being passed
+//      through to a handler, whether that's a DCS or an APC. The content is
+//      defined by whatever consumes it, so the only constraint is that it is
+//      printable; control codes are dealt with separately.
 // Arguments:
 // - wch - Character to check.
 // Return Value:
 // - True if it is. False if it isn't.
-static constexpr bool _isDcsPassThroughValid(const wchar_t wch) noexcept
+static constexpr bool _isPassThroughValid(const wchar_t wch) noexcept
 {
     // 0x20 - 0x7E
     return wch >= AsciiChars::SPC && wch < AsciiChars::DEL;
@@ -628,6 +631,7 @@ void StateMachine::_ActionClear() noexcept
     _oscParameter = 0;
 
     _dcsStringHandler = nullptr;
+    _apcStringHandler = nullptr;
 }
 
 // Routine Description:
@@ -645,18 +649,27 @@ void StateMachine::_ActionIgnore() noexcept
 // Routine Description:
 // - Triggers the end of a data string when a CAN, SUB, or ESC is seen.
 // Arguments:
-// - <none>
+// - terminated - True when the string ended normally (an ESC, and so an ST),
+//                false when it was cancelled by a CAN or SUB.
 // Return Value:
 // - <none>
-void StateMachine::_ActionInterrupt()
+void StateMachine::_ActionInterrupt(const bool terminated)
 {
-    // This is only applicable for DCS strings. OSC strings require a full
-    // ST sequence to be received before they can be dispatched.
+    // This is only applicable for DCS and APC strings. OSC strings require a
+    // full ST sequence to be received before they can be dispatched.
     if (_state == VTStates::DcsPassThrough)
     {
         // The ESC signals the end of the data string.
         _dcsStringHandler(AsciiChars::ESC);
         _dcsStringHandler = nullptr;
+    }
+    else if (_state == VTStates::ApcPassThrough)
+    {
+        // An APC handler can be holding state that spans sequences, so it is
+        // told how the string ended rather than simply being dropped: ESC to
+        // finalize, CAN to abandon whatever it had accumulated.
+        _apcStringHandler(terminated ? AsciiChars::ESC : AsciiChars::CAN);
+        _apcStringHandler = nullptr;
     }
 }
 
@@ -745,6 +758,40 @@ void StateMachine::_ActionDcsDispatch(const wchar_t wch)
     {
         // Otherwise ignore remaining chars.
         _EnterDcsIgnore();
+    }
+}
+
+// Routine Description:
+// - Triggers the ApcDispatch action to indicate that the listener should handle
+//   an application program command. The leading character identifies which
+//   application the string is addressed to, in the same way a DCS is identified
+//   by its final byte; the engine decides whether it recognises it.
+//   The returned handler function will be used to process the rest of the string.
+// Arguments:
+// - wch - Character to dispatch.
+// Return Value:
+// - <none>
+void StateMachine::_ActionApcDispatch(const wchar_t wch)
+{
+    _trace.TraceOnAction(L"ApcDispatch");
+
+    const auto success = _SafeExecute([=]() {
+        _apcStringHandler = _engine->ActionApcDispatch(_identifier.Finalize(wch));
+        return true;
+    });
+
+    // Trace the result.
+    _trace.DispatchSequenceTrace(success);
+
+    if (_apcStringHandler)
+    {
+        _EnterApcPassThrough();
+    }
+    else
+    {
+        // Nothing claimed it, so it degrades to the string every APC used to
+        // be: reported as unknown, and otherwise ignored to its terminator.
+        _EnterSosPmApcString();
     }
 }
 
@@ -1049,6 +1096,37 @@ void StateMachine::_EnterSosPmApcString() noexcept
 }
 
 // Routine Description:
+// - Moves the state machine into the ApcEntry state.
+//   This state is entered:
+//   1. When the Apc character is seen after an Escape entry
+//   The next character identifies the application the string is addressed to.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void StateMachine::_EnterApcEntry() noexcept
+{
+    _state = VTStates::ApcEntry;
+    _cachedSequence.reset();
+    _trace.TraceStateChange(L"ApcEntry");
+}
+
+// Routine Description:
+// - Moves the state machine into the ApcPassThrough state.
+//   This state is entered:
+//   1. When an engine has claimed the APC string by returning a handler
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void StateMachine::_EnterApcPassThrough() noexcept
+{
+    _state = VTStates::ApcPassThrough;
+    _cachedSequence.reset();
+    _trace.TraceStateChange(L"ApcPassThrough");
+}
+
+// Routine Description:
 // - Processes a character event into an Action that occurs while in the Ground state.
 //   Events in this state will:
 //   1. Execute C0 control characters
@@ -1140,9 +1218,13 @@ void StateMachine::_EventEscape(const wchar_t wch)
         {
             _EnterDcsEntry();
         }
-        else if (_isSosIndicator(wch) || _isPmIndicator(wch) || _isApcIndicator(wch))
+        else if (_isSosIndicator(wch) || _isPmIndicator(wch))
         {
             _EnterSosPmApcString();
+        }
+        else if (_isApcIndicator(wch))
+        {
+            _EnterApcEntry();
         }
         else
         {
@@ -1803,7 +1885,7 @@ void StateMachine::_EventDcsParam(const wchar_t wch)
 void StateMachine::_EventDcsPassThrough(const wchar_t wch)
 {
     _trace.TraceOnEvent(L"DcsPassThrough");
-    if (_isC0Code(wch) || _isDcsPassThroughValid(wch))
+    if (_isC0Code(wch) || _isPassThroughValid(wch))
     {
         if (!_dcsStringHandler(wch))
         {
@@ -1831,6 +1913,92 @@ void StateMachine::_EventSosPmApcString(const wchar_t /*wch*/) noexcept
 }
 
 // Routine Description:
+// - Moves the state machine into the ApcIgnore state.
+//   This state is entered:
+//   1. When the handler that claimed an APC string gives up on the rest of it
+//   Unlike SosPmApcString, this does not report an unknown sequence: the string
+//   was recognised and claimed, the handler simply stopped wanting it.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void StateMachine::_EnterApcIgnore() noexcept
+{
+    _state = VTStates::ApcIgnore;
+    _cachedSequence.reset();
+    _trace.TraceStateChange(L"ApcIgnore");
+}
+
+// Routine Description:
+// - Processes a character event into an Action that occurs while in the ApcEntry state.
+//   Events in this state will:
+//   1. Ignore C0 control characters and DEL, exactly as DcsEntry does.
+//   2. Dispatch any other character as the identifier of the application that
+//      the string is addressed to, so an engine can claim it.
+// Arguments:
+// - wch - Character that triggered the event
+// Return Value:
+// - <none>
+void StateMachine::_EventApcEntry(const wchar_t wch)
+{
+    _trace.TraceOnEvent(L"ApcEntry");
+    if (_isC0Code(wch) || _isDelete(wch))
+    {
+        _ActionIgnore();
+    }
+    else
+    {
+        _ActionApcDispatch(wch);
+    }
+}
+
+// Routine Description:
+// - Processes a character event into an Action that occurs while in the
+//   ApcPassThrough state.
+//   Events in this state will:
+//   1. Pass through if character is valid.
+//   2. Ignore everything else.
+//   A handler that declines a character gives up the rest of the string.
+//   The termination state is handled outside when an ESC is seen.
+// Arguments:
+// - wch - Character that triggered the event
+// Return Value:
+// - <none>
+void StateMachine::_EventApcPassThrough(const wchar_t wch)
+{
+    _trace.TraceOnEvent(L"ApcPassThrough");
+    if (_isC0Code(wch) || _isPassThroughValid(wch))
+    {
+        if (!_apcStringHandler(wch))
+        {
+            // The handler has given up on the rest of the string. Drop it,
+            // without reporting it as unknown - it was claimed and processed,
+            // the handler just stopped wanting more of it.
+            _apcStringHandler = nullptr;
+            _EnterApcIgnore();
+        }
+    }
+    else
+    {
+        _ActionIgnore();
+    }
+}
+
+// Routine Description:
+// - Processes a character event into an Action that occurs while in the ApcIgnore state.
+//   In this state the rest of the APC string is discarded.
+//   The termination state is handled outside when an ESC is seen.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void StateMachine::_EventApcIgnore() noexcept
+{
+    _trace.TraceOnEvent(L"ApcIgnore");
+    _ActionIgnore();
+}
+
+// Routine Description:
 // - Entry to the state machine. Takes characters one by one and processes them according to the state machine rules.
 // Arguments:
 // - wch - New character to operate upon
@@ -1849,7 +2017,7 @@ void StateMachine::ProcessCharacter(const wchar_t wch)
     // these from any state.
     if (isFromAnywhereChar && !(_state == VTStates::Escape && _isEngineForInput))
     {
-        _ActionInterrupt();
+        _ActionInterrupt(false);
         _ActionExecute(wch);
         _EnterGround();
     }
@@ -1870,7 +2038,7 @@ void StateMachine::ProcessCharacter(const wchar_t wch)
     // Don't go to escape from the OSC string/param states - ESC can be used to terminate OSC strings.
     else if (_isEscape(wch) && _state != VTStates::OscString && _state != VTStates::OscParam)
     {
-        _ActionInterrupt();
+        _ActionInterrupt(true);
         _EnterEscape();
     }
     else
@@ -1918,6 +2086,12 @@ void StateMachine::ProcessCharacter(const wchar_t wch)
             return _EventDcsPassThrough(wch);
         case VTStates::SosPmApcString:
             return _EventSosPmApcString(wch);
+        case VTStates::ApcEntry:
+            return _EventApcEntry(wch);
+        case VTStates::ApcPassThrough:
+            return _EventApcPassThrough(wch);
+        case VTStates::ApcIgnore:
+            return _EventApcIgnore();
         default:
             return;
         }
@@ -2073,11 +2247,16 @@ void StateMachine::ProcessString(const std::wstring_view string)
                 cacheUnusedRun = false;
             }
         }
-        else if (_state == VTStates::SosPmApcString || _state == VTStates::DcsPassThrough || _state == VTStates::DcsIgnore)
+        else if (_state == VTStates::SosPmApcString || _state == VTStates::ApcEntry || _state == VTStates::ApcPassThrough || _state == VTStates::ApcIgnore || _state == VTStates::DcsPassThrough || _state == VTStates::DcsIgnore)
         {
             // There is no need to cache the run if we've reached one of the
             // string processing states in the output engine, since that data
             // will be dealt with as soon as it is received.
+            // ApcEntry is included because FlushToTerminal can never run from
+            // there - _ActionApcDispatch's lambda always succeeds - and on main
+            // an APC introducer went straight to SosPmApcString, which didn't
+            // cache either. Leaving it out would let ESC _ followed by a long
+            // run of control codes accumulate without bound.
             cacheUnusedRun = false;
         }
 

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -791,7 +791,7 @@ void StateMachine::_ActionApcDispatch(const wchar_t wch)
     {
         // Nothing claimed it, so it degrades to the string every APC used to
         // be: reported as unknown, and otherwise ignored to its terminator.
-        _EnterSosPmApcString();
+        _EnterSosPmString();
     }
 }
 
@@ -1078,7 +1078,7 @@ void StateMachine::_EnterDcsPassThrough() noexcept
 }
 
 // Routine Description:
-// - Moves the state machine into the SosPmApcString state.
+// - Moves the state machine into the SosPmString state.
 //   This state is entered:
 //   1. When the Sos character is seen after an Escape entry
 //   2. When the Pm character is seen after an Escape entry
@@ -1087,12 +1087,12 @@ void StateMachine::_EnterDcsPassThrough() noexcept
 // - <none>
 // Return Value:
 // - <none>
-void StateMachine::_EnterSosPmApcString() noexcept
+void StateMachine::_EnterSosPmString() noexcept
 {
-    _state = VTStates::SosPmApcString;
+    _state = VTStates::SosPmString;
     _cachedSequence.reset();
     _engine->UnknownSequence();
-    _trace.TraceStateChange(L"SosPmApcString");
+    _trace.TraceStateChange(L"SosPmString");
 }
 
 // Routine Description:
@@ -1220,7 +1220,7 @@ void StateMachine::_EventEscape(const wchar_t wch)
         }
         else if (_isSosIndicator(wch) || _isPmIndicator(wch))
         {
-            _EnterSosPmApcString();
+            _EnterSosPmString();
         }
         else if (_isApcIndicator(wch))
         {
@@ -1906,9 +1906,9 @@ void StateMachine::_EventDcsPassThrough(const wchar_t wch)
 // - wch - Character that triggered the event
 // Return Value:
 // - <none>
-void StateMachine::_EventSosPmApcString(const wchar_t /*wch*/) noexcept
+void StateMachine::_EventSosPmString(const wchar_t /*wch*/) noexcept
 {
-    _trace.TraceOnEvent(L"SosPmApcString");
+    _trace.TraceOnEvent(L"SosPmString");
     _ActionIgnore();
 }
 
@@ -1916,7 +1916,7 @@ void StateMachine::_EventSosPmApcString(const wchar_t /*wch*/) noexcept
 // - Moves the state machine into the ApcIgnore state.
 //   This state is entered:
 //   1. When the handler that claimed an APC string gives up on the rest of it
-//   Unlike SosPmApcString, this does not report an unknown sequence: the string
+//   Unlike SosPmString, this does not report an unknown sequence: the string
 //   was recognised and claimed, the handler simply stopped wanting it.
 // Arguments:
 // - <none>
@@ -2083,8 +2083,8 @@ void StateMachine::ProcessCharacter(const wchar_t wch)
             return _EventDcsParam(wch);
         case VTStates::DcsPassThrough:
             return _EventDcsPassThrough(wch);
-        case VTStates::SosPmApcString:
-            return _EventSosPmApcString(wch);
+        case VTStates::SosPmString:
+            return _EventSosPmString(wch);
         case VTStates::ApcEntry:
             return _EventApcEntry(wch);
         case VTStates::ApcPassThrough:
@@ -2246,16 +2246,15 @@ void StateMachine::ProcessString(const std::wstring_view string)
                 cacheUnusedRun = false;
             }
         }
-        else if (_state == VTStates::SosPmApcString || _state == VTStates::ApcEntry || _state == VTStates::ApcPassThrough || _state == VTStates::ApcIgnore || _state == VTStates::DcsPassThrough || _state == VTStates::DcsIgnore)
+        else if (_state == VTStates::SosPmString || _state == VTStates::ApcEntry || _state == VTStates::ApcPassThrough || _state == VTStates::ApcIgnore || _state == VTStates::DcsPassThrough || _state == VTStates::DcsIgnore)
         {
             // There is no need to cache the run if we've reached one of the
             // string processing states in the output engine, since that data
             // will be dealt with as soon as it is received.
             // ApcEntry is included because FlushToTerminal can never run from
-            // there - _ActionApcDispatch's lambda always succeeds - and on main
-            // an APC introducer went straight to SosPmApcString, which didn't
-            // cache either. Leaving it out would let ESC _ followed by a long
-            // run of control codes accumulate without bound.
+            // there - _ActionApcDispatch's lambda always succeeds - so leaving it
+            // out would let ESC _ followed by a long run of control codes
+            // accumulate without bound.
             cacheUnusedRun = false;
         }
 

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -1967,20 +1967,19 @@ void StateMachine::_EventApcEntry(const wchar_t wch)
 void StateMachine::_EventApcPassThrough(const wchar_t wch)
 {
     _trace.TraceOnEvent(L"ApcPassThrough");
-    if (_isC0Code(wch) || _isPassThroughValid(wch))
+    // An APC string is application data: the parser has no idea what encoding
+    // the receiving handler expects, so every character is handed over intact.
+    // Dropping the ones that don't look like text would leave the handler unable
+    // to tell a malformed string from one that was never sent, and it would
+    // report the wrong error. C0 and C1 controls are the only characters with
+    // parser-level meaning, and those are dealt with before we get here.
+    if (!_apcStringHandler(wch))
     {
-        if (!_apcStringHandler(wch))
-        {
-            // The handler has given up on the rest of the string. Drop it,
-            // without reporting it as unknown - it was claimed and processed,
-            // the handler just stopped wanting more of it.
-            _apcStringHandler = nullptr;
-            _EnterApcIgnore();
-        }
-    }
-    else
-    {
-        _ActionIgnore();
+        // The handler has given up on the rest of the string. Drop it,
+        // without reporting it as unknown - it was claimed and processed,
+        // the handler just stopped wanting more of it.
+        _apcStringHandler = nullptr;
+        _EnterApcIgnore();
     }
 }
 

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -109,10 +109,11 @@ namespace Microsoft::Console::VirtualTerminal
         void _ActionOscDispatch();
         void _ActionSs3Dispatch(const wchar_t wch);
         void _ActionDcsDispatch(const wchar_t wch);
+        void _ActionApcDispatch(const wchar_t wch);
 
         void _ActionClear() noexcept;
         void _ActionIgnore() noexcept;
-        void _ActionInterrupt();
+        void _ActionInterrupt(const bool terminated);
 
         void _EnterGround() noexcept;
         void _EnterEscape() noexcept;
@@ -134,6 +135,9 @@ namespace Microsoft::Console::VirtualTerminal
         void _EnterDcsIntermediate() noexcept;
         void _EnterDcsPassThrough() noexcept;
         void _EnterSosPmApcString() noexcept;
+        void _EnterApcEntry() noexcept;
+        void _EnterApcPassThrough() noexcept;
+        void _EnterApcIgnore() noexcept;
 
         void _EventGround(const wchar_t wch);
         void _EventEscape(const wchar_t wch);
@@ -155,6 +159,9 @@ namespace Microsoft::Console::VirtualTerminal
         void _EventDcsParam(const wchar_t wch);
         void _EventDcsPassThrough(const wchar_t wch);
         void _EventSosPmApcString(const wchar_t wch) noexcept;
+        void _EventApcEntry(const wchar_t wch);
+        void _EventApcPassThrough(const wchar_t wch);
+        void _EventApcIgnore() noexcept;
 
         void _AccumulateTo(const wchar_t wch, VTInt& value) noexcept;
 
@@ -184,7 +191,10 @@ namespace Microsoft::Console::VirtualTerminal
             DcsIntermediate,
             DcsParam,
             DcsPassThrough,
-            SosPmApcString
+            SosPmApcString,
+            ApcEntry,
+            ApcPassThrough,
+            ApcIgnore
         };
 
         Microsoft::Console::VirtualTerminal::ParserTracing _trace;
@@ -221,6 +231,7 @@ namespace Microsoft::Console::VirtualTerminal
         VTInt _oscParameter;
 
         IStateMachineEngine::StringHandler _dcsStringHandler;
+        IStateMachineEngine::StringHandler _apcStringHandler;
 
         std::optional<std::wstring> _cachedSequence;
         til::small_vector<Injection, 8> _injections;

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -134,7 +134,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _EnterDcsIgnore() noexcept;
         void _EnterDcsIntermediate() noexcept;
         void _EnterDcsPassThrough() noexcept;
-        void _EnterSosPmApcString() noexcept;
+        void _EnterSosPmString() noexcept;
         void _EnterApcEntry() noexcept;
         void _EnterApcPassThrough() noexcept;
         void _EnterApcIgnore() noexcept;
@@ -158,7 +158,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _EventDcsIntermediate(const wchar_t wch);
         void _EventDcsParam(const wchar_t wch);
         void _EventDcsPassThrough(const wchar_t wch);
-        void _EventSosPmApcString(const wchar_t wch) noexcept;
+        void _EventSosPmString(const wchar_t wch) noexcept;
         void _EventApcEntry(const wchar_t wch);
         void _EventApcPassThrough(const wchar_t wch);
         void _EventApcIgnore() noexcept;
@@ -191,7 +191,7 @@ namespace Microsoft::Console::VirtualTerminal
             DcsIntermediate,
             DcsParam,
             DcsPassThrough,
-            SosPmApcString,
+            SosPmString,
             ApcEntry,
             ApcPassThrough,
             ApcIgnore

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -175,8 +175,8 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         }
         case 17:
         {
-            Log::Comment(L"Escape from SosPmApcString");
-            mach._state = StateMachine::VTStates::SosPmApcString;
+            Log::Comment(L"Escape from SosPmString");
+            mach._state = StateMachine::VTStates::SosPmString;
             break;
         }
         case 18:
@@ -864,7 +864,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L'G');
         // The output engine claims no APC application, so the string falls back
         // to being ignored, exactly as it was before APC was dispatched.
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(AsciiChars::ESC);
         mach.ProcessCharacter(L'\\');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
@@ -883,7 +883,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         // control codes. FlushToTerminal can't run from there, so caching the
         // run would grow without bound for as long as the stream continues.
         // Before APC was dispatched, the introducer went straight to
-        // SosPmApcString and nothing was cached at all.
+        // SosPmString and nothing was cached at all.
         for (auto i = 0; i < 16; i++)
         {
             mach.ProcessString(std::wstring(64, L'\n'));
@@ -893,7 +893,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
 
         // The same is true once the string is under way.
         mach.ProcessString(L"G");
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessString(L"a long payload that nobody claimed");
         VERIFY_IS_FALSE(mach._cachedSequence.has_value());
 
@@ -1058,7 +1058,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
     }
 
-    TEST_METHOD(TestSosPmApcString)
+    TEST_METHOD(TestSosPmString)
     {
         auto dispatch = std::make_unique<DummyDispatch>();
         auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
@@ -1068,11 +1068,11 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'X');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(L'1');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(L'2');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'\\');
@@ -1081,11 +1081,11 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'^');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(L'3');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(L'4');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'\\');
@@ -1096,9 +1096,9 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L'_');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::ApcEntry);
         mach.ProcessCharacter(L'5');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(L'6');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'\\');
@@ -1146,18 +1146,18 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'X');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(L'1');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(L'\x9c');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
 
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'^');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(L'2');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(L'\x9c');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
 
@@ -1166,7 +1166,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L'_');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::ApcEntry);
         mach.ProcessCharacter(L'3');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmString);
         mach.ProcessCharacter(L'\x9c');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
     }

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -52,7 +52,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
     TEST_METHOD(TestEscapePath)
     {
         BEGIN_TEST_METHOD_PROPERTIES()
-            TEST_METHOD_PROPERTY(L"Data:uiTest", L"{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17}") // one value for each type of state test below.
+            TEST_METHOD_PROPERTY(L"Data:uiTest", L"{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20}") // one value for each type of state test below.
         END_TEST_METHOD_PROPERTIES()
 
         size_t uiTest;
@@ -177,6 +177,25 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         {
             Log::Comment(L"Escape from SosPmApcString");
             mach._state = StateMachine::VTStates::SosPmApcString;
+            break;
+        }
+        case 18:
+        {
+            Log::Comment(L"Escape from ApcEntry");
+            mach._state = StateMachine::VTStates::ApcEntry;
+            break;
+        }
+        case 19:
+        {
+            Log::Comment(L"Escape from ApcPassThrough");
+            mach._state = StateMachine::VTStates::ApcPassThrough;
+            mach._apcStringHandler = [](const auto) { return true; };
+            break;
+        }
+        case 20:
+        {
+            Log::Comment(L"Escape from ApcIgnore");
+            mach._state = StateMachine::VTStates::ApcIgnore;
             break;
         }
         }
@@ -830,6 +849,59 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
     }
 
+    TEST_METHOD(TestC1ApcEntry)
+    {
+        auto dispatch = std::make_unique<DummyDispatch>();
+        auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
+        StateMachine mach(std::move(engine));
+
+        // Enable the acceptance of C1 control codes in the state machine.
+        mach.SetParserMode(StateMachine::Mode::AcceptC1, true);
+
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
+        mach.ProcessCharacter(L'\x9f');
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::ApcEntry);
+        mach.ProcessCharacter(L'G');
+        // The output engine claims no APC application, so the string falls back
+        // to being ignored, exactly as it was before APC was dispatched.
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        mach.ProcessCharacter(AsciiChars::ESC);
+        mach.ProcessCharacter(L'\\');
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
+    }
+
+    TEST_METHOD(TestApcEntryDoesNotCacheIgnoredRuns)
+    {
+        auto dispatch = std::make_unique<DummyDispatch>();
+        auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
+        StateMachine mach(std::move(engine));
+
+        mach.ProcessString(L"\x1b_");
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::ApcEntry);
+
+        // An APC that never produces an identifier sits in ApcEntry skipping
+        // control codes. FlushToTerminal can't run from there, so caching the
+        // run would grow without bound for as long as the stream continues.
+        // Before APC was dispatched, the introducer went straight to
+        // SosPmApcString and nothing was cached at all.
+        for (auto i = 0; i < 16; i++)
+        {
+            mach.ProcessString(std::wstring(64, L'\n'));
+        }
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::ApcEntry);
+        VERIFY_IS_FALSE(mach._cachedSequence.has_value());
+
+        // The same is true once the string is under way.
+        mach.ProcessString(L"G");
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        mach.ProcessString(L"a long payload that nobody claimed");
+        VERIFY_IS_FALSE(mach._cachedSequence.has_value());
+
+        mach.ProcessCharacter(AsciiChars::ESC);
+        mach.ProcessCharacter(L'\\');
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
+    }
+
     TEST_METHOD(TestDcsImmediate)
     {
         auto dispatch = std::make_unique<DummyDispatch>();
@@ -1022,7 +1094,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'_');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::ApcEntry);
         mach.ProcessCharacter(L'5');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
         mach.ProcessCharacter(L'6');
@@ -1092,7 +1164,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'_');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::ApcEntry);
         mach.ProcessCharacter(L'3');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
         mach.ProcessCharacter(L'\x9c');

--- a/src/terminal/parser/ut_parser/StateMachineTest.cpp
+++ b/src/terminal/parser/ut_parser/StateMachineTest.cpp
@@ -199,6 +199,7 @@ class Microsoft::Console::VirtualTerminal::StateMachineTest
     TEST_METHOD(ApcWithoutAnIdentifierIsIgnored);
     TEST_METHOD(ApcEntryIgnoresControlCharacters);
     TEST_METHOD(ApcDataStringSplitAcrossWrites);
+    TEST_METHOD(ApcDataStringIsOpaqueToTheParser);
 
     TEST_METHOD(VtParameterSubspanTest);
 };
@@ -538,6 +539,22 @@ void StateMachineTest::ApcDataStringSplitAcrossWrites()
 
     VERIFY_ARE_EQUAL(size_t{ 1 }, engine.apcDispatchCount);
     VERIFY_ARE_EQUAL(L"printed text", engine.printed);
+}
+
+void StateMachineTest::ApcDataStringIsOpaqueToTheParser()
+{
+    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+    auto& engine{ *enginePtr.get() };
+    StateMachine machine{ std::move(enginePtr) };
+
+    // An APC string is application data in an encoding only its handler knows.
+    // The parser must not filter it down to what looks like text: a handler that
+    // is silently handed a shortened string cannot tell a malformed payload from
+    // one that was never sent, and will report the wrong thing back to the app.
+    machine.ProcessString(L"\033_Gok\u00FF\u2603\uFFFD\x7Fdone\033\\");
+    VERIFY_ARE_EQUAL(VTID("G"), engine.apcId);
+    VERIFY_ARE_EQUAL(L"ok\u00FF\u2603\uFFFD\x7Fdone\033", engine.apcDataString);
+    VERIFY_ARE_EQUAL(size_t{ 1 }, engine.apcDispatchCount);
 }
 
 void StateMachineTest::ApcWithoutAnIdentifierIsIgnored()

--- a/src/terminal/parser/ut_parser/StateMachineTest.cpp
+++ b/src/terminal/parser/ut_parser/StateMachineTest.cpp
@@ -38,10 +38,17 @@ public:
         dcsId = 0;
         dcsParams.clear();
         dcsDataString.clear();
+        apcAccepted = true;
+        apcAcceptLimit = SIZE_MAX;
+        apcDispatchCount = 0;
+        apcId = 0;
+        apcDataString.clear();
+        unknownSequenceCount = 0;
     }
 
     void UnknownSequence() noexcept override
     {
+        unknownSequenceCount++;
     }
 
     bool EncounteredWin32InputModeSequence() const noexcept override
@@ -116,6 +123,21 @@ public:
         return [=](const auto ch) { dcsDataString += ch; return true; };
     }
 
+    IStateMachineEngine::StringHandler ActionApcDispatch(const VTID id) override
+    {
+        apcDispatchCount++;
+        apcId = id;
+        apcDataString.clear();
+        if (!apcAccepted)
+        {
+            return nullptr;
+        }
+        return [=](const auto ch) {
+            apcDataString += ch;
+            return apcDataString.size() < apcAcceptLimit;
+        };
+    }
+
     // These will only be populated if ActionCsiDispatch is called.
     uint64_t csiId = 0;
     std::vector<size_t> csiParams;
@@ -136,6 +158,15 @@ public:
     uint64_t dcsId = 0;
     std::vector<size_t> dcsParams;
     std::wstring dcsDataString;
+
+    // Controls how ActionApcDispatch responds, and records what it saw.
+    bool apcAccepted = true;
+    size_t apcAcceptLimit = SIZE_MAX;
+    size_t apcDispatchCount = 0;
+    uint64_t apcId = 0;
+    std::wstring apcDataString;
+
+    size_t unknownSequenceCount = 0;
 };
 
 class Microsoft::Console::VirtualTerminal::StateMachineTest
@@ -160,6 +191,14 @@ class Microsoft::Console::VirtualTerminal::StateMachineTest
     TEST_METHOD(PassThroughUnhandledSplitAcrossWrites);
 
     TEST_METHOD(DcsDataStringsReceivedByHandler);
+
+    TEST_METHOD(ApcDataStringsReceivedByHandler);
+    TEST_METHOD(ApcIdentifiersAreRoutedToTheEngine);
+    TEST_METHOD(ApcDeclinedByEngineIsIgnored);
+    TEST_METHOD(ApcHandlerCanEndTheStringEarly);
+    TEST_METHOD(ApcWithoutAnIdentifierIsIgnored);
+    TEST_METHOD(ApcEntryIgnoresControlCharacters);
+    TEST_METHOD(ApcDataStringSplitAcrossWrites);
 
     TEST_METHOD(VtParameterSubspanTest);
 };
@@ -341,6 +380,195 @@ void StateMachineTest::DcsDataStringsReceivedByHandler()
 
     // Verify the control characters were executed (if expected).
     VERIFY_ARE_EQUAL(expectedExecuted, engine.executed);
+}
+
+void StateMachineTest::ApcDataStringsReceivedByHandler()
+{
+    BEGIN_TEST_METHOD_PROPERTIES()
+        TEST_METHOD_PROPERTY(L"Data:terminatorType", L"{ 0, 1, 2, 3 }")
+    END_TEST_METHOD_PROPERTIES()
+
+    size_t terminatorType;
+    VERIFY_SUCCEEDED(TestData::TryGetValue(L"terminatorType", terminatorType));
+
+    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+    // this dance is required because StateMachine presumes to take ownership of its engine.
+    auto& engine{ *enginePtr.get() };
+    StateMachine machine{ std::move(enginePtr) };
+
+    uint64_t expectedCsiId = 0;
+    std::wstring expectedExecuted = L"";
+    // Unlike DCS, an APC handler is told how the string ended, so it can
+    // distinguish "commit what you have" from "throw it away".
+    std::wstring expectedFinalCharacter = L"\033";
+
+    std::wstring terminatorString;
+    switch (terminatorType)
+    {
+    case 0:
+        Log::Comment(L"Data string terminated with ST");
+        terminatorString = L"\033\\";
+        break;
+    case 1:
+        Log::Comment(L"Data string terminated with CSI sequence");
+        terminatorString = L"\033[m";
+        expectedCsiId = VTID(L'm');
+        break;
+    case 2:
+        Log::Comment(L"Data string cancelled with CAN");
+        terminatorString = L"\030";
+        expectedExecuted = L"\030";
+        expectedFinalCharacter = L"\030";
+        break;
+    case 3:
+        Log::Comment(L"Data string cancelled with SUB");
+        terminatorString = L"\032";
+        expectedExecuted = L"\032";
+        expectedFinalCharacter = L"\030";
+        break;
+    }
+
+    // Output an APC sequence terminated with the current test string
+    machine.ProcessString(L"\033_Gdata string");
+    machine.ProcessString(terminatorString);
+    machine.ProcessString(L"printed text");
+
+    // Verify the application identifier is received.
+    VERIFY_ARE_EQUAL(VTID("G"), engine.apcId);
+
+    // Verify that the data string is received, along with the character that
+    // ended it. Note the identifier is not repeated in the data.
+    VERIFY_ARE_EQUAL(L"data string" + expectedFinalCharacter, engine.apcDataString);
+
+    // Verify the characters following the sequence are printed.
+    VERIFY_ARE_EQUAL(L"printed text", engine.printed);
+
+    // Verify the CSI sequence was received (if expected).
+    VERIFY_ARE_EQUAL(expectedCsiId, engine.csiId);
+
+    // Verify the control characters were executed (if expected).
+    VERIFY_ARE_EQUAL(expectedExecuted, engine.executed);
+}
+
+void StateMachineTest::ApcIdentifiersAreRoutedToTheEngine()
+{
+    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+    auto& engine{ *enginePtr.get() };
+    StateMachine machine{ std::move(enginePtr) };
+
+    // The character after the APC introducer names the application the string
+    // is addressed to, in the same way a DCS is identified by its final byte.
+    // Two different applications must not be confused for each other.
+    machine.ProcessString(L"\033_Gfirst\033\\");
+    VERIFY_ARE_EQUAL(VTID("G"), engine.apcId);
+    VERIFY_ARE_EQUAL(L"first\033", engine.apcDataString);
+
+    machine.ProcessString(L"\033_Qsecond\033\\");
+    VERIFY_ARE_EQUAL(VTID("Q"), engine.apcId);
+    VERIFY_ARE_EQUAL(L"second\033", engine.apcDataString);
+
+    VERIFY_ARE_EQUAL(size_t{ 2 }, engine.apcDispatchCount);
+    VERIFY_ARE_EQUAL(L"", engine.printed);
+}
+
+void StateMachineTest::ApcDeclinedByEngineIsIgnored()
+{
+    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+    auto& engine{ *enginePtr.get() };
+    StateMachine machine{ std::move(enginePtr) };
+
+    // An engine that doesn't recognise the application returns no handler. The
+    // string then behaves exactly as it did before APC was dispatched at all:
+    // swallowed up to its terminator, with nothing printed.
+    engine.apcAccepted = false;
+    machine.ProcessString(L"\033_Zdata string\033\\printed text");
+
+    VERIFY_ARE_EQUAL(VTID("Z"), engine.apcId);
+    VERIFY_ARE_EQUAL(size_t{ 1 }, engine.apcDispatchCount);
+    VERIFY_ARE_EQUAL(L"", engine.apcDataString);
+    VERIFY_ARE_EQUAL(L"printed text", engine.printed);
+    // Nobody claimed it, so it really was an unknown sequence - the same thing
+    // that was reported before APC strings were dispatched at all.
+    VERIFY_ARE_EQUAL(size_t{ 1 }, engine.unknownSequenceCount);
+
+    // And the parser is genuinely back in a good state afterwards.
+    engine.apcAccepted = true;
+    machine.ProcessString(L"\033_Gagain\033\\");
+    VERIFY_ARE_EQUAL(VTID("G"), engine.apcId);
+    VERIFY_ARE_EQUAL(L"again\033", engine.apcDataString);
+}
+
+void StateMachineTest::ApcHandlerCanEndTheStringEarly()
+{
+    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+    auto& engine{ *enginePtr.get() };
+    StateMachine machine{ std::move(enginePtr) };
+
+    // A handler that returns false has given up on the rest of the string. It
+    // must not be called again, and the remainder must not reach the screen.
+    engine.apcAcceptLimit = 4;
+    machine.ProcessString(L"\033_Gdata string\033\\printed text");
+
+    VERIFY_ARE_EQUAL(L"data", engine.apcDataString);
+    VERIFY_ARE_EQUAL(L"printed text", engine.printed);
+    // The string was recognised and claimed, so it is not an unknown sequence.
+    // Reporting one would tell conhost its cursor position may be wrong and
+    // force a needless ConPTY resync.
+    VERIFY_ARE_EQUAL(size_t{ 0 }, engine.unknownSequenceCount);
+}
+
+void StateMachineTest::ApcDataStringSplitAcrossWrites()
+{
+    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+    auto& engine{ *enginePtr.get() };
+    StateMachine machine{ std::move(enginePtr) };
+
+    // A payload can be arbitrarily long, so it arrives across several writes.
+    // Each one must reach the handler as it is received rather than being
+    // buffered up in the state machine waiting for a terminator.
+    machine.ProcessString(L"\033_Gdata");
+    VERIFY_ARE_EQUAL(VTID("G"), engine.apcId);
+    VERIFY_ARE_EQUAL(L"data", engine.apcDataString);
+
+    machine.ProcessString(L" and more");
+    VERIFY_ARE_EQUAL(L"data and more", engine.apcDataString);
+
+    machine.ProcessString(L"\033\\printed text");
+    VERIFY_ARE_EQUAL(L"data and more\033", engine.apcDataString);
+
+    VERIFY_ARE_EQUAL(size_t{ 1 }, engine.apcDispatchCount);
+    VERIFY_ARE_EQUAL(L"printed text", engine.printed);
+}
+
+void StateMachineTest::ApcWithoutAnIdentifierIsIgnored()
+{
+    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+    auto& engine{ *enginePtr.get() };
+    StateMachine machine{ std::move(enginePtr) };
+
+    // There is nothing to route on, so no engine is asked, and the string is
+    // dropped when its terminator arrives.
+    machine.ProcessString(L"\033_\033\\printed text");
+
+    VERIFY_ARE_EQUAL(size_t{ 0 }, engine.apcDispatchCount);
+    VERIFY_ARE_EQUAL(L"printed text", engine.printed);
+}
+
+void StateMachineTest::ApcEntryIgnoresControlCharacters()
+{
+    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+    auto& engine{ *enginePtr.get() };
+    StateMachine machine{ std::move(enginePtr) };
+
+    // A control character can't name an application, so it's skipped while we
+    // wait for one that can - the same thing DcsEntry does with them.
+    machine.ProcessString(L"\033_\a\177Gdata string\033\\");
+
+    VERIFY_ARE_EQUAL(VTID("G"), engine.apcId);
+    VERIFY_ARE_EQUAL(size_t{ 1 }, engine.apcDispatchCount);
+    VERIFY_ARE_EQUAL(L"data string\033", engine.apcDataString);
+    VERIFY_ARE_EQUAL(L"", engine.printed);
+    VERIFY_ARE_EQUAL(L"", engine.executed);
 }
 
 void StateMachineTest::VtParameterSubspanTest()

--- a/src/terminal/parser/ut_parser/StateMachineTest.cpp
+++ b/src/terminal/parser/ut_parser/StateMachineTest.cpp
@@ -194,10 +194,8 @@ class Microsoft::Console::VirtualTerminal::StateMachineTest
 
     TEST_METHOD(ApcDataStringsReceivedByHandler);
     TEST_METHOD(ApcIdentifiersAreRoutedToTheEngine);
-    TEST_METHOD(ApcDeclinedByEngineIsIgnored);
-    TEST_METHOD(ApcHandlerCanEndTheStringEarly);
-    TEST_METHOD(ApcWithoutAnIdentifierIsIgnored);
-    TEST_METHOD(ApcEntryIgnoresControlCharacters);
+    TEST_METHOD(ApcHandlerRejectionBehavior);
+    TEST_METHOD(ApcEntryRoutingBehavior);
     TEST_METHOD(ApcDataStringSplitAcrossWrites);
     TEST_METHOD(ApcDataStringIsOpaqueToTheParser);
 
@@ -472,50 +470,55 @@ void StateMachineTest::ApcIdentifiersAreRoutedToTheEngine()
     VERIFY_ARE_EQUAL(L"", engine.printed);
 }
 
-void StateMachineTest::ApcDeclinedByEngineIsIgnored()
+void StateMachineTest::ApcHandlerRejectionBehavior()
 {
-    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
-    auto& engine{ *enginePtr.get() };
-    StateMachine machine{ std::move(enginePtr) };
+    // A handler can bail out of a string in two ways, and they report different
+    // things back to the app. Declining outright leaves the sequence unclaimed -
+    // an unknown sequence, just as before APC was dispatched at all. Claiming and
+    // then stopping early keeps ownership, so nothing is reported.
+    {
+        auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+        auto& engine{ *enginePtr.get() };
+        StateMachine machine{ std::move(enginePtr) };
 
-    // An engine that doesn't recognise the application returns no handler. The
-    // string then behaves exactly as it did before APC was dispatched at all:
-    // swallowed up to its terminator, with nothing printed.
-    engine.apcAccepted = false;
-    machine.ProcessString(L"\033_Zdata string\033\\printed text");
+        // An engine that doesn't recognise the application returns no handler. The
+        // string then behaves exactly as it did before APC was dispatched at all:
+        // swallowed up to its terminator, with nothing printed.
+        engine.apcAccepted = false;
+        machine.ProcessString(L"\033_Zdata string\033\\printed text");
 
-    VERIFY_ARE_EQUAL(VTID("Z"), engine.apcId);
-    VERIFY_ARE_EQUAL(size_t{ 1 }, engine.apcDispatchCount);
-    VERIFY_ARE_EQUAL(L"", engine.apcDataString);
-    VERIFY_ARE_EQUAL(L"printed text", engine.printed);
-    // Nobody claimed it, so it really was an unknown sequence - the same thing
-    // that was reported before APC strings were dispatched at all.
-    VERIFY_ARE_EQUAL(size_t{ 1 }, engine.unknownSequenceCount);
+        VERIFY_ARE_EQUAL(VTID("Z"), engine.apcId);
+        VERIFY_ARE_EQUAL(size_t{ 1 }, engine.apcDispatchCount);
+        VERIFY_ARE_EQUAL(L"", engine.apcDataString);
+        VERIFY_ARE_EQUAL(L"printed text", engine.printed);
+        // Nobody claimed it, so it really was an unknown sequence - the same thing
+        // that was reported before APC strings were dispatched at all.
+        VERIFY_ARE_EQUAL(size_t{ 1 }, engine.unknownSequenceCount);
 
-    // And the parser is genuinely back in a good state afterwards.
-    engine.apcAccepted = true;
-    machine.ProcessString(L"\033_Gagain\033\\");
-    VERIFY_ARE_EQUAL(VTID("G"), engine.apcId);
-    VERIFY_ARE_EQUAL(L"again\033", engine.apcDataString);
-}
+        // And the parser is genuinely back in a good state afterwards.
+        engine.apcAccepted = true;
+        machine.ProcessString(L"\033_Gagain\033\\");
+        VERIFY_ARE_EQUAL(VTID("G"), engine.apcId);
+        VERIFY_ARE_EQUAL(L"again\033", engine.apcDataString);
+    }
 
-void StateMachineTest::ApcHandlerCanEndTheStringEarly()
-{
-    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
-    auto& engine{ *enginePtr.get() };
-    StateMachine machine{ std::move(enginePtr) };
+    {
+        auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+        auto& engine{ *enginePtr.get() };
+        StateMachine machine{ std::move(enginePtr) };
 
-    // A handler that returns false has given up on the rest of the string. It
-    // must not be called again, and the remainder must not reach the screen.
-    engine.apcAcceptLimit = 4;
-    machine.ProcessString(L"\033_Gdata string\033\\printed text");
+        // A handler that returns false has given up on the rest of the string. It
+        // must not be called again, and the remainder must not reach the screen.
+        engine.apcAcceptLimit = 4;
+        machine.ProcessString(L"\033_Gdata string\033\\printed text");
 
-    VERIFY_ARE_EQUAL(L"data", engine.apcDataString);
-    VERIFY_ARE_EQUAL(L"printed text", engine.printed);
-    // The string was recognised and claimed, so it is not an unknown sequence.
-    // Reporting one would tell conhost its cursor position may be wrong and
-    // force a needless ConPTY resync.
-    VERIFY_ARE_EQUAL(size_t{ 0 }, engine.unknownSequenceCount);
+        VERIFY_ARE_EQUAL(L"data", engine.apcDataString);
+        VERIFY_ARE_EQUAL(L"printed text", engine.printed);
+        // The string was recognised and claimed, so it is not an unknown sequence.
+        // Reporting one would tell conhost its cursor position may be wrong and
+        // force a needless ConPTY resync.
+        VERIFY_ARE_EQUAL(size_t{ 0 }, engine.unknownSequenceCount);
+    }
 }
 
 void StateMachineTest::ApcDataStringSplitAcrossWrites()
@@ -557,35 +560,40 @@ void StateMachineTest::ApcDataStringIsOpaqueToTheParser()
     VERIFY_ARE_EQUAL(size_t{ 1 }, engine.apcDispatchCount);
 }
 
-void StateMachineTest::ApcWithoutAnIdentifierIsIgnored()
+void StateMachineTest::ApcEntryRoutingBehavior()
 {
-    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
-    auto& engine{ *enginePtr.get() };
-    StateMachine machine{ std::move(enginePtr) };
+    // ApcEntry only routes once it has an identifier byte to route on. With none
+    // at all the string is dropped; a control character can't name an application
+    // either, so it's skipped while we wait for one that can - the same thing
+    // DcsEntry does with them.
+    {
+        auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+        auto& engine{ *enginePtr.get() };
+        StateMachine machine{ std::move(enginePtr) };
 
-    // There is nothing to route on, so no engine is asked, and the string is
-    // dropped when its terminator arrives.
-    machine.ProcessString(L"\033_\033\\printed text");
+        // There is nothing to route on, so no engine is asked, and the string is
+        // dropped when its terminator arrives.
+        machine.ProcessString(L"\033_\033\\printed text");
 
-    VERIFY_ARE_EQUAL(size_t{ 0 }, engine.apcDispatchCount);
-    VERIFY_ARE_EQUAL(L"printed text", engine.printed);
-}
+        VERIFY_ARE_EQUAL(size_t{ 0 }, engine.apcDispatchCount);
+        VERIFY_ARE_EQUAL(L"printed text", engine.printed);
+    }
 
-void StateMachineTest::ApcEntryIgnoresControlCharacters()
-{
-    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
-    auto& engine{ *enginePtr.get() };
-    StateMachine machine{ std::move(enginePtr) };
+    {
+        auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+        auto& engine{ *enginePtr.get() };
+        StateMachine machine{ std::move(enginePtr) };
 
-    // A control character can't name an application, so it's skipped while we
-    // wait for one that can - the same thing DcsEntry does with them.
-    machine.ProcessString(L"\033_\a\177Gdata string\033\\");
+        // The control characters are skipped while we wait for an identifier that
+        // can name an application, then routing proceeds as normal.
+        machine.ProcessString(L"\033_\a\177Gdata string\033\\");
 
-    VERIFY_ARE_EQUAL(VTID("G"), engine.apcId);
-    VERIFY_ARE_EQUAL(size_t{ 1 }, engine.apcDispatchCount);
-    VERIFY_ARE_EQUAL(L"data string\033", engine.apcDataString);
-    VERIFY_ARE_EQUAL(L"", engine.printed);
-    VERIFY_ARE_EQUAL(L"", engine.executed);
+        VERIFY_ARE_EQUAL(VTID("G"), engine.apcId);
+        VERIFY_ARE_EQUAL(size_t{ 1 }, engine.apcDispatchCount);
+        VERIFY_ARE_EQUAL(L"data string\033", engine.apcDataString);
+        VERIFY_ARE_EQUAL(L"", engine.printed);
+        VERIFY_ARE_EQUAL(L"", engine.executed);
+    }
 }
 
 void StateMachineTest::VtParameterSubspanTest()


### PR DESCRIPTION
| Stack | |
|---|---|
| #54 | Give `ImageSlice` identified, z-ordered layers |
| #55 | Paint a row's images in z-order around its text |
| **&rarr; #56** | **Route APC strings to the engine by identifier** |
| #57 | Add the Kitty graphics protocol to the VT adapter |
| #58 | Add Kitty graphics animation |
| #59 | Add file and shared-memory transmission |

## TL;DR

`StateMachine` handles APC strings by hardcoding what to do with them. This routes an APC string to the engine **by identifier**, the same way DCS already dispatches — so a protocol can claim `_G` without the parser knowing what Kitty is.

**On its own this changes no pixels.** Nothing yet claims an identifier.

![APC dispatch state flow](https://github.com/user-attachments/assets/9594dc6c-286f-4bc2-af6f-0ead7b9ab8ba)

## Key changes

- **`ActionApcDispatch(VTID)`** — follows the shape of the other dispatcher functions and takes the identifier as a parameter, instead of the engine sniffing the string to work out whether it wants it.
- **The handler is told *how* the string ended** — terminated by ST versus aborted — so it can distinguish a completed transmission from a truncated one rather than guessing.
- **Declining mid-string doesn't report `UnknownSequence`.** The sequence was recognised; the handler just stopped wanting the rest of it. Reporting it as unknown would be a lie to anything watching that signal.
- **`ApcEntry` doesn't accumulate into `_cachedSequence`.** APC payloads are arbitrarily long and are already being streamed to a handler; buffering them a second time is pure cost.

## Notes for the rest of the stack

- **The string body is opaque to the parser.** The state machine routes on the identifier and nothing else — everything after it is handed over untouched. This is the point of the PR: #57 can add a 4,000-line protocol parser without adding a single line of protocol knowledge to `src/terminal/parser`.
- **Route by identifier, not by hardcoding.** DCS already works this way, so an APC dispatcher that took no parameter would have been the odd one out in this file. Matching the existing shape is what makes #57's registration unremarkable.

## Protocol neutrality

```
$ git grep -i kitty -- src/terminal/parser
(no output)
```

Same `kitty` file count as `main`. The engine hook is generic; Kitty is one possible consumer.

## Tests

Parser-level tests drive APC strings through the state machine directly and assert routing, termination kind, mid-string decline, and that the body arrives byte-for-byte unmodified. `ConParser 775 passed + 1 skipped`.

The screenshot below is from the tip of the stack — it's what having a route *for* looks like, and belongs to #57.

![RGB and RGBA images transmitted over APC and displayed](https://github.com/user-attachments/assets/c760f649-074d-42c4-8653-0f8945168511)

---

**Found while doing this, fixable independently of this stack:** `StateMachine::ResetState()` drops a live `_apcStringHandler` without ever calling it, so a handler mid-string at reset never learns the string ended. DCS has the identical hole. Worth a standalone PR against `main`.

**Builds alone.** Built without any PR above it — zero C++ errors.