### PR TITLE
Add Kitty graphics animation

### DIFF
--- a/src/buffer/out/ImageSlice.cpp
+++ b/src/buffer/out/ImageSlice.cpp
@@ -225,6 +225,7 @@ void ImageSlice::_ensureRange(const til::CoordType columnBegin, const til::Coord
     {
         const auto before = _layerBytes(layer);
         RelocatePlane(layer.pixels, oldPixelWidth, _pixelWidth, newPixelOffset, _cellSize.height);
+        RelocatePlane(layer.sourceIndices, oldPixelWidth, _pixelWidth, newPixelOffset, _cellSize.height, NoSourceIndex);
         RelocateColumns(layer.columns, newColumnCount, newColumnOffset);
         // This growth is forced by geometry rather than requested by a write,
         // so it is charged to the budget but not refused.
@@ -477,7 +478,7 @@ void ImageSlice::_eraseBasePlane(const til::CoordType columnBegin, const til::Co
 
 size_t ImageSlice::_layerBytes(const Layer& layer) noexcept
 {
-    return layer.pixels.size() * sizeof(RGBQUAD) + layer.columns.size();
+    return layer.pixels.size() * sizeof(RGBQUAD) + layer.sourceIndices.size() * sizeof(uint32_t) + layer.columns.size();
 }
 
 // A revision of 0 is never handed out by BumpRevision, so it doubles as the
@@ -522,6 +523,20 @@ void ImageSlice::_clearLayerColumns(Layer& layer, const til::CoordType columnBeg
         for (auto y = 0; y < _cellSize.height; y++)
         {
             std::memset(iterator, 0, static_cast<size_t>(length) * sizeof(RGBQUAD));
+            std::advance(iterator, _pixelWidth);
+        }
+    }
+
+    // Cleared cells no longer sample the source image, so a later update must
+    // not write pixels back into them.
+    if (!layer.sourceIndices.empty())
+    {
+        const auto offset = (clearBegin - _columnBegin) * _cellSize.width;
+        const auto length = (clearEnd - clearBegin) * _cellSize.width;
+        auto iterator = std::next(layer.sourceIndices.data(), offset);
+        for (auto y = 0; y < _cellSize.height; y++)
+        {
+            std::fill_n(iterator, length, NoSourceIndex);
             std::advance(iterator, _pixelWidth);
         }
     }
@@ -691,6 +706,7 @@ RGBQUAD* ImageSlice::TryMutablePixels(const til::CoordType columnBegin, const ti
     auto& layer = _getLayer(key, zIndex);
     const auto before = _layerBytes(layer);
     layer.pixels.resize(planeSize);
+    layer.sourceIndices.resize(planeSize, NoSourceIndex);
     layer.columns.resize(columnCount, 0);
     for (auto column = columnBegin; column < columnEnd; column++)
     {
@@ -914,6 +930,25 @@ void ImageSlice::_copyLayers(const ImageSlice& srcSlice, const til::CoordType sr
             std::advance(dstIterator, _pixelWidth);
         }
 
+        // The sampling record travels with the pixels, so a copied layer still
+        // follows changes to its source image.
+        if (!srcLayer.sourceIndices.empty())
+        {
+            const auto dstIndices = MutableSourceIndices(dstColumnBegin, dstColumnEnd, srcLayer.key, srcLayer.zIndex);
+            if (dstIndices)
+            {
+                auto srcIndexIterator = std::next(srcLayer.sourceIndices.data(), (srcColumn - srcColumnBegin) * _cellSize.width);
+                auto dstIndexIterator = dstIndices;
+                const auto indexCount = static_cast<size_t>(columnCount) * _cellSize.width;
+                for (auto y = 0; y < _cellSize.height; y++)
+                {
+                    std::memmove(dstIndexIterator, srcIndexIterator, indexCount * sizeof(uint32_t));
+                    std::advance(srcIndexIterator, srcPixelWidth);
+                    std::advance(dstIndexIterator, _pixelWidth);
+                }
+            }
+        }
+
         // Coverage has to follow the pixels, otherwise a later targeted erase
         // would skip the cells we just wrote.
         auto& dstLayer = _getLayer(srcLayer.key, srcLayer.zIndex);
@@ -933,6 +968,55 @@ void ImageSlice::_copyLayers(const ImageSlice& srcSlice, const til::CoordType sr
     _invalidateComposites();
 }
 
+uint32_t* ImageSlice::MutableSourceIndices(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex)
+{
+    // The base plane carries no identity, so nothing can ever re-sample it.
+    if (key.Untagged())
+    {
+        return nullptr;
+    }
+
+    // MutablePixels is what decides whether the layer may exist at all; asking
+    // it first keeps the budget and layer-count rules in exactly one place.
+    if (!TryMutablePixels(columnBegin, columnEnd, key, zIndex))
+    {
+        return nullptr;
+    }
+
+    auto& layer = _getLayer(key, zIndex);
+    const auto pixelOffset = (columnBegin - _columnBegin) * _cellSize.width;
+    return &til::at(layer.sourceIndices, pixelOffset);
+}
+
+// Re-samples every layer of an image from new pixel data, in place. Only cells
+// that recorded a source index are touched, so cells that were erased or
+// overwritten since the placement stay gone.
+bool ImageSlice::UpdateImage(const uint32_t imageId, const std::span<const RGBQUAD> pixels)
+{
+    auto changed = false;
+    for (auto& layer : _layers)
+    {
+        if (layer.key.imageId != imageId || layer.sourceIndices.size() != layer.pixels.size())
+        {
+            continue;
+        }
+        for (size_t i = 0; i < layer.pixels.size(); i++)
+        {
+            const auto sourceIndex = til::at(layer.sourceIndices, i);
+            if (sourceIndex != NoSourceIndex)
+            {
+                til::at(layer.pixels, i) = sourceIndex < pixels.size() ? pixels[sourceIndex] : RGBQUAD{};
+                changed = true;
+            }
+        }
+    }
+    if (changed)
+    {
+        BumpRevision();
+        _invalidateComposites();
+    }
+    return changed;
+}
 
 size_t ImageSlice::WriteMemoryUpperBound(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex) const noexcept
 {
@@ -1137,6 +1221,23 @@ bool ImageSlice::_copyLayerCells(const ImageSlice& srcSlice, const til::CoordTyp
             std::advance(dstIterator, _pixelWidth);
         }
 
+        if (!srcLayer.sourceIndices.empty())
+        {
+            const auto dstIndices = MutableSourceIndices(dstColumnBegin, dstColumnEnd, srcLayer.key, srcLayer.zIndex);
+            if (dstIndices)
+            {
+                auto srcIndexIterator = std::next(srcLayer.sourceIndices.data(), srcOffset * _cellSize.width);
+                auto dstIndexIterator = dstIndices;
+                const auto indexCount = static_cast<size_t>(columnCount) * _cellSize.width;
+                for (auto y = 0; y < _cellSize.height; y++)
+                {
+                    std::memmove(dstIndexIterator, srcIndexIterator, indexCount * sizeof(uint32_t));
+                    std::advance(srcIndexIterator, srcPixelWidth);
+                    std::advance(dstIndexIterator, _pixelWidth);
+                }
+            }
+        }
+
         auto& dstLayer = _getLayer(srcLayer.key, srcLayer.zIndex);
         for (auto column = 0; column < columnCount; column++)
         {
@@ -1258,6 +1359,22 @@ void ImageSlice::_mergePreservedCells(const ImageSlice& srcSlice)
                 std::memcpy(destination, source, rowByteCount);
                 std::advance(source, srcSlice._pixelWidth);
                 std::advance(destination, _pixelWidth);
+            }
+
+            if (!srcLayer.sourceIndices.empty())
+            {
+                const auto dstIndices = MutableSourceIndices(column, column + 1, srcLayer.key, srcLayer.zIndex);
+                if (dstIndices)
+                {
+                    auto sourceIndices = std::next(srcLayer.sourceIndices.data(), static_cast<til::CoordType>(srcIndex) * _cellSize.width);
+                    auto destinationIndices = dstIndices;
+                    for (auto y = 0; y < _cellSize.height; y++)
+                    {
+                        std::memcpy(destinationIndices, sourceIndices, static_cast<size_t>(_cellSize.width) * sizeof(uint32_t));
+                        std::advance(sourceIndices, srcSlice._pixelWidth);
+                        std::advance(destinationIndices, _pixelWidth);
+                    }
+                }
             }
         }
     }

--- a/src/buffer/out/ImageSlice.hpp
+++ b/src/buffer/out/ImageSlice.hpp
@@ -52,6 +52,8 @@ public:
     // Layers below this z composite behind the cell background rather than
     // merely behind the text.
     static constexpr int32_t BackgroundZThreshold = INT32_MIN / 2;
+    // Marks a pixel that samples nothing, so an image update leaves it alone.
+    static constexpr uint32_t NoSourceIndex = UINT32_MAX;
     // A process-wide ceiling on identified layer storage, plus a per-slice
     // layer count limit, so a stream of images cannot exhaust memory.
     static constexpr size_t MaxLayerBytes = 320ull * 1024ull * 1024ull;
@@ -92,6 +94,11 @@ public:
     RGBQUAD* MutablePixels(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex);
     RGBQUAD* TryMutablePixels(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex);
     bool PlacementCoversColumn(const uint64_t placementId, const til::CoordType column) const noexcept;
+    // Records which source-image pixel each written pixel sampled, so the layer
+    // can be re-sampled in place when the source image's content changes. The
+    // span is laid out exactly like the pixels returned by MutablePixels.
+    uint32_t* MutableSourceIndices(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex);
+    bool UpdateImage(const uint32_t imageId, const std::span<const RGBQUAD> pixels);
     // An upper bound on the bytes a MutablePixels write of this range would add,
     // so a caller can refuse a placement before allocating any of it.
     size_t WriteMemoryUpperBound(const til::CoordType columnBegin, const til::CoordType columnEnd, const LayerKey key, const int32_t zIndex) const noexcept;
@@ -132,6 +139,9 @@ private:
         LayerKey key;
         int32_t zIndex = 0;
         std::vector<RGBQUAD> pixels;
+        // Which source-image pixel each entry of `pixels` sampled, so the layer
+        // survives its image being redrawn. NoSourceIndex means "not sampled".
+        std::vector<uint32_t> sourceIndices;
         // One flag per column in [_columnBegin, _columnEnd) marking the cells
         // this layer actually covers, so an erase can target only those cells
         // without disturbing another layer that overlaps the same range.

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -48,6 +48,7 @@ void Terminal::Create(til::size viewportSize, til::CoordType scrollbackLines, Re
                                 Utils::ClampToShortMax(viewportSize.height + scrollbackLines, 1) };
     const TextAttribute attr{};
     const UINT cursorSize = 12;
+    _renderer = &renderer;
     _mainBuffer = std::make_unique<TextBuffer>(bufferSize, attr, cursorSize, true, &renderer);
 
     auto dispatch = std::make_unique<AdaptDispatch>(*this, &renderer, _renderSettings, _terminalInput);
@@ -259,6 +260,15 @@ void Terminal::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
 {
     auto& engine = reinterpret_cast<OutputStateMachineEngine&>(_stateMachine->Engine());
     engine.Dispatch().SetCursorStyle(cursorStyle);
+}
+
+void Terminal::_notifyFontChanged()
+{
+    if (_stateMachine)
+    {
+        auto& engine = reinterpret_cast<OutputStateMachineEngine&>(_stateMachine->Engine());
+        static_cast<AdaptDispatch&>(engine.Dispatch()).NotifyFontChanged();
+    }
 }
 
 void Terminal::SetOptionalFeatures(winrt::Microsoft::Terminal::Core::ICoreSettings settings)

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -170,6 +170,9 @@ public:
     bool DecodeImageToBgra(const std::span<const uint8_t> data, std::vector<RGBQUAD>& pixels, til::size& size) noexcept override;
     til::size GetCellSize() const noexcept override;
 
+    void SetTimedContentHandler(std::function<void()> handler) override;
+    void RequestTimedContentUpdate(const std::optional<std::chrono::steady_clock::time_point> deadline) override;
+
 #pragma endregion
 
     void ClearMark();
@@ -351,6 +354,15 @@ private:
     std::function<void()> _pfnClearQuickFix;
     std::function<void(int32_t, int32_t)> _pfnWindowSizeChanged;
 
+    // Timed content state. The handler runs on the render thread, so the mutex
+    // guards it against a concurrent SetTimedContentHandler on the writing thread.
+    std::mutex _timedContentMutex;
+    std::function<void()> _timedContentHandler;
+    Microsoft::Console::Render::TimerHandle _timedContentTimer{};
+    std::shared_ptr<int> _timedContentLifetime = std::make_shared<int>(0);
+    // Stored in Create(); null until then and also in the test-dummy constructor.
+    Microsoft::Console::Render::Renderer* _renderer = nullptr;
+
     RenderSettings _renderSettings;
     std::unique_ptr<::Microsoft::Console::VirtualTerminal::StateMachine> _stateMachine;
     ::Microsoft::Console::VirtualTerminal::TerminalInput _terminalInput;
@@ -473,6 +485,7 @@ private:
     void _NotifyScrollEvent();
     bool _inAltBuffer() const noexcept;
     TextBuffer& _activeBuffer() const noexcept;
+    void _notifyFontChanged();
     void _updateUrlDetection();
     interval_tree::IntervalTree<til::point, size_t> _getPatterns(til::CoordType beg, til::CoordType end) const;
 

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -6,6 +6,7 @@
 #include "tracing.hpp"
 
 #include "../src/inc/unicode.hpp"
+#include "../../renderer/base/renderer.hpp"
 
 #include <wincodec.h>
 #include <wil/com.h>
@@ -516,4 +517,62 @@ void Terminal::NotifyShellIntegrationMark()
 {
     // Notify the scrollbar that marks have been added so it can refresh the mark indicators
     _NotifyScrollEvent();
+}
+
+// Stores the handler the adapter wants called when timed content advances.
+// A null handler clears any prior registration and stops the outstanding timer.
+void Terminal::SetTimedContentHandler(std::function<void()> handler)
+{
+    const auto stop = !handler;
+    {
+        std::lock_guard lock(_timedContentMutex);
+        _timedContentHandler = std::move(handler);
+    }
+    if (stop && _renderer && _timedContentTimer)
+    {
+        _renderer->StopTimer(_timedContentTimer);
+    }
+}
+
+// Arms the render-thread timer so the adapter is woken at `deadline`.
+// No value means the adapter no longer needs a wakeup; stop the timer.
+void Terminal::RequestTimedContentUpdate(
+    const std::optional<std::chrono::steady_clock::time_point> deadline)
+{
+    if (!_renderer)
+    {
+        return;
+    }
+
+    if (!deadline)
+    {
+        if (_timedContentTimer)
+        {
+            _renderer->StopTimer(_timedContentTimer);
+        }
+        return;
+    }
+
+    if (!_timedContentTimer)
+    {
+        // Registered lazily, so a session that never shows timed content never
+        // takes a timer slot. Binding the callback to _timedContentLifetime lets
+        // the renderer retire the slot on its own once this object is gone.
+        _timedContentTimer = _renderer->RegisterTimer(
+            "timed content",
+            [this](Renderer&, TimerHandle) {
+                std::function<void()> handler;
+                {
+                    std::lock_guard lock(_timedContentMutex);
+                    handler = _timedContentHandler;
+                }
+                if (handler)
+                {
+                    handler();
+                }
+            },
+            _timedContentLifetime);
+    }
+
+    _renderer->StartTimerAt(_timedContentTimer, *deadline);
 }

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -36,6 +36,7 @@ void Terminal::SetFontInfo(const FontInfo& fontInfo)
 {
     _assertLocked();
     _fontInfo = fontInfo;
+    _notifyFontChanged();
 }
 
 TimerDuration Terminal::GetBlinkInterval() noexcept

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -427,6 +427,7 @@ namespace TerminalCoreUnitTests
 
         TEST_METHOD(GetCellSizeFallsBackWhenFontUnset);
 
+        TEST_METHOD(KittyAnimationSurvivesFontAndRendererRefresh);
         TEST_METHOD(KittyPlaceholderRendersInRealTerminal);
         TEST_METHOD(KittyImageRowCarriesEachCellsBackgroundColor);
         TEST_METHOD(KittyPlaceholderSuppressesGlyphOnPaintAndRepaint);
@@ -798,6 +799,59 @@ void TerminalApiTest::GetCellSizeFallsBackWhenFontUnset()
     const auto cellSize = term.GetCellSize();
     VERIFY_IS_GREATER_THAN(cellSize.width, 1, L"cell width must not be a degenerate 1px");
     VERIFY_IS_GREATER_THAN(cellSize.height, 1, L"cell height must not be a degenerate 1px");
+}
+
+void TerminalApiTest::KittyAnimationSurvivesFontAndRendererRefresh()
+{
+    KittyRenderFixture fixture{ { 6, 3 }, 0 };
+    auto& buffer = *fixture.terminal._mainBuffer;
+    auto& stateMachine = *fixture.terminal._stateMachine;
+
+    stateMachine.ProcessString(L"\x1b_Ga=T,i=7,f=24,s=1,v=1,c=1,r=1,C=1,z=5000,q=2;/wAA\x1b\\");
+    stateMachine.ProcessString(L"\x1b_Ga=f,i=7,f=24,s=1,v=1,z=1000,q=2;AP8A\x1b\\");
+    stateMachine.ProcessString(L"\x1b_Ga=a,i=7,c=1,r=1,z=5000,s=3,v=1,q=2;\x1b\\");
+    fixture.StartPainting();
+    VERIFY_IS_TRUE(FrameContainsKittyColor(fixture.engine.Snapshot(), 7, false), L"frame 1 must be visible before the lifecycle transition");
+
+    // Reproduce the stale retained-layer state observed after renderer recreation:
+    // the animation source of truth is frame 1 (red), while the retained pixels
+    // contain the wrong frame (green).
+    const std::array stalePixels{ RGBQUAD{ 0, 255, 0, 0 } };
+    fixture.terminal.LockConsole();
+    auto unlockAfterStaleLayer = wil::scope_exit([&fixture]() {
+        fixture.terminal.UnlockConsole();
+    });
+    auto* slice = buffer.GetMutableRowByOffset(0).GetMutableImageSlice();
+    VERIFY_IS_NOT_NULL(slice);
+    VERIFY_IS_TRUE(slice && slice->UpdateImage(7, stalePixels));
+    unlockAfterStaleLayer.reset();
+    fixture.Repaint();
+    VERIFY_IS_TRUE(FrameContainsKittyColor(fixture.engine.Snapshot(), 7, true), L"the test must reproduce a stale retained animation layer");
+
+    fixture.terminal.LockConsole();
+    auto unlockAfterFontChange = wil::scope_exit([&fixture]() {
+        fixture.terminal.UnlockConsole();
+    });
+    fixture.terminal.SetFontInfo(FontInfo{ DEFAULT_FONT_FACE, TMPF_TRUETYPE, 10, { 12, 24 }, CP_UTF8, false });
+    unlockAfterFontChange.reset();
+    fixture.Repaint();
+    VERIFY_IS_TRUE(FrameContainsKittyColor(fixture.engine.Snapshot(), 7, false), L"font/DPI recreation must restore the current animation frame");
+
+    fixture.terminal.LockConsole();
+    stateMachine.ProcessString(L"\x1b_Ga=a,i=7,r=1,z=20,q=2;\x1b\\");
+    fixture.terminal.UnlockConsole();
+    // Painting ticks the renderer's timers, so the frame the animation is waiting to
+    // show arrives by painting again once its gap has elapsed -- no render thread, and
+    // no waiting on one to be scheduled. The gap is 20ms; sleep a little and repaint
+    // until the next frame appears.
+    auto advanced = FrameContainsKittyColor(fixture.engine.Snapshot(), 7, true);
+    for (auto attempt = 0; attempt < 50 && !advanced; ++attempt)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        fixture.Repaint();
+        advanced = FrameContainsKittyColor(fixture.engine.Snapshot(), 7, true);
+    }
+    VERIFY_IS_TRUE(advanced, L"animation playback must continue to the next frame after recreation");
 }
 
 void TerminalApiTest::KittyPlaceholderRendersInRealTerminal()

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -12,6 +12,7 @@
 #include "output.h"
 
 #include "../interactivity/inc/ServiceLocator.hpp"
+#include "../renderer/base/renderer.hpp"
 
 #pragma hdrstop
 
@@ -475,4 +476,66 @@ bool ConhostInternalGetSet::DecodeImageToBgra(const std::span<const uint8_t> /*d
 til::size ConhostInternalGetSet::GetCellSize() const noexcept
 {
     return _io.GetActiveOutputBuffer().GetCurrentFont().GetSize();
+}
+
+// Stores the handler the adapter wants called when timed content advances.
+// A null handler clears any prior registration and stops the outstanding timer.
+void ConhostInternalGetSet::SetTimedContentHandler(std::function<void()> handler)
+{
+    const auto stop = !handler;
+    {
+        std::lock_guard lock(_timedContentMutex);
+        _timedContentHandler = std::move(handler);
+    }
+    if (stop && _timedContentTimer)
+    {
+        if (auto* const pRender = ServiceLocator::LocateGlobals().pRender)
+        {
+            pRender->StopTimer(_timedContentTimer);
+        }
+    }
+}
+
+// Arms the render-thread timer so the adapter is woken at `deadline`.
+// No value means the adapter no longer needs a wakeup; stop the timer.
+void ConhostInternalGetSet::RequestTimedContentUpdate(
+    const std::optional<std::chrono::steady_clock::time_point> deadline)
+{
+    auto* const pRender = ServiceLocator::LocateGlobals().pRender;
+    if (!pRender)
+    {
+        return;
+    }
+
+    if (!deadline)
+    {
+        if (_timedContentTimer)
+        {
+            pRender->StopTimer(_timedContentTimer);
+        }
+        return;
+    }
+
+    if (!_timedContentTimer)
+    {
+        // Registered lazily, so a session that never shows timed content never
+        // takes a timer slot. Binding the callback to _timedContentLifetime lets
+        // the renderer retire the slot on its own once this object is gone.
+        _timedContentTimer = pRender->RegisterTimer(
+            "timed content",
+            [this](Microsoft::Console::Render::Renderer&, Microsoft::Console::Render::TimerHandle) {
+                std::function<void()> handler;
+                {
+                    std::lock_guard lock(_timedContentMutex);
+                    handler = _timedContentHandler;
+                }
+                if (handler)
+                {
+                    handler();
+                }
+            },
+            _timedContentLifetime);
+    }
+
+    pRender->StartTimerAt(_timedContentTimer, *deadline);
 }

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -18,6 +18,7 @@ Author:
 #include "../types/inc/IInputEvent.hpp"
 #include "../inc/conattrs.hpp"
 #include "IIoProvider.hpp"
+#include "../renderer/inc/IRenderData.hpp"
 
 // The ConhostInternalGetSet is for the Conhost process to call the entrypoints for its own Get/Set APIs.
 // Normally, these APIs are accessible from the outside of the conhost process (like by the process being "hosted") through
@@ -79,6 +80,16 @@ public:
     bool DecodeImageToBgra(const std::span<const uint8_t> data, std::vector<RGBQUAD>& pixels, til::size& size) noexcept override;
     til::size GetCellSize() const noexcept override;
 
+    void SetTimedContentHandler(std::function<void()> handler) override;
+    void RequestTimedContentUpdate(const std::optional<std::chrono::steady_clock::time_point> deadline) override;
+
 private:
     Microsoft::Console::IIoProvider& _io;
+
+    // Timed content state. The handler runs on the render thread, so the mutex
+    // guards it against a concurrent SetTimedContentHandler on the writing thread.
+    std::mutex _timedContentMutex;
+    std::function<void()> _timedContentHandler;
+    Microsoft::Console::Render::TimerHandle _timedContentTimer{};
+    std::shared_ptr<int> _timedContentLifetime = std::make_shared<int>(0);
 };

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -158,31 +158,54 @@ void Renderer::_waitUntilCanRender() noexcept
     }
 }
 
-TimerHandle Renderer::RegisterTimer(const char* description, TimerCallback routine)
+TimerHandle Renderer::RegisterTimer(const char* description, TimerCallback routine, std::weak_ptr<void> lifetime)
 {
     // If it doesn't crash now, it would crash later.
     WI_ASSERT(routine != nullptr);
 
-    const auto id = _nextTimerId++;
+    auto storedRoutine = std::make_shared<TimerCallback>(std::move(routine));
+    // An already-expired lifetime is indistinguishable from an empty one, so
+    // the intent is captured now rather than inferred later.
+    const auto lifetimeBound = !lifetime.expired();
 
-    _timers.push_back(TimerRoutine{
+    const auto guard = _timerMutex.lock_exclusive();
+
+    // Retired slots are reused, so a caller that registers and drops timers
+    // repeatedly doesn't grow the list without bound.
+    const auto reusable = std::find_if(_timers.begin(), _timers.end(), [](const TimerRoutine& timer) {
+        return !timer.routine || (timer.lifetimeBound && timer.lifetime.expired());
+    });
+
+    auto timer = TimerRoutine{
         .description = description,
         .interval = TimerReprMax,
         .next = TimerReprMax,
-        .routine = std::move(routine),
-    });
+        .routine = std::move(storedRoutine),
+        .lifetime = std::move(lifetime),
+        .lifetimeBound = lifetimeBound,
+    };
 
-    return TimerHandle{ id };
+    if (reusable != _timers.end())
+    {
+        const auto id = gsl::narrow_cast<size_t>(std::distance(_timers.begin(), reusable));
+        *reusable = std::move(timer);
+        return TimerHandle{ id };
+    }
+
+    _timers.push_back(std::move(timer));
+    return TimerHandle{ _timers.size() - 1 };
 }
 
 bool Renderer::IsTimerRunning(TimerHandle handle) const
 {
+    const auto guard = _timerMutex.lock_shared();
     const auto& timer = _timers.at(handle.id);
-    return timer.next != TimerReprMax;
+    return timer.routine && timer.next != TimerReprMax;
 }
 
 TimerDuration Renderer::GetTimerInterval(TimerHandle handle) const
 {
+    const auto guard = _timerMutex.lock_shared();
     const auto& timer = _timers.at(handle.id);
     return TimerDuration{ timer.interval };
 }
@@ -192,6 +215,19 @@ void Renderer::StartTimer(TimerHandle handle, TimerDuration delay)
     _startTimer(handle, delay.count(), TimerReprMax);
 }
 
+// Starts a timer that fires at an absolute deadline rather than after a delay.
+// Callers that track *when* they next have work shouldn't have to know how long
+// a delay this renderer is willing to accept, so the bounds _startTimer asserts
+// on are applied here: a deadline already past becomes the shortest legal delay,
+// and one far in the future is capped so we re-check instead of sleeping through it.
+void Renderer::StartTimerAt(TimerHandle handle, std::chrono::steady_clock::time_point deadline)
+{
+    static constexpr auto shortest = std::chrono::milliseconds{ 1 };
+    static constexpr auto longest = std::chrono::seconds{ 30 };
+    const auto remaining = deadline - std::chrono::steady_clock::now();
+    const auto delay = std::clamp(std::chrono::duration_cast<std::chrono::milliseconds>(remaining), shortest, std::chrono::duration_cast<std::chrono::milliseconds>(longest));
+    StartTimer(handle, std::chrono::duration_cast<TimerDuration>(delay));
+}
 void Renderer::StartRepeatingTimer(TimerHandle handle, TimerDuration interval)
 {
     _startTimer(handle, interval.count(), interval.count());
@@ -209,24 +245,34 @@ void Renderer::_startTimer(TimerHandle handle, TimerRepr delay, TimerRepr interv
     assert(interval > 0 && (interval < one_min_in_100ns || interval == TimerReprMax));
 #endif
 
-    auto& timer = _timers.at(handle.id);
-    timer.interval = interval;
-    timer.next = _timerSaturatingAdd(_timerInstant(), delay);
+    {
+        const auto guard = _timerMutex.lock_exclusive();
+        auto& timer = _timers.at(handle.id);
+        timer.interval = interval;
+        timer.next = _timerSaturatingAdd(_timerInstant(), delay);
+    }
 
-    // Tickle _waitUntilCanRender() into calling _calculateTimerMaxWait() again.
-    // WaitOnAddress() will return with TRUE, even if the atomic didn't change.
-    til::atomic_notify_one(_redraw);
+    // Set the predicate as well as notifying. A start racing the render
+    // thread's wait would otherwise lose the wake-up and sleep past the new
+    // deadline; that was safe while only the render thread started timers.
+    NotifyPaintFrame();
 }
 
 void Renderer::StopTimer(TimerHandle handle)
 {
-    auto& timer = _timers.at(handle.id);
-    timer.interval = TimerReprMax;
-    timer.next = TimerReprMax;
+    {
+        const auto guard = _timerMutex.lock_exclusive();
+        auto& timer = _timers.at(handle.id);
+        timer.interval = TimerReprMax;
+        timer.next = TimerReprMax;
+    }
+    NotifyPaintFrame();
 }
 
 DWORD Renderer::_calculateTimerMaxWait() noexcept
 {
+    const auto guard = _timerMutex.lock_exclusive();
+
     if (_timers.empty())
     {
         return INFINITE;
@@ -235,8 +281,15 @@ DWORD Renderer::_calculateTimerMaxWait() noexcept
     const auto now = _timerInstant();
     auto wait = TimerReprMax;
 
-    for (const auto& timer : _timers)
+    for (auto& timer : _timers)
     {
+        // Retiring here as well as in _tickTimers means an expired timer stops
+        // holding the wait down even if it never comes due again.
+        if (!timer.routine || (timer.lifetimeBound && timer.lifetime.expired()))
+        {
+            timer = {};
+            continue;
+        }
         wait = std::min(wait, _timerSaturatingSub(timer.next, now));
     }
 
@@ -275,12 +328,44 @@ void Renderer::_waitUntilTimerOrRedraw() noexcept
 void Renderer::_tickTimers() noexcept
 {
     const auto now = _timerInstant();
-    size_t id = 0;
 
-    for (auto& timer : _timers)
+    // Indexed rather than iterated: a callback may register a timer, which can
+    // reallocate the list out from under an iterator. The lock is also dropped
+    // across the callback, so a callback is free to start or stop timers.
+    for (size_t id = 0;; ++id)
     {
-        if (now >= timer.next)
+        std::shared_ptr<TimerCallback> routine;
+        std::shared_ptr<void> lifetime;
+
         {
+            const auto guard = _timerMutex.lock_exclusive();
+            if (id >= _timers.size())
+            {
+                break;
+            }
+
+            auto& timer = _timers.at(id);
+            if (!timer.routine || (timer.lifetimeBound && timer.lifetime.expired()))
+            {
+                timer = {};
+                continue;
+            }
+            if (timer.lifetimeBound)
+            {
+                // Pinning the owner for the duration of the call is what makes
+                // a lifetime-bound callback safe to run without the lock.
+                lifetime = timer.lifetime.lock();
+                if (!lifetime)
+                {
+                    timer = {};
+                    continue;
+                }
+            }
+            if (now < timer.next)
+            {
+                continue;
+            }
+
             // Prevent clock drift by incrementing the originally scheduled time.
             timer.next = _timerSaturatingAdd(timer.next, timer.interval);
             // ...but still take care to not schedule in the past.
@@ -289,14 +374,14 @@ void Renderer::_tickTimers() noexcept
                 timer.next = now + timer.interval;
             }
 
-            try
-            {
-                timer.routine(*this, TimerHandle{ id });
-            }
-            CATCH_LOG();
+            routine = timer.routine;
         }
 
-        id++;
+        try
+        {
+            (*routine)(*this, TimerHandle{ id });
+        }
+        CATCH_LOG();
     }
 }
 
@@ -1288,7 +1373,6 @@ static std::wstring_view _GetForegroundRenderText(const TextBufferCellIterator& 
 {
     return it.HasImageCellRef() ? std::wstring_view{ L" " } : it->Chars();
 }
-
 void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
                                         TextBufferCellIterator it,
                                         const til::point target)

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -6,6 +6,7 @@
 #include "../../buffer/out/textBuffer.hpp"
 #include "../inc/IRenderEngine.hpp"
 #include "../inc/RenderSettings.hpp"
+#include <memory>
 
 namespace Microsoft::Console::Render
 {
@@ -24,10 +25,11 @@ namespace Microsoft::Console::Render
 
         IRenderData* GetRenderData() const noexcept;
 
-        TimerHandle RegisterTimer(const char* description, TimerCallback routine);
+        TimerHandle RegisterTimer(const char* description, TimerCallback routine, std::weak_ptr<void> lifetime = {});
         bool IsTimerRunning(TimerHandle handle) const;
         TimerDuration GetTimerInterval(TimerHandle handle) const;
         void StartTimer(TimerHandle handle, TimerDuration delay);
+        void StartTimerAt(TimerHandle handle, std::chrono::steady_clock::time_point deadline);
         void StartRepeatingTimer(TimerHandle handle, TimerDuration interval);
         void StopTimer(TimerHandle handle);
 
@@ -87,9 +89,16 @@ namespace Microsoft::Console::Render
         struct TimerRoutine
         {
             const char* description = nullptr;
-            TimerRepr interval = 0; // Timers with a 0 interval are marked for deletion.
+            TimerRepr interval = 0;
             TimerRepr next = 0;
-            TimerCallback routine;
+            // Held by shared_ptr so the render thread can run a callback after
+            // releasing the lock, without the slot being reused underneath it.
+            std::shared_ptr<TimerCallback> routine;
+            // A lifetime-bound timer retires itself once its owner is gone, so a
+            // caller that can outlive its own registration doesn't have to
+            // unregister from a destructor racing the render thread.
+            std::weak_ptr<void> lifetime;
+            bool lifetimeBound = false;
         };
 
         // Caches some essential information about the active composition.
@@ -156,8 +165,11 @@ namespace Microsoft::Console::Render
         std::atomic<bool> _redraw;
         std::atomic<bool> _threadKeepRunning{ false };
         til::small_vector<IRenderEngine*, 2> _engines;
+        // Timers may now be registered and stopped from threads other than the
+        // render thread, so the list needs a lock; the two built-in timers no
+        // longer have it to themselves.
+        mutable wil::srwlock _timerMutex;
         til::small_vector<TimerRoutine, 4> _timers;
-        size_t _nextTimerId = 0;
 
         static constexpr size_t _firstSoftFontChar = 0xEF20;
         size_t _lastSoftFontChar = 0;

--- a/src/terminal/adapter/ITerminalApi.hpp
+++ b/src/terminal/adapter/ITerminalApi.hpp
@@ -20,8 +20,11 @@ Author(s):
 #include "../../buffer/out/textBuffer.hpp"
 #include "../../renderer/inc/RenderSettings.hpp"
 
+#include <chrono>
 #include <deque>
+#include <functional>
 #include <memory>
+#include <optional>
 #include <span>
 
 namespace Microsoft::Console::VirtualTerminal
@@ -100,6 +103,14 @@ namespace Microsoft::Console::VirtualTerminal
         // host has an image decoder; one that does not returns false and its caller goes
         // without the image.
         virtual bool DecodeImageToBgra(const std::span<const uint8_t> data, std::vector<RGBQUAD>& pixels, til::size& size) noexcept = 0;
+
+        // Some content changes on a clock rather than on input, so the adapter has work
+        // to do when nothing is arriving to drive it. It hands the host a routine to run
+        // and then reports the deadline it next wants that routine run at; no deadline
+        // withdraws the request. Arranging the wakeup is the host's business, because the
+        // host owns the render thread: the adapter says when it has work, not when to run.
+        virtual void SetTimedContentHandler(std::function<void()> handler) = 0;
+        virtual void RequestTimedContentUpdate(const std::optional<std::chrono::steady_clock::time_point> deadline) = 0;
 
         // The pixel size of a text cell, for anything that has to lay pixels out against
         // the grid.

--- a/src/terminal/adapter/KittyParser.cpp
+++ b/src/terminal/adapter/KittyParser.cpp
@@ -42,6 +42,7 @@ void KittyParser::SaveMainBufferState() noexcept
 {
     _mainBufferState.emplace(_takeBufferState());
     _clearChunk();
+    _scheduleAnimationTimer();
 }
 
 void KittyParser::DiscardBufferState() noexcept
@@ -58,6 +59,8 @@ void KittyParser::RestoreMainBufferState() noexcept
         _mainBufferState.reset();
         _restoreBufferState(std::move(state));
     }
+    RefreshImageLayers();
+    _scheduleAnimationTimer();
 }
 
 // Handles the Kitty graphics protocol (APC G <control>;<payload> ST). The parser
@@ -900,6 +903,42 @@ void KittyParser::_ProcessCommand(const Control& command, const std::string_view
             }
             break;
         }
+        case L'f': // transmit animation frame
+        case L'a': // control animation
+        case L'c': // compose animation frames
+        {
+            uint32_t targetId = 0;
+            if (haveId)
+            {
+                targetId = imageId;
+            }
+            else if (haveNumber)
+            {
+                const auto it = _imageNumbers.find(imageNumber);
+                if (it != _imageNumbers.end())
+                {
+                    targetId = it->second;
+                }
+            }
+            if (targetId == 0)
+            {
+                success = false;
+                code = L"ENOENT:image not found";
+            }
+            else if (action == L'f')
+            {
+                success = _processAnimationFrame(command, payload, payloadValid, payloadTooLarge, targetId, code);
+            }
+            else if (action == L'a')
+            {
+                success = _processAnimationControl(command, targetId, code);
+            }
+            else
+            {
+                success = _processFrameComposition(command, targetId, code);
+            }
+            break;
+        }
         case L'd': // delete
         {
             // Lowercase d= selectors delete placements + on-screen pixels but KEEP the image data
@@ -1034,6 +1073,28 @@ void KittyParser::_ProcessCommand(const Control& command, const std::string_view
                     _deletePlacementsByZ(command.zIndex, freeData, til::point{ x, y });
                 }
                 break;
+            case L'f': // delete animation frame r= (default: root frame)
+            case L'F':
+            {
+                uint32_t targetId = 0;
+                if (haveId)
+                {
+                    targetId = imageId;
+                }
+                else if (haveNumber)
+                {
+                    const auto it = _imageNumbers.find(imageNumber);
+                    if (it != _imageNumbers.end())
+                    {
+                        targetId = it->second;
+                    }
+                }
+                if (targetId != 0)
+                {
+                    _deleteAnimationFrames(targetId, command.rows == 0 ? 1 : command.rows, freeData);
+                }
+                break;
+            }
             default:
                 success = false;
                 code = L"EINVAL:unsupported delete target";
@@ -1216,6 +1277,11 @@ void KittyParser::_eraseImage(const uint32_t id)
         return;
     }
     _totalPixelBytes -= it->second.PixelBytes();
+    // If this image was the one the host is waiting on, the deadline it was told
+    // about is about to name an image that no longer exists, so it has to be
+    // recomputed. Nothing changes when a still image goes, and this runs inside
+    // loops that drop many at once, so only pay for it when it can matter.
+    const auto wasAnimating = it->second.animationState == 2 || it->second.animationState == 3;
     // Only drop the reverse entry if it still points at this id (a newer image
     // may have taken over the number).
     if (it->second.number != 0)
@@ -1250,6 +1316,10 @@ void KittyParser::_eraseImage(const uint32_t id)
     {
         _imageOrder.erase(std::remove(_imageOrder.begin(), _imageOrder.end(), id), _imageOrder.end());
     }
+    if (wasAnimating)
+    {
+        _scheduleAnimationTimer();
+    }
 }
 
 // Clears the entire image registry and erases all drawn kitty placements, leaving any
@@ -1265,6 +1335,7 @@ try
     _placements.clear();
     _anonymousPlacements.clear();
     _totalPixelBytes = 0;
+    _scheduleAnimationTimer();
     auto page = _dispatcher._pages.ActivePage();
     auto& buffer = page.Buffer();
     auto erased = false;
@@ -1400,6 +1471,734 @@ std::vector<RGBQUAD> KittyParser::_decodePixels(const uint32_t format, const std
     return pixels;
 }
 
+RGBQUAD KittyParser::_rgbaColor(const uint32_t rgba) noexcept
+{
+    const auto alpha = rgba & 0xffu;
+    RGBQUAD pixel{};
+    pixel.rgbRed = static_cast<BYTE>(((rgba >> 24) & 0xffu) * alpha / 255u);
+    pixel.rgbGreen = static_cast<BYTE>(((rgba >> 16) & 0xffu) * alpha / 255u);
+    pixel.rgbBlue = static_cast<BYTE>(((rgba >> 8) & 0xffu) * alpha / 255u);
+    pixel.rgbReserved = static_cast<BYTE>(alpha);
+    return pixel;
+}
+
+void KittyParser::_compositePixels(const std::span<RGBQUAD> destination, const std::span<const RGBQUAD> source, const bool replace) noexcept
+{
+    const auto count = std::min(destination.size(), source.size());
+    for (size_t i = 0; i < count; ++i)
+    {
+        const auto& src = source[i];
+        auto& dst = destination[i];
+        if (replace)
+        {
+            dst = src;
+            continue;
+        }
+        const auto inverseAlpha = 255u - src.rgbReserved;
+        dst.rgbRed = static_cast<BYTE>(std::min(255u, static_cast<uint32_t>(src.rgbRed) + (static_cast<uint32_t>(dst.rgbRed) * inverseAlpha + 127u) / 255u));
+        dst.rgbGreen = static_cast<BYTE>(std::min(255u, static_cast<uint32_t>(src.rgbGreen) + (static_cast<uint32_t>(dst.rgbGreen) * inverseAlpha + 127u) / 255u));
+        dst.rgbBlue = static_cast<BYTE>(std::min(255u, static_cast<uint32_t>(src.rgbBlue) + (static_cast<uint32_t>(dst.rgbBlue) * inverseAlpha + 127u) / 255u));
+        dst.rgbReserved = static_cast<BYTE>(std::min(255u, static_cast<uint32_t>(src.rgbReserved) + (static_cast<uint32_t>(dst.rgbReserved) * inverseAlpha + 127u) / 255u));
+    }
+}
+
+size_t KittyParser::_frameCount(const Image& image) noexcept
+{
+    return image.pixels.empty() ? 0 : image.animationFrames.size() + 1;
+}
+
+std::vector<RGBQUAD>* KittyParser::_framePixels(Image& image, const uint32_t frameNumber) noexcept
+{
+    if (frameNumber == 1)
+    {
+        return &image.pixels;
+    }
+    const auto index = static_cast<size_t>(frameNumber) - 2;
+    return index < image.animationFrames.size() ? &image.animationFrames[index].pixels : nullptr;
+}
+
+const std::vector<RGBQUAD>* KittyParser::_framePixels(const Image& image, const uint32_t frameNumber) noexcept
+{
+    if (frameNumber == 1)
+    {
+        return &image.pixels;
+    }
+    const auto index = static_cast<size_t>(frameNumber) - 2;
+    return index < image.animationFrames.size() ? &image.animationFrames[index].pixels : nullptr;
+}
+
+int32_t* KittyParser::_frameGap(Image& image, const uint32_t frameNumber) noexcept
+{
+    if (frameNumber == 1)
+    {
+        return &image.rootGapMilliseconds;
+    }
+    const auto index = static_cast<size_t>(frameNumber) - 2;
+    return index < image.animationFrames.size() ? &image.animationFrames[index].gapMilliseconds : nullptr;
+}
+
+void KittyParser::_updateImageLayers(const uint32_t imageId, const std::span<const RGBQUAD> pixels)
+{
+    const auto image = _images.find(imageId);
+    if (image == _images.end() || !image->second.hasRenderedPlacements)
+    {
+        return;
+    }
+
+    const auto visiblePageNumber = _dispatcher._pages.VisiblePage().Number();
+    auto foundLayer = false;
+    _dispatcher._pages.ForEachPage([&](const Page page) {
+        auto& buffer = page.Buffer();
+        auto firstRow = page.Bottom();
+        auto lastRow = 0;
+        for (auto row = 0; row < page.Bottom(); ++row)
+        {
+            const auto* slice = buffer.GetRowByOffset(row).GetImageSlice();
+            if (slice && slice->Contains(imageId))
+            {
+                foundLayer = true;
+                auto* mutableSlice = buffer.GetMutableRowByOffset(row).GetMutableImageSlice();
+                if (mutableSlice->UpdateImage(imageId, pixels))
+                {
+                    firstRow = std::min(firstRow, row);
+                    lastRow = std::max(lastRow, row);
+                }
+            }
+        }
+        if (page.Number() == visiblePageNumber && firstRow <= lastRow)
+        {
+            buffer.TriggerRedraw(Viewport::FromExclusive({ 0, firstRow, page.Width(), lastRow + 1 }));
+        }
+    });
+    if (!foundLayer)
+    {
+        image->second.hasRenderedPlacements = false;
+    }
+}
+
+void KittyParser::RefreshImageLayers()
+{
+    for (const auto& [imageId, image] : _images)
+    {
+        if (image.animationFrames.empty())
+        {
+            continue;
+        }
+        if (const auto pixels = _framePixels(image, image.presentedFrame))
+        {
+            _updateImageLayers(imageId, *pixels);
+        }
+    }
+    _scheduleAnimationTimer();
+}
+
+bool KittyParser::_processAnimationFrame(const Control& command, const std::string_view payload, const bool payloadValid, const bool payloadTooLarge, const uint32_t imageId, std::wstring_view& code)
+try
+{
+    auto imageIt = _images.find(imageId);
+    if (imageIt == _images.end())
+    {
+        code = L"ENOENT:image not found";
+        return false;
+    }
+    if (command.medium != L'd' || command.compression != 0)
+    {
+        code = command.medium != L'd' ? L"EINVAL:unsupported transmission medium" : L"EINVAL:unsupported compression";
+        return false;
+    }
+    if (command.format != 24 && command.format != 32 && command.format != 100)
+    {
+        code = L"EINVAL:unsupported format";
+        return false;
+    }
+    if (command.upperX > 1)
+    {
+        code = L"EINVAL:invalid frame composition mode";
+        return false;
+    }
+
+    std::vector<uint8_t> bytes;
+    if (!payloadValid || !_DecodeBase64(payload, bytes))
+    {
+        code = payloadTooLarge ? L"EFBIG:payload exceeds maximum size" : L"EINVAL:bad payload";
+        return false;
+    }
+
+    uint32_t frameWidth = 0;
+    uint32_t frameHeight = 0;
+    std::vector<RGBQUAD> framePixels;
+    if (command.format == 24 || command.format == 32)
+    {
+        const auto depth = command.format == 24 ? 3u : 4u;
+        if (command.width == 0 || command.height == 0)
+        {
+            code = L"EINVAL:missing frame dimensions";
+            return false;
+        }
+        const auto area = static_cast<uint64_t>(command.width) * command.height;
+        if (area > bytes.size() / depth || area * depth != bytes.size())
+        {
+            code = L"EINVAL:payload size mismatch";
+            return false;
+        }
+        frameWidth = command.width;
+        frameHeight = command.height;
+        framePixels = _decodePixels(command.format, bytes);
+    }
+    else
+    {
+        til::size decodedSize;
+        if (bytes.empty() ||
+            !_dispatcher._api.DecodeImageToBgra(bytes, framePixels, decodedSize) ||
+            decodedSize.width <= 0 || decodedSize.height <= 0 ||
+            framePixels.size() != static_cast<size_t>(decodedSize.width) * decodedSize.height)
+        {
+            code = L"EBADPNG:could not decode frame";
+            return false;
+        }
+        frameWidth = static_cast<uint32_t>(decodedSize.width);
+        frameHeight = static_cast<uint32_t>(decodedSize.height);
+    }
+
+    auto& image = imageIt->second;
+    if (command.srcX > image.width || command.srcY > image.height ||
+        frameWidth > image.width - command.srcX || frameHeight > image.height - command.srcY)
+    {
+        code = L"EINVAL:frame rectangle out of bounds";
+        return false;
+    }
+
+    const auto editFrame = command.rows;
+    const auto backgroundFrame = command.cols;
+    if (editFrame != 0 && backgroundFrame != 0)
+    {
+        code = L"EINVAL:cannot edit and create a frame simultaneously";
+        return false;
+    }
+    if (editFrame == 0 && _frameCount(image) >= MaxFramesPerImage)
+    {
+        code = L"ENOSPC:frame count limit exceeded";
+        return false;
+    }
+    if (editFrame != 0 && !_framePixels(image, editFrame))
+    {
+        code = L"ENOENT:frame not found";
+        return false;
+    }
+    if (editFrame == 0 && backgroundFrame != 0 && !_framePixels(image, backgroundFrame))
+    {
+        code = L"ENOENT:background frame not found";
+        return false;
+    }
+
+    const auto frameBytes = image.pixels.size() * sizeof(RGBQUAD);
+    std::vector<uint32_t> victims;
+    if (editFrame == 0)
+    {
+        // A victim whose placement is an ancestor of the target would cascade-delete
+        // the image we are extending. Build the target's bounded parent ancestry once,
+        // then exclude those image ids from the eviction plan.
+        std::vector<uint32_t> protectedImageIds{ imageId };
+        const auto protectAncestors = [&](std::pair<uint32_t, uint32_t> parent) {
+            for (auto depth = 0; depth < MaxPlacementDepth; ++depth)
+            {
+                if (std::find(protectedImageIds.begin(), protectedImageIds.end(), parent.first) == protectedImageIds.end())
+                {
+                    protectedImageIds.push_back(parent.first);
+                }
+                const auto placement = _placements.find(parent);
+                if (placement == _placements.end() || !placement->second.hasParent)
+                {
+                    break;
+                }
+                parent = { placement->second.parentImageId, placement->second.parentPlacementId };
+            }
+        };
+        for (const auto& [key, placement] : _placements)
+        {
+            if (key.first == imageId && placement.hasParent)
+            {
+                protectAncestors({ placement.parentImageId, placement.parentPlacementId });
+            }
+        }
+        for (const auto& placement : _anonymousPlacements)
+        {
+            if (placement.imageId == imageId && placement.hasParent)
+            {
+                protectAncestors({ placement.parentImageId, placement.parentPlacementId });
+            }
+        }
+
+        const auto retainedBytes = _retainedPixelBytes();
+        const auto requiredBytes = retainedBytes > MaxTotalBytes - frameBytes ?
+                                       retainedBytes - (MaxTotalBytes - frameBytes) :
+                                       size_t{ 0 };
+        auto reclaimableBytes = size_t{ 0 };
+        if (requiredBytes != 0)
+        {
+            for (const auto candidateId : _imageOrder)
+            {
+                if (std::find(protectedImageIds.begin(), protectedImageIds.end(), candidateId) != protectedImageIds.end())
+                {
+                    continue;
+                }
+                const auto candidate = _images.find(candidateId);
+                if (candidate == _images.end())
+                {
+                    continue;
+                }
+                victims.push_back(candidateId);
+                reclaimableBytes += candidate->second.PixelBytes();
+                if (reclaimableBytes >= requiredBytes)
+                {
+                    break;
+                }
+            }
+        }
+        if (reclaimableBytes < requiredBytes)
+        {
+            code = L"ENOSPC:image storage limit exceeded";
+            return false;
+        }
+    }
+
+    auto canvas = std::vector<RGBQUAD>{};
+    if (editFrame != 0)
+    {
+        canvas = *_framePixels(imageIt->second, editFrame);
+    }
+    else if (backgroundFrame != 0)
+    {
+        canvas = *_framePixels(imageIt->second, backgroundFrame);
+    }
+    else
+    {
+        canvas.assign(imageIt->second.pixels.size(), _rgbaColor(command.upperY));
+    }
+
+    for (uint32_t row = 0; row < frameHeight; ++row)
+    {
+        const auto srcOffset = static_cast<size_t>(row) * frameWidth;
+        const auto dstOffset = static_cast<size_t>(command.srcY + row) * imageIt->second.width + command.srcX;
+        _compositePixels(std::span{ canvas }.subspan(dstOffset, frameWidth),
+                              std::span{ framePixels }.subspan(srcOffset, frameWidth),
+                              command.upperX == 1);
+    }
+
+    if (editFrame == 0)
+    {
+        // Allocate every fallible part of the append before eviction mutates unrelated
+        // images. The subsequent frame move cannot allocate once capacity is reserved.
+        imageIt->second.animationFrames.reserve(imageIt->second.animationFrames.size() + 1);
+        for (const auto victimId : victims)
+        {
+            if (_images.count(victimId) == 0)
+            {
+                continue;
+            }
+            _erasePlacementsForImage(victimId);
+            _eraseImageRows(victimId);
+            _eraseImage(victimId);
+        }
+        imageIt = _images.find(imageId);
+        WI_ASSERT(imageIt != _images.end());
+    }
+
+    auto& storedImage = imageIt->second;
+    uint32_t changedFrame = 0;
+    if (editFrame != 0)
+    {
+        *_framePixels(storedImage, editFrame) = std::move(canvas);
+        changedFrame = editFrame;
+        if (command.haveZ && command.zIndex != 0)
+        {
+            *_frameGap(storedImage, editFrame) = command.zIndex;
+        }
+    }
+    else
+    {
+        AnimationFrame frame;
+        frame.pixels = std::move(canvas);
+        frame.gapMilliseconds = command.haveZ && command.zIndex != 0 ? command.zIndex : 40;
+        storedImage.animationFrames.push_back(std::move(frame));
+        _totalPixelBytes += frameBytes;
+        changedFrame = gsl::narrow_cast<uint32_t>(_frameCount(storedImage));
+    }
+
+    if (storedImage.presentedFrame == changedFrame)
+    {
+        _updateImageLayers(imageId, *_framePixels(storedImage, changedFrame));
+    }
+    const auto now = std::chrono::steady_clock::now();
+    if (storedImage.animationState == 2 && storedImage.waitingForFrames)
+    {
+        storedImage.waitingForFrames = false;
+        _advanceImage(imageId, storedImage, now);
+    }
+    else if (storedImage.currentFrame == changedFrame &&
+             command.haveZ && command.zIndex != 0 &&
+             (storedImage.animationState == 2 || storedImage.animationState == 3))
+    {
+        _scheduleAnimation(imageId, storedImage, now);
+    }
+    _scheduleAnimationTimer();
+    return true;
+}
+catch (const std::bad_alloc&)
+{
+    code = L"ENOSPC:could not allocate frame";
+    return false;
+}
+
+bool KittyParser::_processAnimationControl(const Control& command, const uint32_t imageId, std::wstring_view& code)
+{
+    const auto imageIt = _images.find(imageId);
+    if (imageIt == _images.end())
+    {
+        code = L"ENOENT:image not found";
+        return false;
+    }
+    auto& image = imageIt->second;
+    if (command.width > 3)
+    {
+        code = L"EINVAL:invalid animation state";
+        return false;
+    }
+    if (command.cols != 0 && !_framePixels(image, command.cols))
+    {
+        code = L"ENOENT:frame not found";
+        return false;
+    }
+    if (command.rows != 0 && !_frameGap(image, command.rows))
+    {
+        code = L"ENOENT:frame not found";
+        return false;
+    }
+
+    auto reschedule = false;
+    if (command.cols != 0)
+    {
+        image.currentFrame = command.cols;
+        image.presentedFrame = image.currentFrame;
+        _updateImageLayers(imageId, *_framePixels(image, image.currentFrame));
+        reschedule = true;
+    }
+    if (command.rows != 0 && command.haveZ && command.zIndex != 0)
+    {
+        *_frameGap(image, command.rows) = command.zIndex;
+        reschedule |= command.rows == image.currentFrame;
+    }
+    if (command.height != 0)
+    {
+        image.loopCount = command.height;
+        image.loopsRemaining = command.height == 1 ? UINT32_MAX : command.height - 1;
+    }
+    if (command.width != 0)
+    {
+        image.animationState = command.width;
+        image.waitingForFrames = false;
+        image.nextFrameTime = {};
+        image.loopsRemaining = image.loopCount == 1 ? UINT32_MAX : image.loopCount - 1;
+        reschedule = true;
+    }
+
+    if (image.animationState == 1)
+    {
+        image.nextFrameTime = {};
+        image.waitingForFrames = false;
+    }
+    else if (reschedule)
+    {
+        _scheduleAnimation(imageId, image, std::chrono::steady_clock::now());
+    }
+    _scheduleAnimationTimer();
+    return true;
+}
+
+bool KittyParser::_processFrameComposition(const Control& command, const uint32_t imageId, std::wstring_view& code)
+try
+{
+    const auto imageIt = _images.find(imageId);
+    if (imageIt == _images.end())
+    {
+        code = L"ENOENT:image not found";
+        return false;
+    }
+    auto& image = imageIt->second;
+    const auto sourceFrame = command.rows;
+    const auto destinationFrame = command.cols;
+    const auto* source = _framePixels(image, sourceFrame);
+    auto* destination = _framePixels(image, destinationFrame);
+    if (sourceFrame == 0 || destinationFrame == 0 || !source || !destination)
+    {
+        code = L"ENOENT:frame not found";
+        return false;
+    }
+
+    const auto width = command.srcW == 0 ? image.width : command.srcW;
+    const auto height = command.srcH == 0 ? image.height : command.srcH;
+    if (width == 0 || height == 0 ||
+        command.srcX > image.width || command.srcY > image.height ||
+        command.upperX > image.width || command.upperY > image.height ||
+        width > image.width - command.srcX || height > image.height - command.srcY ||
+        width > image.width - command.upperX || height > image.height - command.upperY)
+    {
+        code = L"EINVAL:composition rectangle out of bounds";
+        return false;
+    }
+
+    const til::rect sourceRect{
+        gsl::narrow_cast<til::CoordType>(command.upperX),
+        gsl::narrow_cast<til::CoordType>(command.upperY),
+        gsl::narrow_cast<til::CoordType>(command.upperX + width),
+        gsl::narrow_cast<til::CoordType>(command.upperY + height),
+    };
+    const til::rect destinationRect{
+        gsl::narrow_cast<til::CoordType>(command.srcX),
+        gsl::narrow_cast<til::CoordType>(command.srcY),
+        gsl::narrow_cast<til::CoordType>(command.srcX + width),
+        gsl::narrow_cast<til::CoordType>(command.srcY + height),
+    };
+    const auto rectanglesOverlap = sourceRect.left < destinationRect.right &&
+                                   destinationRect.left < sourceRect.right &&
+                                   sourceRect.top < destinationRect.bottom &&
+                                   destinationRect.top < sourceRect.bottom;
+    if (sourceFrame == destinationFrame && rectanglesOverlap)
+    {
+        code = L"EINVAL:overlapping self-composition";
+        return false;
+    }
+
+    std::vector<RGBQUAD> sourcePixels(static_cast<size_t>(width) * height);
+    for (uint32_t row = 0; row < height; ++row)
+    {
+        const auto srcOffset = static_cast<size_t>(command.upperY + row) * image.width + command.upperX;
+        std::copy_n(source->begin() + srcOffset, width, sourcePixels.begin() + static_cast<size_t>(row) * width);
+    }
+    for (uint32_t row = 0; row < height; ++row)
+    {
+        const auto dstOffset = static_cast<size_t>(command.srcY + row) * image.width + command.srcX;
+        _compositePixels(std::span{ *destination }.subspan(dstOffset, width),
+                              std::span{ sourcePixels }.subspan(static_cast<size_t>(row) * width, width),
+                              command.noCursorMovement);
+    }
+    if (image.presentedFrame == destinationFrame)
+    {
+        _updateImageLayers(imageId, *destination);
+    }
+    return true;
+}
+catch (const std::bad_alloc&)
+{
+    code = L"ENOSPC:could not compose frame";
+    return false;
+}
+
+void KittyParser::_scheduleAnimation(const uint32_t imageId, Image& image, const std::chrono::steady_clock::time_point now)
+{
+    if (image.animationState != 2 && image.animationState != 3)
+    {
+        image.nextFrameTime = {};
+        return;
+    }
+    const auto* gap = _frameGap(image, image.currentFrame);
+    if (!gap)
+    {
+        image.animationState = 1;
+        image.nextFrameTime = {};
+        return;
+    }
+    if (*gap > 0)
+    {
+        image.waitingForFrames = false;
+        if (image.presentedFrame != image.currentFrame)
+        {
+            image.presentedFrame = image.currentFrame;
+            _updateImageLayers(imageId, *_framePixels(image, image.presentedFrame));
+        }
+        image.nextFrameTime = now + std::chrono::milliseconds(*gap);
+    }
+    else
+    {
+        image.nextFrameTime = now;
+        _advanceImage(imageId, image, now);
+    }
+}
+
+bool KittyParser::_advanceImage(const uint32_t imageId, Image& image, const std::chrono::steady_clock::time_point now)
+{
+    if (image.animationState != 2 && image.animationState != 3)
+    {
+        image.nextFrameTime = {};
+        return false;
+    }
+
+    const auto frameCount = gsl::narrow_cast<uint32_t>(_frameCount(image));
+    if (frameCount < 2)
+    {
+        image.waitingForFrames = image.animationState == 2;
+        image.nextFrameTime = {};
+        return false;
+    }
+
+    // A full pass is enough to prove that every frame is gapless. Stop rather
+    // than spin forever on an animation that can never present a frame.
+    for (uint32_t skipped = 0; skipped <= frameCount; ++skipped)
+    {
+        if (image.currentFrame < frameCount)
+        {
+            ++image.currentFrame;
+        }
+        else if (image.animationState == 2)
+        {
+            image.waitingForFrames = true;
+            image.nextFrameTime = {};
+            return false;
+        }
+        else
+        {
+            if (image.loopsRemaining != UINT32_MAX)
+            {
+                if (image.loopsRemaining == 0)
+                {
+                    image.animationState = 1;
+                    image.nextFrameTime = {};
+                    return false;
+                }
+                --image.loopsRemaining;
+            }
+            image.currentFrame = 1;
+        }
+
+        const auto* gap = _frameGap(image, image.currentFrame);
+        if (gap && *gap > 0)
+        {
+            image.waitingForFrames = false;
+            image.presentedFrame = image.currentFrame;
+            _updateImageLayers(imageId, *_framePixels(image, image.currentFrame));
+            image.nextFrameTime = now + std::chrono::milliseconds(*gap);
+            return true;
+        }
+    }
+
+    image.animationState = 1;
+    image.nextFrameTime = {};
+    return false;
+}
+
+void KittyParser::AdvanceAnimations(const std::chrono::steady_clock::time_point now)
+{
+    for (auto& [imageId, image] : _images)
+    {
+        if ((image.animationState == 2 || image.animationState == 3) &&
+            image.nextFrameTime != std::chrono::steady_clock::time_point{} &&
+            image.nextFrameTime <= now)
+        {
+            _advanceImage(imageId, image, now);
+        }
+    }
+    _scheduleAnimationTimer();
+}
+
+// Animated images advance on their own schedule, with nothing arriving in the
+// stream to drive them. Work out when the soonest one is due and tell the host,
+// which owns the render thread and decides how to arrange the wakeup. Whether
+// that deadline is honoured early, late, or coalesced with other work is the
+// host's business; this only reports when there is something to do.
+void KittyParser::_scheduleAnimationTimer()
+{
+    auto earliest = std::chrono::steady_clock::time_point::max();
+    for (const auto& [id, image] : _images)
+    {
+        static_cast<void>(id);
+        if ((image.animationState == 2 || image.animationState == 3) &&
+            image.nextFrameTime != std::chrono::steady_clock::time_point{})
+        {
+            earliest = std::min(earliest, image.nextFrameTime);
+        }
+    }
+    _dispatcher._api.RequestTimedContentUpdate(earliest == std::chrono::steady_clock::time_point::max() ?
+                                                   std::nullopt :
+                                                   std::optional{ earliest });
+}
+
+void KittyParser::_deleteAnimationFrames(const uint32_t imageId, const uint32_t frameNumber, const bool freeData)
+{
+    const auto imageIt = _images.find(imageId);
+    if (imageIt == _images.end())
+    {
+        return;
+    }
+    auto& image = imageIt->second;
+    const auto frameCount = gsl::narrow_cast<uint32_t>(_frameCount(image));
+    if (frameNumber == 0 || frameNumber > frameCount)
+    {
+        return;
+    }
+    if (frameCount <= 1)
+    {
+        if (freeData)
+        {
+            _erasePlacementsForImage(imageId);
+            _eraseImageRows(imageId);
+            _eraseImage(imageId);
+        }
+        _scheduleAnimationTimer();
+        return;
+    }
+    const auto frameBytes = image.pixels.size() * sizeof(RGBQUAD);
+    if (frameNumber == 1)
+    {
+        auto promoted = std::move(image.animationFrames.front());
+        image.animationFrames.erase(image.animationFrames.begin());
+        image.pixels = std::move(promoted.pixels);
+        image.rootGapMilliseconds = promoted.gapMilliseconds;
+    }
+    else
+    {
+        image.animationFrames.erase(image.animationFrames.begin() + (frameNumber - 2));
+    }
+    _totalPixelBytes -= frameBytes;
+
+    const auto remaining = gsl::narrow_cast<uint32_t>(_frameCount(image));
+    if (image.currentFrame > frameNumber)
+    {
+        --image.currentFrame;
+    }
+    else if (image.currentFrame == frameNumber)
+    {
+        image.currentFrame = std::min(frameNumber, remaining);
+    }
+    if (image.presentedFrame > frameNumber)
+    {
+        --image.presentedFrame;
+    }
+    else if (image.presentedFrame == frameNumber)
+    {
+        image.presentedFrame = std::min(frameNumber, remaining);
+    }
+
+    if (remaining == 1)
+    {
+        image.animationState = 1;
+        image.waitingForFrames = false;
+        image.nextFrameTime = {};
+    }
+    _updateImageLayers(imageId, *_framePixels(image, image.presentedFrame));
+
+    if (freeData && remaining == 1)
+    {
+        _erasePlacementsForImage(imageId);
+        _eraseImageRows(imageId);
+        _eraseImage(imageId);
+    }
+    else if (image.animationState == 2 || image.animationState == 3)
+    {
+        _scheduleAnimation(imageId, image, std::chrono::steady_clock::now());
+    }
+    _scheduleAnimationTimer();
+}
+
 bool KittyParser::_placementFitsMemory(const Image& image, const uint32_t imageId, const uint64_t layerId, const uint32_t cols, const uint32_t rows, const uint32_t srcX, const uint32_t srcY, const uint32_t srcW, const uint32_t srcH, const int32_t zIndex, const std::optional<til::point> anchor) const noexcept
 {
     if (image.pixels.empty() || image.width == 0 || image.height == 0)
@@ -1466,7 +2265,7 @@ bool KittyParser::_placementFitsMemory(const Image& image, const uint32_t imageI
 // Protocol: https://sw.kovidgoyal.net/kitty/graphics-protocol/#controlling-displayed-image-layout
 til::size KittyParser::_placeImage(const Image& image, const bool moveCursor, const uint32_t imageId, const uint64_t layerId, const uint32_t cols, const uint32_t rows, const uint32_t srcX, const uint32_t srcY, const uint32_t srcW, const uint32_t srcH, const uint32_t cellOffsetX, const uint32_t cellOffsetY, const int32_t zIndex, const std::optional<til::point> anchor)
 {
-    const auto framePixels = &image.pixels;
+    const auto framePixels = _framePixels(image, image.presentedFrame);
     if (!framePixels || framePixels->empty() || image.width == 0 || image.height == 0)
     {
         return {};
@@ -1567,6 +2366,7 @@ til::size KittyParser::_placeImage(const Image& image, const bool moveCursor, co
         staged->BumpRevision();
         const auto dstSlice = staged.get();
         auto dstIterator = dstSlice->MutablePixels(columnBegin, columnEnd, { imageId, layerId }, zIndex);
+        auto sourceIterator = dstSlice->MutableSourceIndices(columnBegin, columnEnd, { imageId, layerId }, zIndex);
         for (auto pixelRow = 0; pixelRow < cellHeight; ++pixelRow)
         {
             const auto dstY = row * cellHeight + pixelRow;
@@ -1580,19 +2380,23 @@ til::size KittyParser::_placeImage(const Image& image, const bool moveCursor, co
             for (auto pixelColumn = 0; pixelColumn < drawWidth; ++pixelColumn)
             {
                 RGBQUAD px{};
+                auto sourceIndex = ImageSlice::NoSourceIndex;
                 if (rowInImage && sampleXMap[pixelColumn] >= 0)
                 {
                     const auto srcIndex = srcRowStart + static_cast<size_t>(sampleXMap[pixelColumn]);
                     if (srcIndex < framePixels->size())
                     {
                         px = til::at(*framePixels, srcIndex);
+                        sourceIndex = gsl::narrow_cast<uint32_t>(srcIndex);
                     }
                 }
                 til::at(dstIterator, pixelColumn) = px;
+                til::at(sourceIterator, pixelColumn) = sourceIndex;
             }
             if (pixelRow + 1 < cellHeight)
             {
                 std::advance(dstIterator, dstSlice->PixelWidth());
+                std::advance(sourceIterator, dstSlice->PixelWidth());
             }
         }
     }
@@ -2233,6 +3037,7 @@ void KittyParser::_deleteAllPlacements(const bool freeData)
             _eraseImageRows(imageId);
         }
     }
+    _scheduleAnimationTimer();
 }
 
 // Deletes every NON-VIRTUAL image with at least one physical placement inside the half-open cell
@@ -2751,7 +3556,7 @@ int KittyParser::_PlaceholderDiacriticIndex(const char32_t ch) noexcept
 // redraw (the caller batches one bounded redraw per segment). Returns true if a tile was drawn.
 bool KittyParser::_placeImageCellRef(const Image& image, const uint32_t imageId, const til::CoordType column, const til::CoordType row, const uint32_t cellRow, const uint32_t cellCol, const VirtualPlacement& place)
 {
-    const auto framePixels = &image.pixels;
+    const auto framePixels = _framePixels(image, image.presentedFrame);
     if (!framePixels || framePixels->empty() || image.width == 0 || image.height == 0)
     {
         return false;
@@ -2801,6 +3606,7 @@ bool KittyParser::_placeImageCellRef(const Image& image, const uint32_t imageId,
         dstSlice = dstRow.SetImageSlice(std::make_unique<ImageSlice>(clampedCellSize));
     }
     auto dstIterator = dstSlice->MutablePixels(column, column + 1, { imageId, place.layerId }, place.zIndex);
+    auto sourceIterator = dstSlice->MutableSourceIndices(column, column + 1, { imageId, place.layerId }, place.zIndex);
     for (auto pixelRow = 0; pixelRow < cellHeight; ++pixelRow)
     {
         const auto targetY = targetYBase + pixelRow;
@@ -2815,15 +3621,18 @@ bool KittyParser::_placeImageCellRef(const Image& image, const uint32_t imageId,
                 const auto sampleX = cropX + std::min(cropW - 1, static_cast<til::CoordType>(targetX * cropW / targetW));
                 const auto srcIndex = srcRowStart + static_cast<size_t>(sampleX);
                 til::at(dstIterator, pixelColumn) = srcIndex < framePixels->size() ? til::at(*framePixels, srcIndex) : RGBQUAD{};
+                til::at(sourceIterator, pixelColumn) = srcIndex < framePixels->size() ? gsl::narrow_cast<uint32_t>(srcIndex) : ImageSlice::NoSourceIndex;
             }
             else
             {
                 til::at(dstIterator, pixelColumn) = RGBQUAD{}; // aspect padding beyond the scaled target
+                til::at(sourceIterator, pixelColumn) = ImageSlice::NoSourceIndex;
             }
         }
         if (pixelRow + 1 < cellHeight)
         {
             std::advance(dstIterator, dstSlice->PixelWidth());
+            std::advance(sourceIterator, dstSlice->PixelWidth());
         }
     }
     return true;

--- a/src/terminal/adapter/KittyParser.hpp
+++ b/src/terminal/adapter/KittyParser.hpp
@@ -51,6 +51,16 @@ namespace Microsoft::Console::VirtualTerminal
         // Resolves the placeholder cells in a run of text the writer just placed.
         void RenderPlaceholders(const std::wstring_view segment, const til::CoordType screenRow, const til::CoordType startColumn);
 
+        // Runs every animated image forward to the given time, then reports when it
+        // next needs to be called. The host calls this when the deadline it was last
+        // given comes due.
+        void AdvanceAnimations(std::chrono::steady_clock::time_point now);
+
+        // Re-pushes every placement's pixels into the active page's buffer. The
+        // registry outlives the buffer it drew into, so anything that swaps the
+        // buffer under it has to ask for the layers again.
+        void RefreshImageLayers();
+
         // Drops every image, every placement, and any transfer in progress.
         void HardReset() noexcept;
 
@@ -108,18 +118,38 @@ namespace Microsoft::Console::VirtualTerminal
             bool havePlacementId = false;    // true if p= was present (so p= is echoed in the ack)
             bool haveParent = false;         // true if P= was present (a relative placement was requested)
         };
-        // A stored Kitty image: RGBA pixels plus the canvas dimensions they describe.
+        struct AnimationFrame
+        {
+            std::vector<RGBQUAD> pixels;
+            int32_t gapMilliseconds = 0;
+        };
+        // A stored Kitty image. Frame 1 is the root pixel vector; additional
+        // full-canvas frames share its dimensions and carry their own next-frame gap.
         struct Image
         {
             uint32_t number = 0;
             uint32_t width = 0;
             uint32_t height = 0;
             std::vector<RGBQUAD> pixels;
+            int32_t rootGapMilliseconds = 0;
+            std::vector<AnimationFrame> animationFrames;
+            uint32_t currentFrame = 1;
+            uint32_t animationState = 1;
+            uint32_t loopCount = 1;
+            uint32_t loopsRemaining = UINT32_MAX;
+            uint32_t presentedFrame = 1;
+            bool waitingForFrames = false;
             bool hasRenderedPlacements = false;
+            std::chrono::steady_clock::time_point nextFrameTime{};
 
             size_t PixelBytes() const noexcept
             {
-                return pixels.size() * sizeof(RGBQUAD);
+                auto bytes = pixels.size() * sizeof(RGBQUAD);
+                for (const auto& frame : animationFrames)
+                {
+                    bytes += frame.pixels.size() * sizeof(RGBQUAD);
+                }
+                return bytes;
             }
         };
         // The target pixel size a c=/r= request maps to (one axis preserves aspect). Shared
@@ -210,6 +240,20 @@ namespace Microsoft::Console::VirtualTerminal
         static bool _DecodeBase64(const std::string_view input, std::vector<uint8_t>& output) noexcept;
         static bool _inflateZlib(const std::vector<uint8_t>& input, std::vector<uint8_t>& output, size_t cap) noexcept;
         static std::vector<RGBQUAD> _decodePixels(const uint32_t format, const std::vector<uint8_t>& bytes);
+        static RGBQUAD _rgbaColor(uint32_t rgba) noexcept;
+        static void _compositePixels(std::span<RGBQUAD> destination, std::span<const RGBQUAD> source, bool replace) noexcept;
+        static size_t _frameCount(const Image& image) noexcept;
+        static std::vector<RGBQUAD>* _framePixels(Image& image, uint32_t frameNumber) noexcept;
+        static const std::vector<RGBQUAD>* _framePixels(const Image& image, uint32_t frameNumber) noexcept;
+        static int32_t* _frameGap(Image& image, uint32_t frameNumber) noexcept;
+        void _updateImageLayers(uint32_t imageId, std::span<const RGBQUAD> pixels);
+        void _scheduleAnimation(uint32_t imageId, Image& image, std::chrono::steady_clock::time_point now);
+        void _scheduleAnimationTimer();
+        bool _advanceImage(uint32_t imageId, Image& image, std::chrono::steady_clock::time_point now);
+        bool _processAnimationFrame(const Control& command, const std::string_view payload, bool payloadValid, bool payloadTooLarge, uint32_t imageId, std::wstring_view& code);
+        bool _processAnimationControl(const Control& command, uint32_t imageId, std::wstring_view& code);
+        bool _processFrameComposition(const Control& command, uint32_t imageId, std::wstring_view& code);
+        void _deleteAnimationFrames(uint32_t imageId, uint32_t frameNumber, bool freeData);
         uint32_t _assignImageId();
         bool _registerImage(const uint32_t id, Image&& image);
         void _eraseImage(const uint32_t id);
@@ -270,6 +314,7 @@ namespace Microsoft::Console::VirtualTerminal
         std::unordered_map<uint32_t, Image> _images;
         std::unordered_map<uint32_t, uint32_t> _imageNumbers;
         std::deque<uint32_t> _imageOrder;
+
         // Virtual placements keyed by the external (image id, placement id). U+10EEEE selects
         // this key through its foreground and underline colors.
         std::map<std::pair<uint32_t, uint32_t>, VirtualPlacement> _virtualIds;

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -61,6 +61,21 @@ AdaptDispatch::AdaptDispatch(ITerminalApi& api, Renderer* renderer, RenderSettin
     _termOutput(),
     _pages{ api, renderer }
 {
+    // Animated images have to keep advancing with nothing arriving in the stream to
+    // drive them. Hand the host a routine to run; it decides when to run it.
+    _api.SetTimedContentHandler([this]() {
+        if (_kittyParser)
+        {
+            _kittyParser->AdvanceAnimations(std::chrono::steady_clock::now());
+        }
+    });
+}
+
+AdaptDispatch::~AdaptDispatch()
+{
+    // _api is a reference, so it outlives us; withdraw before the captured pointer
+    // back to this object goes stale.
+    _api.SetTimedContentHandler(nullptr);
 }
 
 void AdaptDispatch::UnknownSequence() noexcept
@@ -1712,6 +1727,17 @@ void AdaptDispatch::PrecedingPage(const VTInt pageCount)
 }
 
 // Routine Description:
+// - Lets the host tell us its font changed. Anything the dispatch has laid out in
+//   pixels was measured against the old cell size and has to be measured again.
+void AdaptDispatch::NotifyFontChanged()
+{
+    if (_kittyParser)
+    {
+        _kittyParser->RefreshImageLayers();
+    }
+}
+
+// Routine Description:
 // - PPA - Moves the active position to the specified page number, without
 //   altering the cursor coordinates.
 // Arguments:
@@ -1719,6 +1745,10 @@ void AdaptDispatch::PrecedingPage(const VTInt pageCount)
 void AdaptDispatch::PagePositionAbsolute(const VTInt page)
 {
     _pages.MoveTo(page, _modes.test(Mode::PageCursorCoupling));
+    if (_kittyParser)
+    {
+        _kittyParser->RefreshImageLayers();
+    }
 }
 
 // Routine Description:
@@ -1729,6 +1759,10 @@ void AdaptDispatch::PagePositionAbsolute(const VTInt page)
 void AdaptDispatch::PagePositionRelative(const VTInt pageCount)
 {
     _pages.MoveRelative(pageCount, _modes.test(Mode::PageCursorCoupling));
+    if (_kittyParser)
+    {
+        _kittyParser->RefreshImageLayers();
+    }
 }
 
 // Routine Description:
@@ -1739,6 +1773,10 @@ void AdaptDispatch::PagePositionRelative(const VTInt pageCount)
 void AdaptDispatch::PagePositionBack(const VTInt pageCount)
 {
     _pages.MoveRelative(-pageCount, _modes.test(Mode::PageCursorCoupling));
+    if (_kittyParser)
+    {
+        _kittyParser->RefreshImageLayers();
+    }
 }
 
 // Routine Description:

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -48,6 +48,9 @@ namespace Microsoft::Console::VirtualTerminal
 
     public:
         AdaptDispatch(ITerminalApi& api, Renderer* renderer, RenderSettings& renderSettings, TerminalInput& terminalInput) noexcept;
+        ~AdaptDispatch() override;
+
+        void NotifyFontChanged();
 
         void UnknownSequence() noexcept override;
         void Print(const wchar_t wchPrintable) override;

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -240,6 +240,16 @@ public:
         Log::Comment(L"ShowNotification MOCK called...");
     }
 
+    void SetTimedContentHandler(std::function<void()> handler) override
+    {
+        _timedContentHandler = std::move(handler);
+    }
+
+    void RequestTimedContentUpdate(const std::optional<std::chrono::steady_clock::time_point> deadline) override
+    {
+        _timedContentDeadline = deadline;
+    }
+
     bool DecodeImageToBgra(const std::span<const uint8_t> data, std::vector<RGBQUAD>& pixels, til::size& size) noexcept override
     {
         Log::Comment(L"DecodeImageToBgra MOCK called...");
@@ -434,6 +444,9 @@ public:
 
     std::wstring _expectedMenuJson{};
     unsigned int _expectedReplaceLength = 0;
+
+    std::function<void()> _timedContentHandler;
+    std::optional<std::chrono::steady_clock::time_point> _timedContentDeadline;
 
 private:
     HANDLE _hCon;
@@ -9395,6 +9408,113 @@ public:
         VERIFY_ARE_EQUAL(availableBefore, ImageSlice::LayerBytesAvailable(), L"destroying a slice must return its retained-layer budget");
     }
 
+    TEST_METHOD(KittyAnimationFrameTransferCreatesFullFrame)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=2,v=1;/wAA/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=2,v=1;AP8AAAD/\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;OK\x1b\\");
+
+        const auto& image = _kitty()._images.at(1);
+        VERIFY_ARE_EQUAL(static_cast<size_t>(2), _kitty()._frameCount(image));
+        VERIFY_ARE_EQUAL(40, image.animationFrames.front().gapMilliseconds, L"new frames default to a 40 ms gap");
+        const auto& frame = image.animationFrames.front().pixels;
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), frame[0].rgbGreen);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), frame[1].rgbBlue);
+    }
+
+    TEST_METHOD(KittyAnimationPartialFrameUsesBackgroundFrame)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=2,v=1;/wAAAP8A\x1b\\"); // red, green
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,x=1,y=0,c=1,X=1;AAD/\x1b\\"); // replace pixel 1 with blue
+
+        const auto& frame = _kitty()._images.at(1).animationFrames.front().pixels;
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), frame[0].rgbRed, L"unspecified pixels come from c= background frame");
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), frame[1].rgbBlue);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), frame[1].rgbGreen);
+    }
+
+    TEST_METHOD(KittyAnimationFrameBackgroundColorAndAlphaBlend)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=2,v=1;AAAAAP8A\x1b\\");
+        // Y=0x0000ffff is opaque blue. Source is 50%-alpha red and X=0 selects source-over.
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=32,s=1,v=1,Y=65535;/wAAgA==\x1b\\");
+
+        const auto& frame = _kitty()._images.at(1).animationFrames.front().pixels;
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(128), frame[0].rgbRed);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(127), frame[0].rgbBlue);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), frame[0].rgbReserved);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), frame[1].rgbBlue, L"the unmodified canvas retains its Y= background");
+    }
+
+    TEST_METHOD(KittyAnimationFrameEditUpdatesCurrentPlacement)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        const auto origin = _testGetSet->_textBuffer->GetCursor().GetPosition();
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,r=2,X=1;AAD/\x1b\\");
+
+        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbBlue, L"editing the displayed frame refreshes retained placements");
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), pixel.rgbGreen);
+    }
+
+    TEST_METHOD(KittyAnimationRefreshesPageWhenItBecomesActive)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        auto& firstPageBuffer = *_testGetSet->_textBuffer;
+        const auto origin = firstPageBuffer.GetCursor().GetPosition();
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+
+        _pDispatch->ResetMode(DispatchTypes::ModeParams::DECPCCM_PageCursorCouplingMode);
+        _pDispatch->PagePositionAbsolute(2);
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
+        auto* slice = firstPageBuffer.GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbGreen, L"the visible page must animate while a decoupled background page is active");
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), pixel.rgbRed);
+        _pDispatch->PagePositionAbsolute(1);
+
+        slice = firstPageBuffer.GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbGreen, L"reactivating a page must refresh it to the animation's current frame");
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), pixel.rgbRed);
+    }
+
+    TEST_METHOD(KittyAnimationStateIsIsolatedFromAlternateBuffer)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._images.at(1).animationFrames.size());
+        VERIFY_ARE_EQUAL(2u, _kitty()._images.at(1).presentedFrame);
+
+        _pDispatch->_SetAlternateScreenBufferMode(true);
+        VERIFY_IS_TRUE(_kitty()._images.empty(), L"the alternate buffer starts with isolated graphics state");
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;AAD/\x1b\\");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(0), _kitty()._images.at(1).animationFrames.size());
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), _kitty()._images.at(1).pixels.front().rgbBlue);
+
+        _pDispatch->_SetAlternateScreenBufferMode(false);
+        const auto& restored = _kitty()._images.at(1);
+        VERIFY_ARE_EQUAL(static_cast<size_t>(1), restored.animationFrames.size());
+        VERIFY_ARE_EQUAL(2u, restored.currentFrame);
+        VERIFY_ARE_EQUAL(2u, restored.presentedFrame);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), restored.animationFrames.front().pixels.front().rgbGreen);
+    }
+
     TEST_METHOD(KittyGraphicsImageAdmissionIsTransactionalAcrossBuffers)
     {
         _testGetSet->PrepData();
@@ -9411,6 +9531,477 @@ public:
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._images.size());
         VERIFY_IS_TRUE(_kitty()._images.contains(1), L"a rejected image must not evict an existing alternate-buffer image");
         VERIFY_ARE_EQUAL(sizeof(RGBQUAD), _kitty()._totalPixelBytes);
+    }
+
+    TEST_METHOD(KittyAnimationUnplacedImageDoesNotInvalidateRetainedLayers)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        auto& buffer = *_testGetSet->_textBuffer;
+        const auto origin = buffer.GetCursor().GetPosition();
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+        const auto* slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        const auto revision = slice->Revision();
+
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=2,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=2,f=24,s=1,v=1,z=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=2,r=1,z=1,c=1,s=3;\x1b\\");
+        auto& image = _kitty()._images.at(2);
+        VERIFY_IS_TRUE(_kitty()._advanceImage(2, image, std::chrono::steady_clock::now()));
+
+        slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        VERIFY_ARE_EQUAL(revision, slice->Revision(), L"an animation with no rendered placements must not scan or invalidate unrelated retained layers");
+    }
+
+    TEST_METHOD(KittyAnimationClearsRenderedHintAfterLastLayerIsErased)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        auto& buffer = *_testGetSet->_textBuffer;
+        const auto origin = buffer.GetCursor().GetPosition();
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,z=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=1,z=1,c=1,s=3;\x1b\\");
+        auto& image = _kitty()._images.at(1);
+        VERIFY_IS_TRUE(image.hasRenderedPlacements);
+
+        buffer.GetMutableRowByOffset(origin.y).SetImageSlice(nullptr);
+        VERIFY_IS_TRUE(_kitty()._advanceImage(1, image, std::chrono::steady_clock::now()));
+        VERIFY_IS_FALSE(image.hasRenderedPlacements, L"the first empty scan must disable future full-page animation scans");
+    }
+
+    TEST_METHOD(KittyAnimationRefreshKeepsLastPresentedGaplessFrame)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        auto& buffer = *_testGetSet->_textBuffer;
+        const auto origin = buffer.GetCursor().GetPosition();
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,z=-1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=1,z=1,c=1,s=2;\x1b\\");
+
+        auto& image = _kitty()._images.at(1);
+        VERIFY_IS_FALSE(_kitty()._advanceImage(1, image, std::chrono::steady_clock::now()));
+        VERIFY_IS_TRUE(image.waitingForFrames);
+        VERIFY_ARE_EQUAL(2u, image.currentFrame);
+        VERIFY_ARE_EQUAL(1u, image.presentedFrame);
+        _pDispatch->NotifyFontChanged();
+
+        const auto* slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbRed, L"lifecycle refresh must restore the last presented frame");
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), pixel.rgbGreen, L"a skipped gapless frame must remain hidden");
+
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=2,z=20;\x1b\\");
+        VERIFY_ARE_EQUAL(2u, image.presentedFrame, L"giving the skipped current frame a duration must present it before scheduling");
+        slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        const auto resumedPixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), resumedPixel.rgbGreen);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), resumedPixel.rgbRed);
+    }
+
+    TEST_METHOD(KittyAnimationNewPlacementsUseCurrentFrame)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        const auto origin = _testGetSet->_textBuffer->GetCursor().GetPosition();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,C=1;\x1b\\");
+
+        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbGreen);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), pixel.rgbRed, L"a=p must sample the selected frame, not the root frame");
+    }
+
+    TEST_METHOD(KittyAnimationNewPlaceholdersUseCurrentFrame)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        _stateMachine->ProcessString(L"\x1b_Ga=T,U=1,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
+        _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m");
+        _stateMachine->ProcessString(Placeholder());
+
+        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0), L"new placeholders must sample the selected frame");
+        VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0));
+    }
+
+    TEST_METHOD(KittyAnimationFrameSupportsRequiredActionOnEveryChunk)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=2,v=1;/wAA/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=2,v=1,m=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,m=0;AAD/\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;OK\x1b\\");
+
+        const auto& frame = _kitty()._images.at(1).animationFrames.front().pixels;
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), frame[0].rgbGreen);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), frame[1].rgbBlue);
+    }
+
+    TEST_METHOD(KittyAnimationFrameRejectsCreateAndEditTogether)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _testGetSet->_response.clear();
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,c=1,r=2;AAD/\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;EINVAL:cannot edit and create a frame simultaneously\x1b\\");
+    }
+
+    TEST_METHOD(KittyAnimationPngFrameUsesDecodedDimensions)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=2,v=2;AAAAAAAAAAAAAAAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=100;iVBORw0K\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;OK\x1b\\");
+
+        const auto& frame = _kitty()._images.at(1).animationFrames.front().pixels;
+        VERIFY_ARE_EQUAL(static_cast<size_t>(4), frame.size());
+        VERIFY_IS_TRUE(std::all_of(frame.begin(), frame.end(), [](const auto& pixel) {
+            return pixel.rgbBlue == 255 && pixel.rgbReserved == 255;
+        }));
+    }
+
+    TEST_METHOD(KittyAnimationCompositionUsesDocumentedCoordinateRoles)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=3,v=1;/wAAAP8AAAD/\x1b\\"); // root: red, green, blue
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,c=1,X=1;AAAA\x1b\\"); // frame 2: black, green, blue
+        // r=source, c=destination; X/Y are source coordinates and x/y are destination coordinates.
+        _stateMachine->ProcessString(L"\x1b_Ga=c,i=1,r=1,c=2,X=2,Y=0,x=0,y=0,w=1,h=1,C=1;\x1b\\");
+
+        const auto& frame = _kitty()._images.at(1).animationFrames.front().pixels;
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), frame[0].rgbBlue, L"root pixel 2 must replace destination pixel 0");
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), frame[1].rgbGreen, L"pixels outside the destination rectangle survive");
+    }
+
+    TEST_METHOD(KittyAnimationCompositionRejectsInvalidRectangles)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=2,v=1;/wAAAP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=2,v=1,c=1,X=1;AAAAAAAA\x1b\\");
+        _testGetSet->_response.clear();
+        _stateMachine->ProcessString(L"\x1b_Ga=c,i=1,r=2,c=2,X=0,x=0,w=1,h=1;\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;EINVAL:overlapping self-composition\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=c,i=1,r=1,c=2,X=2,x=0,w=1,h=1;\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;EINVAL:composition rectangle out of bounds\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=c,i=1,r=9,c=2,w=1,h=1;\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;ENOENT:frame not found\x1b\\");
+    }
+
+    TEST_METHOD(KittyAnimationControlSelectsFrameAndChangesGap)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        const auto origin = _testGetSet->_textBuffer->GetCursor().GetPosition();
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,r=2,z=75,s=1;\x1b\\");
+
+        const auto& image = _kitty()._images.at(1);
+        VERIFY_ARE_EQUAL(2u, image.currentFrame);
+        VERIFY_ARE_EQUAL(75, image.animationFrames.front().gapMilliseconds);
+        VERIFY_ARE_EQUAL(1u, image.animationState);
+        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbGreen);
+    }
+
+    TEST_METHOD(KittyAnimationEditingCurrentGapReschedulesDeadline)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=1,z=1000,c=1,s=3;\x1b\\");
+        const auto oldDeadline = _kitty()._images.at(1).nextFrameTime;
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,r=1,z=10,X=1;/wAA\x1b\\");
+        const auto newDeadline = _kitty()._images.at(1).nextFrameTime;
+        VERIFY_IS_TRUE(newDeadline < oldDeadline, L"editing the current gap must replace the old playback deadline");
+    }
+
+    TEST_METHOD(KittyAnimationEditingFutureGapPreservesDeadline)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=1,z=1000,c=1,s=3;\x1b\\");
+        const auto oldDeadline = _kitty()._images.at(1).nextFrameTime;
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=2,z=10;\x1b\\");
+        VERIFY_IS_TRUE(oldDeadline == _kitty()._images.at(1).nextFrameTime, L"editing a future frame must not postpone the current frame");
+    }
+
+    TEST_METHOD(KittyAnimationSelectingFrameWinsOverOtherGapEdit)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=1,z=1000,c=1,s=3;\x1b\\");
+        const auto oldDeadline = _kitty()._images.at(1).nextFrameTime;
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,r=1,z=10;\x1b\\");
+
+        const auto& image = _kitty()._images.at(1);
+        VERIFY_ARE_EQUAL(2u, image.currentFrame);
+        VERIFY_IS_TRUE(image.nextFrameTime < oldDeadline, L"selecting a frame must reschedule even when the same command edits another frame");
+    }
+
+    TEST_METHOD(KittyAnimationFiniteNormalPlaybackStopsAfterRequestedLoops)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,z=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=1,z=1,c=1,s=3,v=2;\x1b\\");
+
+        auto& image = _kitty()._images.at(1);
+        const auto now = std::chrono::steady_clock::now();
+        VERIFY_IS_TRUE(_kitty()._advanceImage(1, image, now)); // frame 2, first pass
+        VERIFY_IS_TRUE(_kitty()._advanceImage(1, image, now)); // frame 1, second pass
+        VERIFY_IS_TRUE(_kitty()._advanceImage(1, image, now)); // frame 2, second pass
+        VERIFY_IS_FALSE(_kitty()._advanceImage(1, image, now)); // finite loop complete
+        VERIFY_ARE_EQUAL(1u, image.animationState);
+        VERIFY_ARE_EQUAL(2u, image.currentFrame);
+    }
+
+    TEST_METHOD(KittyAnimationLoadingModeResumesWhenFrameArrives)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,z=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=2;\x1b\\");
+
+        auto& image = _kitty()._images.at(1);
+        VERIFY_IS_FALSE(_kitty()._advanceImage(1, image, std::chrono::steady_clock::now()));
+        VERIFY_IS_TRUE(image.waitingForFrames);
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,z=1;AAD/\x1b\\");
+        VERIFY_IS_FALSE(image.waitingForFrames);
+        VERIFY_ARE_EQUAL(3u, image.currentFrame, L"the newly appended frame becomes current without looping");
+    }
+
+    // TestGetSet has no renderer, no render thread and no timer of any kind. If an
+    // animation still advances here, the dispatch is genuinely reporting a deadline
+    // and running the routine the host handed it, rather than driving the renderer.
+    TEST_METHOD(KittyAnimationRunsOffTheHostDeadlineWithNoRenderer)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,z=25;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=1,z=25,c=1,s=3;\x1b\\");
+
+        VERIFY_IS_TRUE(_testGetSet->_timedContentHandler != nullptr, L"the dispatch must hand the host a routine to run");
+        VERIFY_IS_TRUE(_testGetSet->_timedContentDeadline.has_value(), L"an animating image must report when it is next due");
+
+        auto& image = _kitty()._images.at(1);
+        VERIFY_ARE_EQUAL(1u, image.currentFrame);
+
+        // Bring the deadline forward instead of sleeping on it; the host is entitled
+        // to run the routine whenever it likes, and the routine reads the clock itself.
+        image.nextFrameTime = std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
+        _testGetSet->_timedContentHandler();
+
+        VERIFY_ARE_EQUAL(2u, image.currentFrame, L"running the host's routine must advance the animation");
+        VERIFY_IS_TRUE(_testGetSet->_timedContentDeadline.has_value(), L"a still-animating image must report its next deadline");
+        VERIFY_IS_TRUE(*_testGetSet->_timedContentDeadline > std::chrono::steady_clock::now() - std::chrono::seconds(1), L"the reported deadline must move forward, not stay in the past");
+    }
+
+    // The mirror image: once nothing is animating, the dispatch must withdraw its
+    // request so the host can stop waking up for it.
+    TEST_METHOD(KittyAnimationWithdrawsTheDeadlineWhenNothingIsAnimating)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,z=25;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=1,z=25,c=1,s=3;\x1b\\");
+        VERIFY_IS_TRUE(_testGetSet->_timedContentDeadline.has_value());
+
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,s=1;\x1b\\"); // stop playback
+        VERIFY_IS_FALSE(_testGetSet->_timedContentDeadline.has_value(), L"a stopped animation must withdraw the deadline");
+
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=1,z=25,c=1,s=3;\x1b\\"); // start again
+        VERIFY_IS_TRUE(_testGetSet->_timedContentDeadline.has_value());
+
+        _stateMachine->ProcessString(L"\x1b_Ga=d,d=I,i=1;\x1b\\"); // uppercase: drop the image data too
+        VERIFY_IS_FALSE(_testGetSet->_timedContentDeadline.has_value(), L"deleting the last animating image must withdraw the deadline");
+    }
+    TEST_METHOD(KittyAnimationGaplessFramesAreSkipped)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,z=-1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,z=25;AAD/\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=1,z=1,c=1,s=3;\x1b\\");
+
+        auto& image = _kitty()._images.at(1);
+        VERIFY_IS_TRUE(_kitty()._advanceImage(1, image, std::chrono::steady_clock::now()));
+        VERIFY_ARE_EQUAL(3u, image.currentFrame, L"negative-gap frame 2 is data-only and must not be presented");
+    }
+
+    TEST_METHOD(KittyAnimationFrameChangesSurviveScrollAndCellCopy)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        auto& buffer = *_testGetSet->_textBuffer;
+        const auto origin = buffer.GetCursor().GetPosition();
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        buffer.ScrollRows(origin.y, 1, 1);
+        buffer.GetCursor().SetPosition({ origin.x, origin.y + 1 });
+        _stateMachine->ProcessString(L"\x1b[@");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
+
+        const auto* slice = buffer.GetRowByOffset(origin.y + 1).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        const auto inserted = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
+        const auto moved = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x + 1 - slice->ColumnOffset(), 0);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), inserted.rgbReserved);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), moved.rgbGreen, L"source mappings ride both row scroll and ICH copies");
+    }
+
+    TEST_METHOD(KittyAnimationSourceMappingsSurviveReflow)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        auto& buffer = *_testGetSet->_textBuffer;
+        const auto origin = buffer.GetCursor().GetPosition();
+        buffer.GetCursor().SetPosition({ 10, origin.y });
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+
+        auto reflowed = std::make_unique<TextBuffer>(til::size{ 5, 600 }, TextAttribute{}, 0, false, &_testGetSet->_renderer);
+        TextBuffer::Reflow(buffer, *reflowed);
+        const std::vector<RGBQUAD> green{ RGBQUAD{ 0, 255, 0, 255 } };
+        auto found = false;
+        for (auto row = 0; row < reflowed->GetSize().Height(); ++row)
+        {
+            if (auto* slice = reflowed->GetMutableRowByOffset(row).GetMutableImageSlice())
+            {
+                slice->UpdateImage(1, green);
+                found |= SliceContainsColor(slice, 0, 255, 0);
+            }
+        }
+        VERIFY_IS_TRUE(found, L"reflow must preserve the per-pixel source mapping used by animation updates");
+    }
+
+    TEST_METHOD(KittyAnimationUpdatesDistinctPlacementLayers)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        auto page = _pDispatch->_pages.ActivePage();
+        auto& buffer = page.Buffer();
+        const auto row = page.Top();
+        buffer.GetCursor().SetPosition({ 0, row });
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,z=2,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+        buffer.GetCursor().SetPosition({ 3, row });
+        _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=2,z=2,C=1;\x1b\\");
+        const auto firstLayer = _kitty()._placements.at({ 1u, 1u }).layerId;
+        const auto secondLayer = _kitty()._placements.at({ 1u, 2u }).layerId;
+
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
+        auto* slice = buffer.GetMutableRowByOffset(row).GetMutableImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        VERIFY_IS_TRUE(slice->ContainsPlacement(firstLayer));
+        VERIFY_IS_TRUE(slice->ContainsPlacement(secondLayer));
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, 0, 0).rgbGreen);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, 3, 0).rgbGreen);
+
+        _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1,p=1;\x1b\\");
+        slice = buffer.GetMutableRowByOffset(row).GetMutableImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        VERIFY_IS_FALSE(slice->ContainsPlacement(firstLayer));
+        VERIFY_IS_TRUE(slice->ContainsPlacement(secondLayer), L"animation updates do not merge placement ownership");
+    }
+
+    TEST_METHOD(KittyAnimationFrameCountAndMemoryAreBounded)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        auto& image = _kitty()._images.at(1);
+        image.animationFrames.resize(KittyParser::MaxFramesPerImage - 1);
+        _testGetSet->_response.clear();
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;ENOSPC:frame count limit exceeded\x1b\\");
+
+        image.animationFrames.clear();
+        const auto savedBytes = _kitty()._totalPixelBytes;
+        _kitty()._totalPixelBytes = KittyParser::MaxTotalBytes;
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;ENOSPC:image storage limit exceeded\x1b\\");
+        _kitty()._totalPixelBytes = savedBytes;
+    }
+
+    TEST_METHOD(KittyAnimationDeleteFrameRenumbersAndRetainsImage)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AAD/\x1b\\");
+        const auto bytesBefore = _kitty()._totalPixelBytes;
+        _stateMachine->ProcessString(L"\x1b_Ga=d,d=f,i=1,r=2;\x1b\\");
+
+        const auto& image = _kitty()._images.at(1);
+        VERIFY_ARE_EQUAL(static_cast<size_t>(2), _kitty()._frameCount(image));
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), image.animationFrames.front().pixels.front().rgbBlue, L"old frame 3 is renumbered to frame 2");
+        VERIFY_ARE_EQUAL(bytesBefore - sizeof(RGBQUAD), _kitty()._totalPixelBytes);
+    }
+
+    TEST_METHOD(KittyAnimationDeleteRootPromotesNextFrame)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,z=63;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AAD/\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=d,d=f,i=1;\x1b\\"); // omitted r defaults to frame 1
+
+        const auto& image = _kitty()._images.at(1);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), image.pixels.front().rgbGreen);
+        VERIFY_ARE_EQUAL(63, image.rootGapMilliseconds, L"the promoted frame keeps its gap");
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), image.animationFrames.front().pixels.front().rgbBlue);
+    }
+
+    TEST_METHOD(KittyAnimationUppercaseDeleteFreesStaticResult)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
+        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0));
+        _stateMachine->ProcessString(L"\x1b_Ga=d,d=F,i=1,r=2;\x1b\\");
+
+        VERIFY_ARE_EQUAL(static_cast<size_t>(0), _kitty()._images.count(1));
+        VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"uppercase F frees the now-static image and its placements");
+    }
+
+    TEST_METHOD(KittyAnimationUppercaseDeleteIgnoresMissingFrame)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=d,d=F,i=1,r=999;\x1b\\");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._images.count(1), L"a missing frame must not free a static image");
+    }
+
+    TEST_METHOD(KittyAnimationQuotaEvictionCascadesRelativeChildren)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,P=1,Q=1,H=1,f=24,s=1,v=1,C=1;AP8A\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=3,f=24,s=1,v=1;AAD/\x1b\\");
+        _kitty()._totalPixelBytes = KittyParser::MaxTotalBytes;
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=3,f=24,s=1,v=1;AAAA\x1b\\");
+
+        VERIFY_ARE_EQUAL(static_cast<size_t>(0), _kitty()._images.count(1), L"the oldest parent is evicted");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(0), _kitty()._images.count(2), L"its relative child cascades instead of becoming orphaned");
+        VERIFY_IS_TRUE(_kitty()._placements.empty());
+        _kitty()._totalPixelBytes = _kitty()._images.at(3).PixelBytes();
     }
 
     TEST_METHOD(KittyGraphicsQuotaEvictionCascadesRelativeChildren)
@@ -9431,6 +10022,24 @@ public:
         VERIFY_ARE_EQUAL(static_cast<size_t>(0), _kitty()._images.count(2), L"normal admission cascades its relative child");
         VERIFY_IS_TRUE(_kitty()._placements.empty());
         VERIFY_ARE_EQUAL(KittyParser::MaxImages - 1, _kitty()._images.size());
+    }
+
+    TEST_METHOD(KittyAnimationFailedAppendDoesNotEvictTargetAncestor)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_cellSize = { 1, 1 };
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,P=1,Q=1,H=1,f=24,s=1,v=1,C=1;AP8A\x1b\\");
+        const auto savedBytes = _kitty()._totalPixelBytes;
+        _kitty()._totalPixelBytes = KittyParser::MaxTotalBytes;
+        _testGetSet->_response.clear();
+        _stateMachine->ProcessString(L"\x1b_Ga=f,i=2,f=24,s=1,v=1;AAD/\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=2;ENOSPC:image storage limit exceeded\x1b\\");
+
+        VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._images.count(1), L"failed append keeps the target's parent");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._images.count(2), L"failed append keeps the target");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(2), _kitty()._placements.size());
+        _kitty()._totalPixelBytes = savedBytes;
     }
 
     // An APC string with a non-'G' identifier is not Kitty graphics and is ignored.


### PR DESCRIPTION
| Stack | |
|---|---|
| #54 | Give `ImageSlice` identified, z-ordered layers |
| #55 | Paint a row's images in z-order around its text |
| #56 | Route APC strings to the engine by identifier |
| #57 | Add the Kitty graphics protocol to the VT adapter |
| **&rarr; #58** | **Add Kitty graphics animation** |
| #59 | Add file and shared-memory transmission |

## TL;DR

`a=f` transmit a frame · `a=a` animate · `a=c` compose. Frames replay off the renderer's timer without reallocating, and an animation keeps playing after its row scrolls, reflows, or is copied.

![Four frames of a looping animation captured at 2.00s, 2.26s, 2.52s and 2.78s](https://github.com/user-attachments/assets/7dbbc536-cc49-4b0a-9712-a58250d18abd)

## Key changes

- **A frame is a full canvas, not a delta.** Partial frames (`x`/`y`/`w`/`h`) are composited onto a chosen background frame *at transmit time*, so by the time a frame is stored it is already complete. Playback never reconstructs anything, which is what makes the timer path allocation-free.
- **Already-painted cells are re-sampled in place, not repainted.** Each destination pixel records which source pixel it sampled (`ImageSlice::MutableSourceIndices`); a new frame walks those indices and writes the new colour into the same slot.

  ![Animation re-samples cells that are already on screen](https://github.com/user-attachments/assets/f68a773a-54f8-4a23-92b1-669605078ed4)
- **Frames are bounded the same way images are.** Frame count and total frame bytes charge against the same budget as image pixels, so an animation can't walk around the transmit limit one frame at a time.

## Notes for the rest of the stack

- **The adapter does not start the timer.** Per review, it reports *when it next has work* via `ITerminalApi::RequestTimedContentUpdate` and the host decides how to honour it — the `[1ms, 30s]` clamp lives in `Renderer::StartTimerAt`. `adaptDispatch` starts zero timers.
- **A cell erased since the placement stays erased.** Clearing a range resets its indices to `NoSourceIndex`, so a later frame has nothing to write there. That falls out of the sampling design rather than being special-cased.

## The renderer timer change

This is the part worth reading closely. `Renderer::RegisterTimer` is Leonard Hecker's API from #19330. Until now it had exactly two callers, both in the `Renderer` constructor, and every start/stop happened on the render thread. This is the first caller to register a timer **dynamically, from the VT parser thread, owned by an object that can die before the renderer does**.

**There is no bug on `main` here** — the existing timers genuinely cannot hit any of this. The hardening is required by the new usage, not a fix.

- **A lock.** `_timers` is guarded by a `wil::srwlock`, because registration and start/stop no longer happen only on the render thread.
- **`NotifyPaintFrame` instead of a bare notify.** `StartTimer` used to nudge `_redraw` without setting the predicate — fine when only the render thread started timers. A start from another thread racing the render thread's wait would lose the wake-up and sleep past the new deadline.
- **Lifetime binding.** `RegisterTimer` takes an optional `std::weak_ptr<void>`; a bound timer retires itself once its owner is gone, so `AdaptDispatch` never has to unregister from a destructor racing a callback already running on the render thread.
- **The callback runs without the lock held**, so it's free to start, stop or register timers. That's also why the tick loop is indexed rather than iterated — registering during a callback can reallocate the list. Retired slots are reused so repeated register/drop doesn't grow `_timers` unbounded.

## Tests

`Terminal.Core 86`, all suites at baseline. The animation tests paint on the calling thread rather than starting a render thread — `Renderer::_PaintFrame()` drives `_tickTimers()`, so a synchronous paint advances animation the same way the thread would. No test in this suite starts a render thread now.

---

**Builds alone.** Built without any PR above it — zero C++ errors.