### PR TITLE
Add file and shared-memory transmission to Kitty graphics

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -16,6 +16,7 @@
 #include "../../cascadia/terminalcore/ITerminalInput.hpp"
 
 #include <til/generational.h>
+#include <til/io.h>
 #include <til/ticket_lock.h>
 #include <til/winrt.h>
 
@@ -169,6 +170,8 @@ public:
 
     bool DecodeImageToBgra(const std::span<const uint8_t> data, std::vector<RGBQUAD>& pixels, til::size& size) noexcept override;
     til::size GetCellSize() const noexcept override;
+    til::read_file_result ReadLocalFile(const std::wstring_view path, uint64_t offset, uint64_t size, bool deleteAfter, const std::wstring_view deleteNameMarker, std::vector<uint8_t>& out) noexcept override;
+    Microsoft::Console::Utils::ReadSharedMemoryResult ReadSharedMemory(const std::wstring_view name, uint64_t offset, uint64_t size, std::vector<uint8_t>& out) noexcept override;
 
     void SetTimedContentHandler(std::function<void()> handler) override;
     void RequestTimedContentUpdate(const std::optional<std::chrono::steady_clock::time_point> deadline) override;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -12,6 +12,8 @@
 #include <wil/com.h>
 #include <wil/resource.h>
 
+#include <til/io.h>
+
 using namespace Microsoft::Terminal::Core;
 using namespace Microsoft::Console::Render;
 using namespace Microsoft::Console::Types;
@@ -475,6 +477,20 @@ til::size Terminal::GetCellSize() const noexcept
         return { 10, 20 };
     }
     return size;
+}
+
+til::read_file_result Terminal::ReadLocalFile(const std::wstring_view path, uint64_t offset, uint64_t size, bool deleteAfter, const std::wstring_view deleteNameMarker, std::vector<uint8_t>& out) noexcept
+{
+    // Windows Terminal is the final terminal in the chain, so it owns deletion of a t=t
+    // temporary file (conhost suppresses its own delete under ConPTY). The shared helper
+    // still enforces local fixed-drive reads and temp-dir + marker containment before it
+    // removes anything.
+    return til::read_file_as_bytes(path, offset, size, deleteAfter, deleteNameMarker, out);
+}
+
+Microsoft::Console::Utils::ReadSharedMemoryResult Terminal::ReadSharedMemory(const std::wstring_view name, uint64_t offset, uint64_t size, std::vector<uint8_t>& out) noexcept
+{
+    return Microsoft::Console::Utils::ReadSharedMemory(name, offset, size, out);
 }
 
 void Terminal::NotifyBufferRotation(const int delta)

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -438,20 +438,13 @@ namespace TerminalCoreUnitTests
         // filesystem path of Terminal::ReadLocalFile (the shared til::read_file_as_bytes
         // helper), including the security gates that the adapter-level mock cannot cover.
         TEST_METHOD(ReadLocalFileReadsFromTemp);
-        TEST_METHOD(ReadLocalFileDeletesTempWithMarker);
-        TEST_METHOD(ReadLocalFileOutsideTempNotDeleted);
-        TEST_METHOD(ReadLocalFileNoMarkerNotDeleted);
-        TEST_METHOD(ReadLocalFileEmptyMarkerNeverDeletes);
-        TEST_METHOD(ReadLocalFileParentMarkerNotDeleted);
+        TEST_METHOD(ReadLocalFileMarkerGatesDeletion);
         TEST_METHOD(ReadLocalFileOffsetAndSizeSlice);
         TEST_METHOD(ReadLocalFileOversizeSizeClampsToEof);
-        TEST_METHOD(ReadLocalFileRejectsUncPath);
-        TEST_METHOD(ReadLocalFileRejectsRelativePath);
+        TEST_METHOD(ReadLocalFileRejectsInvalidPaths);
         TEST_METHOD(ReadLocalFileNormalizesWin32Path);
         TEST_METHOD(ReadLocalFileRejectsIntermediateJunction);
-        TEST_METHOD(ReadLocalFileNonexistentFails);
         TEST_METHOD(ReadLocalFileRejectsCharDevice);
-        TEST_METHOD(ReadLocalFileRejectsDirectory);
         TEST_METHOD(ReadLocalFileCapsAtMaxBytes);
         TEST_METHOD(ReadLocalFileFailedReadKeepsTempFile);
 
@@ -1063,106 +1056,114 @@ void TerminalApiTest::ReadLocalFileReadsFromTemp()
     DeleteFileW(path.c_str());
 }
 
-void TerminalApiTest::ReadLocalFileDeletesTempWithMarker()
+void TerminalApiTest::ReadLocalFileMarkerGatesDeletion()
 {
-    Terminal term{ Terminal::TestDummyMarker{} };
-    DummyRenderer renderer{ &term };
-    term.Create({ 100, 100 }, 0, renderer);
+    // A t=t read only deletes the file it read when the file is under the system temp
+    // directory AND its name carries the "tty-graphics-protocol" marker AND the caller
+    // passes that same marker. Every other combination must leave the file in place --
+    // the gate exists so a client cannot turn "read this file" into "delete that file".
 
-    const auto dir = KittyTempDir();
-    VERIFY_IS_FALSE(dir.empty());
-    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-del-");
-    VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 9, 8, 7 }));
-
-    std::vector<uint8_t> out;
-    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should succeed");
-    VERIFY_ARE_EQUAL(static_cast<size_t>(3), out.size());
-    VERIFY_IS_FALSE(KittyFileExists(path), L"a temp file carrying the kitty marker must be deleted after a t=t read");
-
-    if (KittyFileExists(path))
+    // Under temp, marked name, marker passed: the file is deleted.
     {
+        Terminal term{ Terminal::TestDummyMarker{} };
+        DummyRenderer renderer{ &term };
+        term.Create({ 100, 100 }, 0, renderer);
+
+        const auto dir = KittyTempDir();
+        VERIFY_IS_FALSE(dir.empty());
+        const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-del-");
+        VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 9, 8, 7 }));
+
+        std::vector<uint8_t> out;
+        VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should succeed");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(3), out.size());
+        VERIFY_IS_FALSE(KittyFileExists(path), L"a temp file carrying the kitty marker must be deleted after a t=t read");
+
+        if (KittyFileExists(path))
+        {
+            DeleteFileW(path.c_str());
+        }
+    }
+
+    // Outside the temp dir: never deleted, even with the marker and deleteAfter.
+    {
+        Terminal term{ Terminal::TestDummyMarker{} };
+        DummyRenderer renderer{ &term };
+        term.Create({ 100, 100 }, 0, renderer);
+
+        // The current directory (the test's output folder) is a local, writable location
+        // that is not under the system temp directory.
+        const auto dir = KittyCurrentDir();
+        VERIFY_IS_FALSE(dir.empty());
+        const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-outside-");
+        VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 4, 5, 6 }));
+
+        std::vector<uint8_t> out;
+        VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should still succeed");
+        VERIFY_IS_TRUE(KittyFileExists(path), L"a file OUTSIDE the temp dir must never be deleted, even with deleteAfter (anti arbitrary-delete)");
+
         DeleteFileW(path.c_str());
     }
-}
 
-void TerminalApiTest::ReadLocalFileOutsideTempNotDeleted()
-{
-    Terminal term{ Terminal::TestDummyMarker{} };
-    DummyRenderer renderer{ &term };
-    term.Create({ 100, 100 }, 0, renderer);
+    // Under temp but the name lacks the marker: not deleted.
+    {
+        Terminal term{ Terminal::TestDummyMarker{} };
+        DummyRenderer renderer{ &term };
+        term.Create({ 100, 100 }, 0, renderer);
 
-    // The current directory (the test's output folder) is a local, writable location
-    // that is not under the system temp directory.
-    const auto dir = KittyCurrentDir();
-    VERIFY_IS_FALSE(dir.empty());
-    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-outside-");
-    VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 4, 5, 6 }));
+        const auto dir = KittyTempDir();
+        VERIFY_IS_FALSE(dir.empty());
+        // Under temp, but the name lacks the "tty-graphics-protocol" marker.
+        const auto path = KittyUniquePath(dir, L"kitty-no-marker-");
+        VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 1, 1, 1 }));
 
-    std::vector<uint8_t> out;
-    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should still succeed");
-    VERIFY_IS_TRUE(KittyFileExists(path), L"a file OUTSIDE the temp dir must never be deleted, even with deleteAfter (anti arbitrary-delete)");
+        std::vector<uint8_t> out;
+        VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should succeed");
+        VERIFY_IS_TRUE(KittyFileExists(path), L"a temp file WITHOUT the kitty marker must not be auto-deleted");
 
-    DeleteFileW(path.c_str());
-}
+        DeleteFileW(path.c_str());
+    }
 
-void TerminalApiTest::ReadLocalFileNoMarkerNotDeleted()
-{
-    Terminal term{ Terminal::TestDummyMarker{} };
-    DummyRenderer renderer{ &term };
-    term.Create({ 100, 100 }, 0, renderer);
+    // Marked name under temp, but the caller passes an EMPTY marker: deletes nothing.
+    {
+        Terminal term{ Terminal::TestDummyMarker{} };
+        DummyRenderer renderer{ &term };
+        term.Create({ 100, 100 }, 0, renderer);
 
-    const auto dir = KittyTempDir();
-    VERIFY_IS_FALSE(dir.empty());
-    // Under temp, but the name lacks the "tty-graphics-protocol" marker.
-    const auto path = KittyUniquePath(dir, L"kitty-no-marker-");
-    VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 1, 1, 1 }));
+        const auto dir = KittyTempDir();
+        VERIFY_IS_FALSE(dir.empty());
+        // Named exactly the way a caller that DOES pass a marker would name it, so the only
+        // thing standing between this file and deletion is the empty marker below.
+        const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-nomarker-");
+        VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 1, 1, 1 }));
 
-    std::vector<uint8_t> out;
-    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should succeed");
-    VERIFY_IS_TRUE(KittyFileExists(path), L"a temp file WITHOUT the kitty marker must not be auto-deleted");
+        std::vector<uint8_t> out;
+        VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, L"", out), L"the read should succeed");
+        VERIFY_IS_TRUE(KittyFileExists(path), L"an empty marker must delete nothing: a caller cannot opt out of the name check by omitting it");
 
-    DeleteFileW(path.c_str());
-}
+        DeleteFileW(path.c_str());
+    }
 
-void TerminalApiTest::ReadLocalFileEmptyMarkerNeverDeletes()
-{
-    Terminal term{ Terminal::TestDummyMarker{} };
-    DummyRenderer renderer{ &term };
-    term.Create({ 100, 100 }, 0, renderer);
+    // The marker on a PARENT directory does not authorize deleting a file inside it.
+    {
+        Terminal term{ Terminal::TestDummyMarker{} };
+        DummyRenderer renderer{ &term };
+        term.Create({ 100, 100 }, 0, renderer);
 
-    const auto dir = KittyTempDir();
-    VERIFY_IS_FALSE(dir.empty());
-    // Named exactly the way a caller that DOES pass a marker would name it, so the only
-    // thing standing between this file and deletion is the empty marker below.
-    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-nomarker-");
-    VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 1, 1, 1 }));
+        const auto dir = KittyTempDir();
+        VERIFY_IS_FALSE(dir.empty());
+        const auto subdir = KittyUniquePath(dir, L"tty-graphics-protocol-parent-");
+        VERIFY_IS_TRUE(CreateDirectoryW(subdir.c_str(), nullptr) != FALSE, L"failed to create the marked parent directory");
+        const auto path = KittyUniquePath(subdir + L"\\", L"unrelated-");
+        VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 1, 2, 3 }));
 
-    std::vector<uint8_t> out;
-    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, L"", out), L"the read should succeed");
-    VERIFY_IS_TRUE(KittyFileExists(path), L"an empty marker must delete nothing: a caller cannot opt out of the name check by omitting it");
+        std::vector<uint8_t> out;
+        VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should succeed");
+        VERIFY_IS_TRUE(KittyFileExists(path), L"a marker in a parent directory must not authorize deleting an unrelated file");
 
-    DeleteFileW(path.c_str());
-}
-
-void TerminalApiTest::ReadLocalFileParentMarkerNotDeleted()
-{
-    Terminal term{ Terminal::TestDummyMarker{} };
-    DummyRenderer renderer{ &term };
-    term.Create({ 100, 100 }, 0, renderer);
-
-    const auto dir = KittyTempDir();
-    VERIFY_IS_FALSE(dir.empty());
-    const auto subdir = KittyUniquePath(dir, L"tty-graphics-protocol-parent-");
-    VERIFY_IS_TRUE(CreateDirectoryW(subdir.c_str(), nullptr) != FALSE, L"failed to create the marked parent directory");
-    const auto path = KittyUniquePath(subdir + L"\\", L"unrelated-");
-    VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 1, 2, 3 }));
-
-    std::vector<uint8_t> out;
-    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should succeed");
-    VERIFY_IS_TRUE(KittyFileExists(path), L"a marker in a parent directory must not authorize deleting an unrelated file");
-
-    DeleteFileW(path.c_str());
-    RemoveDirectoryW(subdir.c_str());
+        DeleteFileW(path.c_str());
+        RemoveDirectoryW(subdir.c_str());
+    }
 }
 
 void TerminalApiTest::ReadLocalFileOffsetAndSizeSlice()
@@ -1207,29 +1208,69 @@ void TerminalApiTest::ReadLocalFileOversizeSizeClampsToEof()
     DeleteFileW(path.c_str());
 }
 
-void TerminalApiTest::ReadLocalFileRejectsUncPath()
+void TerminalApiTest::ReadLocalFileRejectsInvalidPaths()
 {
-    Terminal term{ Terminal::TestDummyMarker{} };
-    DummyRenderer renderer{ &term };
-    term.Create({ 100, 100 }, 0, renderer);
+    // A path that is malformed or does not name a readable regular file is refused before
+    // any bytes are returned, and a rejected read always leaves the output empty. Each
+    // class of bad path reports its own result code.
 
-    // A UNC path must be rejected up front (no SMB connection, no NTLM handshake).
-    std::vector<uint8_t> out{ 7, 7, 7 };
-    VERIFY_IS_TRUE(til::read_file_result::invalid == term.ReadLocalFile(L"\\\\127.0.0.1\\share\\never.bin", 0, 0, false, TempFileMarker, out), L"a UNC path must be rejected as an invalid request");
-    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size(), L"a rejected read must leave the output empty");
-}
+    // A UNC path is rejected up front (no SMB connection, no NTLM handshake): invalid.
+    {
+        Terminal term{ Terminal::TestDummyMarker{} };
+        DummyRenderer renderer{ &term };
+        term.Create({ 100, 100 }, 0, renderer);
 
-void TerminalApiTest::ReadLocalFileRejectsRelativePath()
-{
-    Terminal term{ Terminal::TestDummyMarker{} };
-    DummyRenderer renderer{ &term };
-    term.Create({ 100, 100 }, 0, renderer);
+        std::vector<uint8_t> out{ 7, 7, 7 };
+        VERIFY_IS_TRUE(til::read_file_result::invalid == term.ReadLocalFile(L"\\\\127.0.0.1\\share\\never.bin", 0, 0, false, TempFileMarker, out), L"a UNC path must be rejected as an invalid request");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size(), L"a rejected read must leave the output empty");
+    }
 
-    // Relative paths are rejected so a client cannot read a file resolved against the
-    // terminal's own working directory.
-    std::vector<uint8_t> out;
-    VERIFY_IS_TRUE(til::read_file_result::invalid == term.ReadLocalFile(L"relative\\file.bin", 0, 0, false, TempFileMarker, out), L"a non-absolute path must be rejected as an invalid request");
-    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
+    // A relative path is rejected so a client cannot read a file resolved against the
+    // terminal's own working directory: invalid.
+    {
+        Terminal term{ Terminal::TestDummyMarker{} };
+        DummyRenderer renderer{ &term };
+        term.Create({ 100, 100 }, 0, renderer);
+
+        std::vector<uint8_t> out;
+        VERIFY_IS_TRUE(til::read_file_result::invalid == term.ReadLocalFile(L"relative\\file.bin", 0, 0, false, TempFileMarker, out), L"a non-absolute path must be rejected as an invalid request");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
+    }
+
+    // A well-formed absolute path that names no file reports not_found (ENOENT).
+    {
+        Terminal term{ Terminal::TestDummyMarker{} };
+        DummyRenderer renderer{ &term };
+        term.Create({ 100, 100 }, 0, renderer);
+
+        const auto dir = KittyTempDir();
+        VERIFY_IS_FALSE(dir.empty());
+        // A unique path we never create.
+        const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-missing-");
+
+        std::vector<uint8_t> out;
+        VERIFY_IS_TRUE(til::read_file_result::not_found == term.ReadLocalFile(path, 0, 0, false, TempFileMarker, out), L"a missing file must report not_found (ENOENT)");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
+    }
+
+    // A real, drive-absolute directory passes every pre-open path check but must not be
+    // readable as an image. FILE_NON_DIRECTORY_FILE reports it as read_error (EBADF).
+    {
+        Terminal term{ Terminal::TestDummyMarker{} };
+        DummyRenderer renderer{ &term };
+        term.Create({ 100, 100 }, 0, renderer);
+
+        const auto dir = KittyTempDir();
+        VERIFY_IS_FALSE(dir.empty());
+        const auto subdir = KittyUniquePath(dir, L"tty-graphics-protocol-dir-");
+        VERIFY_IS_TRUE(CreateDirectoryW(subdir.c_str(), nullptr) != FALSE, L"failed to create the test directory");
+
+        std::vector<uint8_t> out{ 1, 2, 3 };
+        VERIFY_IS_TRUE(til::read_file_result::read_error == term.ReadLocalFile(subdir, 0, 0, false, TempFileMarker, out), L"a directory must be refused as unreadable (EBADF): only regular files may be read");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size(), L"a rejected read must leave the output empty");
+
+        RemoveDirectoryW(subdir.c_str());
+    }
 }
 
 void TerminalApiTest::ReadLocalFileNormalizesWin32Path()
@@ -1280,22 +1321,6 @@ void TerminalApiTest::ReadLocalFileRejectsIntermediateJunction()
     VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
 }
 
-void TerminalApiTest::ReadLocalFileNonexistentFails()
-{
-    Terminal term{ Terminal::TestDummyMarker{} };
-    DummyRenderer renderer{ &term };
-    term.Create({ 100, 100 }, 0, renderer);
-
-    const auto dir = KittyTempDir();
-    VERIFY_IS_FALSE(dir.empty());
-    // A unique path we never create.
-    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-missing-");
-
-    std::vector<uint8_t> out;
-    VERIFY_IS_TRUE(til::read_file_result::not_found == term.ReadLocalFile(path, 0, 0, false, TempFileMarker, out), L"a missing file must report not_found (ENOENT)");
-    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
-}
-
 void TerminalApiTest::ReadLocalFileRejectsCharDevice()
 {
     Terminal term{ Terminal::TestDummyMarker{} };
@@ -1313,26 +1338,6 @@ void TerminalApiTest::ReadLocalFileRejectsCharDevice()
         VERIFY_IS_TRUE(til::read_file_result::read_error == term.ReadLocalFile(devicePath, 0, 0, false, TempFileMarker, out), L"a DOS character device must be refused as unreadable (EBADF): only regular files may be read");
         VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size(), L"a rejected read must leave the output empty");
     }
-}
-
-void TerminalApiTest::ReadLocalFileRejectsDirectory()
-{
-    Terminal term{ Terminal::TestDummyMarker{} };
-    DummyRenderer renderer{ &term };
-    term.Create({ 100, 100 }, 0, renderer);
-
-    const auto dir = KittyTempDir();
-    VERIFY_IS_FALSE(dir.empty());
-    // A real, drive-absolute directory passes every pre-open path check but must not be
-    // readable as an image. FILE_NON_DIRECTORY_FILE reports it as read_error (EBADF).
-    const auto subdir = KittyUniquePath(dir, L"tty-graphics-protocol-dir-");
-    VERIFY_IS_TRUE(CreateDirectoryW(subdir.c_str(), nullptr) != FALSE, L"failed to create the test directory");
-
-    std::vector<uint8_t> out{ 1, 2, 3 };
-    VERIFY_IS_TRUE(til::read_file_result::read_error == term.ReadLocalFile(subdir, 0, 0, false, TempFileMarker, out), L"a directory must be refused as unreadable (EBADF): only regular files may be read");
-    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size(), L"a rejected read must leave the output empty");
-
-    RemoveDirectoryW(subdir.c_str());
 }
 
 void TerminalApiTest::ReadLocalFileCapsAtMaxBytes()

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -434,6 +434,35 @@ namespace TerminalCoreUnitTests
         TEST_METHOD(KittyPlaceholderLeavesUnrecognizedTextUntouched);
         TEST_METHOD(KittyPlaceholderSuppressesGlyphAfterResize);
         TEST_METHOD(KittyPlaceholderSuppressesGlyphAfterScroll);
+        // Kitty graphics file-transmission host I/O (t=f / t=t). These exercise the real
+        // filesystem path of Terminal::ReadLocalFile (the shared til::read_file_as_bytes
+        // helper), including the security gates that the adapter-level mock cannot cover.
+        TEST_METHOD(ReadLocalFileReadsFromTemp);
+        TEST_METHOD(ReadLocalFileDeletesTempWithMarker);
+        TEST_METHOD(ReadLocalFileOutsideTempNotDeleted);
+        TEST_METHOD(ReadLocalFileNoMarkerNotDeleted);
+        TEST_METHOD(ReadLocalFileEmptyMarkerNeverDeletes);
+        TEST_METHOD(ReadLocalFileParentMarkerNotDeleted);
+        TEST_METHOD(ReadLocalFileOffsetAndSizeSlice);
+        TEST_METHOD(ReadLocalFileOversizeSizeClampsToEof);
+        TEST_METHOD(ReadLocalFileRejectsUncPath);
+        TEST_METHOD(ReadLocalFileRejectsRelativePath);
+        TEST_METHOD(ReadLocalFileNormalizesWin32Path);
+        TEST_METHOD(ReadLocalFileRejectsIntermediateJunction);
+        TEST_METHOD(ReadLocalFileNonexistentFails);
+        TEST_METHOD(ReadLocalFileRejectsCharDevice);
+        TEST_METHOD(ReadLocalFileRejectsDirectory);
+        TEST_METHOD(ReadLocalFileCapsAtMaxBytes);
+        TEST_METHOD(ReadLocalFileFailedReadKeepsTempFile);
+
+        // Kitty graphics shared-memory host I/O (t=s).
+        TEST_METHOD(ReadSharedMemoryCopiesSliceAndCloses);
+        TEST_METHOD(ReadSharedMemoryCapsAtMaxBytes);
+        TEST_METHOD(ReadSharedMemoryRejectsUnsafeNames);
+        TEST_METHOD(ReadSharedMemoryMissingFails);
+        TEST_METHOD(ReadSharedMemoryRejectsOffsetPastEnd);
+        TEST_METHOD(ReadSharedMemoryRejectsReservedPages);
+        TEST_METHOD(ReadSharedMemoryRejectsPartiallyCommittedMapping);
     };
 };
 
@@ -852,6 +881,638 @@ void TerminalApiTest::KittyAnimationSurvivesFontAndRendererRefresh()
         advanced = FrameContainsKittyColor(fixture.engine.Snapshot(), 7, true);
     }
     VERIFY_IS_TRUE(advanced, L"animation playback must continue to the next frame after recreation");
+}
+
+// --- Kitty graphics file-transmission host I/O ------------------------------------
+//
+// These build a Terminal in TestDummyMarker mode and call ReadLocalFile against
+// real files, validating the security-critical behavior the adapter-level mock cannot:
+// local fixed-drive enforcement, temp-dir + "tty-graphics-protocol" marker gated
+// deletion via the open handle, offset/size slicing, and the 32 MiB read bound.
+namespace
+{
+    // The system temp directory (ends with a backslash), or empty on failure.
+    std::wstring KittyTempDir()
+    {
+        wchar_t buf[MAX_PATH + 1]{};
+        const auto len = GetTempPathW(ARRAYSIZE(buf), buf);
+        if (len == 0 || len >= ARRAYSIZE(buf))
+        {
+            return {};
+        }
+        return std::wstring{ buf, len };
+    }
+
+    // The process's current directory (ends with a backslash); used as a location that
+    // is reliably NOT under the system temp directory.
+    std::wstring KittyCurrentDir()
+    {
+        wchar_t buf[MAX_PATH + 1]{};
+        const auto len = GetCurrentDirectoryW(ARRAYSIZE(buf), buf);
+        if (len == 0 || len >= ARRAYSIZE(buf))
+        {
+            return {};
+        }
+        std::wstring dir{ buf, len };
+        if (!dir.empty() && dir.back() != L'\\')
+        {
+            dir.push_back(L'\\');
+        }
+        return dir;
+    }
+
+    std::wstring KittyUniquePath(const std::wstring& dir, const std::wstring& namePart)
+    {
+        static unsigned int counter = 0;
+        return dir + namePart + std::to_wstring(GetCurrentProcessId()) + L"-" +
+               std::to_wstring(GetTickCount64()) + L"-" + std::to_wstring(counter++) + L".bin";
+    }
+
+    bool KittyWriteAllBytes(const std::wstring& path, const std::vector<uint8_t>& bytes)
+    {
+        wil::unique_hfile file{ CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr) };
+        if (!file)
+        {
+            return false;
+        }
+        if (bytes.empty())
+        {
+            return true;
+        }
+        DWORD written = 0;
+        return WriteFile(file.get(), bytes.data(), static_cast<DWORD>(bytes.size()), &written, nullptr) && written == bytes.size();
+    }
+
+    bool KittyFileExists(const std::wstring& path)
+    {
+        return GetFileAttributesW(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+    }
+
+    struct KittyMountPointReparseBuffer
+    {
+        ULONG reparseTag;
+        USHORT reparseDataLength;
+        USHORT reserved;
+        USHORT substituteNameOffset;
+        USHORT substituteNameLength;
+        USHORT printNameOffset;
+        USHORT printNameLength;
+        WCHAR pathBuffer[MAX_PATH * 2];
+    };
+
+    bool KittyCreateJunction(const std::wstring& junctionPath, const std::wstring& targetPath)
+    {
+        static constexpr DWORD fsctlSetReparsePoint{ 0x000900A4 };
+
+        if (!CreateDirectoryW(junctionPath.c_str(), nullptr))
+        {
+            return false;
+        }
+
+        wil::unique_hfile junction{ CreateFileW(junctionPath.c_str(),
+                                                GENERIC_WRITE,
+                                                0,
+                                                nullptr,
+                                                OPEN_EXISTING,
+                                                FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+                                                nullptr) };
+        if (!junction)
+        {
+            return false;
+        }
+
+        const auto substituteName = L"\\??\\" + targetPath;
+        const auto substituteBytes = substituteName.size() * sizeof(wchar_t);
+        const auto printBytes = targetPath.size() * sizeof(wchar_t);
+        KittyMountPointReparseBuffer buffer{};
+        if (substituteBytes + printBytes + 2 * sizeof(wchar_t) > sizeof(buffer.pathBuffer))
+        {
+            return false;
+        }
+
+        buffer.reparseTag = IO_REPARSE_TAG_MOUNT_POINT;
+        buffer.substituteNameLength = static_cast<USHORT>(substituteBytes);
+        buffer.printNameOffset = static_cast<USHORT>(substituteBytes + sizeof(wchar_t));
+        buffer.printNameLength = static_cast<USHORT>(printBytes);
+        memcpy(buffer.pathBuffer, substituteName.c_str(), substituteBytes);
+        memcpy(reinterpret_cast<std::byte*>(buffer.pathBuffer) + buffer.printNameOffset, targetPath.c_str(), printBytes);
+
+        const auto pathBytes = buffer.printNameOffset + buffer.printNameLength + sizeof(wchar_t);
+        buffer.reparseDataLength = static_cast<USHORT>(8 + pathBytes);
+        const auto inputBytes = static_cast<DWORD>(FIELD_OFFSET(KittyMountPointReparseBuffer, pathBuffer) + pathBytes);
+        DWORD returned{};
+        return DeviceIoControl(junction.get(), fsctlSetReparsePoint, &buffer, inputBytes, nullptr, 0, &returned, nullptr) != FALSE;
+    }
+
+    std::wstring KittyUniqueMappingName()
+    {
+        static unsigned int counter = 0;
+        return L"Local\\tty-graphics-protocol-" + std::to_wstring(GetCurrentProcessId()) + L"-" +
+               std::to_wstring(GetTickCount64()) + L"-" + std::to_wstring(counter++);
+    }
+
+    wil::unique_handle KittyCreateMapping(const std::wstring& name,
+                                          const uint64_t size,
+                                          const std::span<const uint8_t> content = {},
+                                          const DWORD protection = PAGE_READWRITE)
+    {
+        wil::unique_handle mapping{ CreateFileMappingW(INVALID_HANDLE_VALUE,
+                                                       nullptr,
+                                                       protection,
+                                                       static_cast<DWORD>(size >> 32),
+                                                       static_cast<DWORD>(size),
+                                                       name.c_str()) };
+        if (!mapping || content.empty())
+        {
+            return mapping;
+        }
+
+        const auto view = MapViewOfFile(mapping.get(), FILE_MAP_WRITE, 0, 0, content.size());
+        if (!view)
+        {
+            return {};
+        }
+        memcpy(view, content.data(), content.size());
+        UnmapViewOfFile(view);
+        return mapping;
+    }
+
+    // What the adapter passes for t=t: only a temporary file carrying this in its
+    // name may be deleted after a successful read.
+    constexpr std::wstring_view TempFileMarker{ L"tty-graphics-protocol" };
+}
+
+void TerminalApiTest::ReadLocalFileReadsFromTemp()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty(), L"need a usable system temp directory");
+    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-read-");
+    const std::vector<uint8_t> content{ 1, 2, 3, 4, 5 };
+    VERIFY_IS_TRUE(KittyWriteAllBytes(path, content), L"failed to create the test file");
+
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, false, TempFileMarker, out), L"a readable local temp file must succeed");
+    VERIFY_ARE_EQUAL(content.size(), out.size());
+    VERIFY_IS_TRUE(out == content, L"the bytes read must equal the file contents");
+    VERIFY_IS_TRUE(KittyFileExists(path), L"deleteAfter=false must not remove the file");
+
+    DeleteFileW(path.c_str());
+}
+
+void TerminalApiTest::ReadLocalFileDeletesTempWithMarker()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-del-");
+    VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 9, 8, 7 }));
+
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should succeed");
+    VERIFY_ARE_EQUAL(static_cast<size_t>(3), out.size());
+    VERIFY_IS_FALSE(KittyFileExists(path), L"a temp file carrying the kitty marker must be deleted after a t=t read");
+
+    if (KittyFileExists(path))
+    {
+        DeleteFileW(path.c_str());
+    }
+}
+
+void TerminalApiTest::ReadLocalFileOutsideTempNotDeleted()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    // The current directory (the test's output folder) is a local, writable location
+    // that is not under the system temp directory.
+    const auto dir = KittyCurrentDir();
+    VERIFY_IS_FALSE(dir.empty());
+    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-outside-");
+    VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 4, 5, 6 }));
+
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should still succeed");
+    VERIFY_IS_TRUE(KittyFileExists(path), L"a file OUTSIDE the temp dir must never be deleted, even with deleteAfter (anti arbitrary-delete)");
+
+    DeleteFileW(path.c_str());
+}
+
+void TerminalApiTest::ReadLocalFileNoMarkerNotDeleted()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    // Under temp, but the name lacks the "tty-graphics-protocol" marker.
+    const auto path = KittyUniquePath(dir, L"kitty-no-marker-");
+    VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 1, 1, 1 }));
+
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should succeed");
+    VERIFY_IS_TRUE(KittyFileExists(path), L"a temp file WITHOUT the kitty marker must not be auto-deleted");
+
+    DeleteFileW(path.c_str());
+}
+
+void TerminalApiTest::ReadLocalFileEmptyMarkerNeverDeletes()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    // Named exactly the way a caller that DOES pass a marker would name it, so the only
+    // thing standing between this file and deletion is the empty marker below.
+    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-nomarker-");
+    VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 1, 1, 1 }));
+
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, L"", out), L"the read should succeed");
+    VERIFY_IS_TRUE(KittyFileExists(path), L"an empty marker must delete nothing: a caller cannot opt out of the name check by omitting it");
+
+    DeleteFileW(path.c_str());
+}
+
+void TerminalApiTest::ReadLocalFileParentMarkerNotDeleted()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    const auto subdir = KittyUniquePath(dir, L"tty-graphics-protocol-parent-");
+    VERIFY_IS_TRUE(CreateDirectoryW(subdir.c_str(), nullptr) != FALSE, L"failed to create the marked parent directory");
+    const auto path = KittyUniquePath(subdir + L"\\", L"unrelated-");
+    VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 1, 2, 3 }));
+
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, true, TempFileMarker, out), L"the read should succeed");
+    VERIFY_IS_TRUE(KittyFileExists(path), L"a marker in a parent directory must not authorize deleting an unrelated file");
+
+    DeleteFileW(path.c_str());
+    RemoveDirectoryW(subdir.c_str());
+}
+
+void TerminalApiTest::ReadLocalFileOffsetAndSizeSlice()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-slice-");
+    const std::vector<uint8_t> content{ 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H' };
+    VERIFY_IS_TRUE(KittyWriteAllBytes(path, content));
+
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 2, 3, false, TempFileMarker, out), L"offset+size read should succeed");
+    const std::vector<uint8_t> expected{ 'C', 'D', 'E' };
+    VERIFY_ARE_EQUAL(expected.size(), out.size());
+    VERIFY_IS_TRUE(out == expected, L"O=2,S=3 must read exactly bytes [2,5) of the file");
+
+    DeleteFileW(path.c_str());
+}
+
+void TerminalApiTest::ReadLocalFileOversizeSizeClampsToEof()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-clamp-");
+    const std::vector<uint8_t> content{ 10, 20, 30, 40, 50 };
+    VERIFY_IS_TRUE(KittyWriteAllBytes(path, content));
+
+    std::vector<uint8_t> out;
+    // Ask for far more than the file holds; the read must clamp to the file's size.
+    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 100ull * 1024 * 1024, false, TempFileMarker, out), L"read should succeed");
+    VERIFY_ARE_EQUAL(content.size(), out.size(), L"an oversize S= must clamp to EOF (the file size)");
+    VERIFY_IS_TRUE(out == content);
+
+    DeleteFileW(path.c_str());
+}
+
+void TerminalApiTest::ReadLocalFileRejectsUncPath()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    // A UNC path must be rejected up front (no SMB connection, no NTLM handshake).
+    std::vector<uint8_t> out{ 7, 7, 7 };
+    VERIFY_IS_TRUE(til::read_file_result::invalid == term.ReadLocalFile(L"\\\\127.0.0.1\\share\\never.bin", 0, 0, false, TempFileMarker, out), L"a UNC path must be rejected as an invalid request");
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size(), L"a rejected read must leave the output empty");
+}
+
+void TerminalApiTest::ReadLocalFileRejectsRelativePath()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    // Relative paths are rejected so a client cannot read a file resolved against the
+    // terminal's own working directory.
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(til::read_file_result::invalid == term.ReadLocalFile(L"relative\\file.bin", 0, 0, false, TempFileMarker, out), L"a non-absolute path must be rejected as an invalid request");
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
+}
+
+void TerminalApiTest::ReadLocalFileNormalizesWin32Path()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-normalize-");
+    const auto filename = path.substr(path.find_last_of(L'\\') + 1);
+    const std::vector<uint8_t> content{ 1, 2, 3 };
+    VERIFY_IS_TRUE(KittyWriteAllBytes(path, content));
+
+    const auto equivalentPath = dir + L".\\unused\\..\\\\" + filename + L".";
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(equivalentPath, 0, 0, false, TempFileMarker, out), L"Win32-equivalent dot segments, duplicate separators, and a trailing period must resolve to the same file");
+    VERIFY_IS_TRUE(out == content);
+
+    DeleteFileW(path.c_str());
+}
+
+void TerminalApiTest::ReadLocalFileRejectsIntermediateJunction()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    const auto targetDir = KittyUniquePath(dir, L"kitty-junction-target-");
+    const auto junctionPath = KittyUniquePath(dir, L"kitty-junction-link-");
+    const auto targetFile = targetDir + L"\\payload.bin";
+    const auto junctionFile = junctionPath + L"\\payload.bin";
+    auto cleanup = wil::scope_exit([&]() {
+        DeleteFileW(targetFile.c_str());
+        RemoveDirectoryW(junctionPath.c_str());
+        RemoveDirectoryW(targetDir.c_str());
+    });
+
+    VERIFY_IS_TRUE(CreateDirectoryW(targetDir.c_str(), nullptr) != FALSE, L"failed to create the junction target directory");
+    VERIFY_IS_TRUE(KittyWriteAllBytes(targetFile, { 1, 2, 3 }), L"failed to create the junction target file");
+    VERIFY_IS_TRUE(KittyCreateJunction(junctionPath, targetDir), L"failed to create the test junction");
+
+    std::vector<uint8_t> out{ 7, 7, 7 };
+    VERIFY_IS_TRUE(til::read_file_result::read_error == term.ReadLocalFile(junctionFile, 0, 0, false, TempFileMarker, out), L"an intermediate reparse point must be rejected before its target is opened");
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
+}
+
+void TerminalApiTest::ReadLocalFileNonexistentFails()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    // A unique path we never create.
+    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-missing-");
+
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(til::read_file_result::not_found == term.ReadLocalFile(path, 0, 0, false, TempFileMarker, out), L"a missing file must report not_found (ENOENT)");
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
+}
+
+void TerminalApiTest::ReadLocalFileRejectsCharDevice()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    // DOS device aliases resolve in any directory, with optional extensions and legacy
+    // superscript digits. They must retain EBADF semantics after switching to native opens.
+    for (const auto deviceName : { L"NUL", L"NUL.txt", L"COM\u00B9", L"LPT\u00B3.txt" })
+    {
+        const auto devicePath = dir.substr(0, 3) + deviceName; // e.g. "C:\\NUL"
+        std::vector<uint8_t> out{ 1, 2, 3 };
+        VERIFY_IS_TRUE(til::read_file_result::read_error == term.ReadLocalFile(devicePath, 0, 0, false, TempFileMarker, out), L"a DOS character device must be refused as unreadable (EBADF): only regular files may be read");
+        VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size(), L"a rejected read must leave the output empty");
+    }
+}
+
+void TerminalApiTest::ReadLocalFileRejectsDirectory()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    // A real, drive-absolute directory passes every pre-open path check but must not be
+    // readable as an image. FILE_NON_DIRECTORY_FILE reports it as read_error (EBADF).
+    const auto subdir = KittyUniquePath(dir, L"tty-graphics-protocol-dir-");
+    VERIFY_IS_TRUE(CreateDirectoryW(subdir.c_str(), nullptr) != FALSE, L"failed to create the test directory");
+
+    std::vector<uint8_t> out{ 1, 2, 3 };
+    VERIFY_IS_TRUE(til::read_file_result::read_error == term.ReadLocalFile(subdir, 0, 0, false, TempFileMarker, out), L"a directory must be refused as unreadable (EBADF): only regular files may be read");
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size(), L"a rejected read must leave the output empty");
+
+    RemoveDirectoryW(subdir.c_str());
+}
+
+void TerminalApiTest::ReadLocalFileCapsAtMaxBytes()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-huge-");
+
+    // The 32 MiB hard cap in til::read_file_as_bytes. Kept in sync by intent; a mismatch here
+    // means the cap moved and this test must be revisited.
+    constexpr uint64_t cap = 32ull * 1024 * 1024;
+
+    // Create a file LARGER than the cap WITHOUT writing 33 MiB of data: extend the size with
+    // SetEndOfFile so the [0, EOF) range reads back as zeros via NTFS valid-data-length
+    // semantics (no bulk disk I/O), which is enough to exercise the read bound.
+    {
+        wil::unique_hfile f{ CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr) };
+        VERIFY_IS_TRUE(static_cast<bool>(f), L"failed to create the oversize test file");
+        LARGE_INTEGER eof{};
+        eof.QuadPart = static_cast<LONGLONG>(cap + 1024 * 1024); // 33 MiB, comfortably over the cap
+        VERIFY_IS_TRUE(SetFilePointerEx(f.get(), eof, nullptr, FILE_BEGIN) != FALSE);
+        VERIFY_IS_TRUE(SetEndOfFile(f.get()) != FALSE, L"failed to size the oversize test file");
+    }
+
+    std::vector<uint8_t> out;
+    // S=0 means "read the whole file"; the cap must still bound the result so a client cannot
+    // make the terminal allocate/return an unbounded amount from a huge (or lying) file.
+    VERIFY_IS_TRUE(til::read_file_result::ok == term.ReadLocalFile(path, 0, 0, false, TempFileMarker, out), L"reading a huge file must still succeed (clamped)");
+    VERIFY_ARE_EQUAL(static_cast<size_t>(cap), out.size(), L"the read must be capped at 32 MiB regardless of the file's size");
+
+    DeleteFileW(path.c_str());
+}
+
+void TerminalApiTest::ReadLocalFileFailedReadKeepsTempFile()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto dir = KittyTempDir();
+    VERIFY_IS_FALSE(dir.empty());
+    // A temp file that satisfies BOTH deletion gates (under %TEMP% AND carrying the
+    // "tty-graphics-protocol" marker), so a *successful* t=t read WOULD delete it.
+    const auto path = KittyUniquePath(dir, L"tty-graphics-protocol-faildelete-");
+    VERIFY_IS_TRUE(KittyWriteAllBytes(path, { 1, 2, 3, 4 }));
+
+    // Force the operation to FAIL with an offset past EOF. deleteAfter=true opens the file
+    // WITH delete access, but deletion is decided only AFTER a successful read -- so a failed
+    // t=t must never delete its target. This proves a malformed/failed transfer cannot be
+    // turned into an arbitrary-delete primitive on a file that otherwise qualifies.
+    std::vector<uint8_t> out{ 9, 9, 9 };
+    VERIFY_IS_TRUE(til::read_file_result::invalid == term.ReadLocalFile(path, 1000, 0, true, TempFileMarker, out), L"an offset past EOF must fail as an invalid request");
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size(), L"a failed read must leave the output empty");
+    VERIFY_IS_TRUE(KittyFileExists(path), L"a failed t=t read must NOT delete its target, even a marked temp file");
+
+    DeleteFileW(path.c_str());
+}
+
+void TerminalApiTest::ReadSharedMemoryCopiesSliceAndCloses()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto name = KittyUniqueMappingName();
+    const std::vector<uint8_t> content{ 'A', 'B', 'C', 'D', 'E', 'F' };
+    auto mapping = KittyCreateMapping(name, content.size(), content);
+    VERIFY_IS_TRUE(static_cast<bool>(mapping), L"failed to create the shared-memory test object");
+
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(Microsoft::Console::Utils::ReadSharedMemoryResult::ok == term.ReadSharedMemory(name, 2, 3, out));
+    const std::vector<uint8_t> expected{ 'C', 'D', 'E' };
+    VERIFY_IS_TRUE(out == expected, L"O=2,S=3 must copy exactly bytes [2,5)");
+
+    // The protocol requires Windows terminals to close (not unlink) the object. Once
+    // the creator closes its handle, no leaked terminal handle may keep the name alive.
+    mapping.reset();
+    wil::unique_handle reopened{ OpenFileMappingW(FILE_MAP_READ, FALSE, name.c_str()) };
+    VERIFY_IS_FALSE(static_cast<bool>(reopened), L"the terminal must close its mapping handle before returning");
+}
+
+void TerminalApiTest::ReadSharedMemoryCapsAtMaxBytes()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    constexpr uint64_t cap = 32ull * 1024 * 1024;
+    const auto name = KittyUniqueMappingName();
+    auto mapping = KittyCreateMapping(name, cap + 1024 * 1024);
+    VERIFY_IS_TRUE(static_cast<bool>(mapping), L"failed to create the oversize shared-memory object");
+
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(Microsoft::Console::Utils::ReadSharedMemoryResult::ok == term.ReadSharedMemory(name, 0, 0, out));
+    VERIFY_ARE_EQUAL(static_cast<size_t>(cap), out.size(), L"S=0 must still honor the 32 MiB hard cap");
+}
+
+void TerminalApiTest::ReadSharedMemoryRejectsUnsafeNames()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    std::vector<uint8_t> out{ 1, 2, 3 };
+    VERIFY_IS_TRUE(Microsoft::Console::Utils::ReadSharedMemoryResult::invalid == term.ReadSharedMemory(L"Global\\service-object", 0, 1, out), L"cross-session Global objects must be unreachable");
+    VERIFY_IS_TRUE(Microsoft::Console::Utils::ReadSharedMemoryResult::invalid == term.ReadSharedMemory(L"Session\\1\\object", 0, 1, out), L"system and nested object-manager paths must be rejected");
+    VERIFY_IS_TRUE(Microsoft::Console::Utils::ReadSharedMemoryResult::invalid == term.ReadSharedMemory(L"Local\\nested\\object", 0, 1, out), L"Local names may not escape into nested namespaces");
+    const std::wstring nulName{ L"Local\\foo\0bar", 13 };
+    VERIFY_IS_TRUE(Microsoft::Console::Utils::ReadSharedMemoryResult::invalid == term.ReadSharedMemory(nulName, 0, 1, out), L"embedded NULs must not truncate the opened name");
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
+}
+
+void TerminalApiTest::ReadSharedMemoryMissingFails()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto name = KittyUniqueMappingName();
+    std::vector<uint8_t> out;
+    VERIFY_IS_TRUE(Microsoft::Console::Utils::ReadSharedMemoryResult::not_found == term.ReadSharedMemory(name, 0, 1, out));
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
+}
+
+void TerminalApiTest::ReadSharedMemoryRejectsOffsetPastEnd()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto name = KittyUniqueMappingName();
+    auto mapping = KittyCreateMapping(name, 4096);
+    VERIFY_IS_TRUE(static_cast<bool>(mapping));
+
+    std::vector<uint8_t> out{ 1 };
+    VERIFY_IS_TRUE(Microsoft::Console::Utils::ReadSharedMemoryResult::invalid == term.ReadSharedMemory(name, 128 * 1024, 1, out));
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
+}
+
+void TerminalApiTest::ReadSharedMemoryRejectsReservedPages()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    const auto name = KittyUniqueMappingName();
+    auto mapping = KittyCreateMapping(name, 64 * 1024, {}, PAGE_READWRITE | SEC_RESERVE);
+    VERIFY_IS_TRUE(static_cast<bool>(mapping), L"failed to create the reserved shared-memory object");
+
+    std::vector<uint8_t> out{ 1 };
+    VERIFY_IS_TRUE(Microsoft::Console::Utils::ReadSharedMemoryResult::read_error == term.ReadSharedMemory(name, 0, 1, out));
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
+}
+
+void TerminalApiTest::ReadSharedMemoryRejectsPartiallyCommittedMapping()
+{
+    Terminal term{ Terminal::TestDummyMarker{} };
+    DummyRenderer renderer{ &term };
+    term.Create({ 100, 100 }, 0, renderer);
+
+    SYSTEM_INFO systemInfo{};
+    GetSystemInfo(&systemInfo);
+    const auto pageSize = static_cast<uint64_t>(systemInfo.dwPageSize);
+    const auto name = KittyUniqueMappingName();
+    auto mapping = KittyCreateMapping(name, pageSize * 2, {}, PAGE_READWRITE | SEC_RESERVE);
+    VERIFY_IS_TRUE(static_cast<bool>(mapping), L"failed to create the reserved shared-memory object");
+
+    const auto view = MapViewOfFile(mapping.get(), FILE_MAP_WRITE, 0, 0, 0);
+    VERIFY_IS_NOT_NULL(view);
+    const auto unmap = wil::scope_exit([&]() noexcept { UnmapViewOfFile(view); });
+    VERIFY_ARE_EQUAL(view, VirtualAlloc(view, gsl::narrow_cast<size_t>(pageSize), MEM_COMMIT, PAGE_READWRITE));
+    *static_cast<uint8_t*>(view) = 42;
+
+    std::vector<uint8_t> out{ 1 };
+    VERIFY_IS_TRUE(Microsoft::Console::Utils::ReadSharedMemoryResult::read_error == term.ReadSharedMemory(name, 0, 0, out));
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), out.size());
 }
 
 void TerminalApiTest::KittyPlaceholderRendersInRealTerminal()

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -14,6 +14,8 @@
 #include "../interactivity/inc/ServiceLocator.hpp"
 #include "../renderer/base/renderer.hpp"
 
+#include <til/io.h>
+
 #pragma hdrstop
 
 using namespace Microsoft::Console;
@@ -465,19 +467,6 @@ void ConhostInternalGetSet::ShowNotification(std::wstring_view /*title*/, std::w
     // Not implemented for conhost.
 }
 
-bool ConhostInternalGetSet::DecodeImageToBgra(const std::span<const uint8_t> /*data*/, std::vector<RGBQUAD>& pixels, til::size& /*size*/) noexcept
-{
-    // conhost has no image decoder. Under ConPTY the connected terminal decodes; standalone,
-    // an encoded image simply isn't displayed.
-    pixels.clear();
-    return false;
-}
-
-til::size ConhostInternalGetSet::GetCellSize() const noexcept
-{
-    return _io.GetActiveOutputBuffer().GetCurrentFont().GetSize();
-}
-
 // Stores the handler the adapter wants called when timed content advances.
 // A null handler clears any prior registration and stops the outstanding timer.
 void ConhostInternalGetSet::SetTimedContentHandler(std::function<void()> handler)
@@ -538,4 +527,45 @@ void ConhostInternalGetSet::RequestTimedContentUpdate(
     }
 
     pRender->StartTimerAt(_timedContentTimer, *deadline);
+}
+
+bool ConhostInternalGetSet::DecodeImageToBgra(const std::span<const uint8_t> /*data*/, std::vector<RGBQUAD>& pixels, til::size& /*size*/) noexcept
+{
+    // conhost has no image decoder. Under ConPTY the connected terminal decodes; standalone,
+    // an encoded image simply isn't displayed.
+    pixels.clear();
+    return false;
+}
+
+til::size ConhostInternalGetSet::GetCellSize() const noexcept
+{
+    return _io.GetActiveOutputBuffer().GetCurrentFont().GetSize();
+}
+
+til::read_file_result ConhostInternalGetSet::ReadLocalFile(const std::wstring_view path, uint64_t offset, uint64_t size, bool deleteAfter, const std::wstring_view deleteNameMarker, std::vector<uint8_t>& out) noexcept
+{
+    // Under ConPTY, conhost is parse-only: it has no renderer, its ACK is suppressed
+    // (ReturnResponse early-returns in VtIo mode), and the raw APC is forwarded verbatim to
+    // the connected terminal (e.g. Windows Terminal), which performs the file read and owns
+    // t=t deletion. Reading the file here would be redundant filesystem access in the wrong
+    // process context (and deleting it would remove it before the terminal can read it), so
+    // skip the read entirely and let the final terminal handle the transmission.
+    if (IsConPTY())
+    {
+        out.clear();
+        return til::read_file_result::read_error;
+    }
+    return til::read_file_as_bytes(path, offset, size, deleteAfter, deleteNameMarker, out);
+}
+
+Microsoft::Console::Utils::ReadSharedMemoryResult ConhostInternalGetSet::ReadSharedMemory(const std::wstring_view name, uint64_t offset, uint64_t size, std::vector<uint8_t>& out) noexcept
+{
+    // Under ConPTY the final terminal receives the raw APC and owns the mapping read.
+    // Avoid a redundant read in conhost, matching the t=f/t=t path above.
+    if (IsConPTY())
+    {
+        out.clear();
+        return Microsoft::Console::Utils::ReadSharedMemoryResult::read_error;
+    }
+    return Microsoft::Console::Utils::ReadSharedMemory(name, offset, size, out);
 }

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -82,6 +82,8 @@ public:
 
     void SetTimedContentHandler(std::function<void()> handler) override;
     void RequestTimedContentUpdate(const std::optional<std::chrono::steady_clock::time_point> deadline) override;
+    til::read_file_result ReadLocalFile(const std::wstring_view path, uint64_t offset, uint64_t size, bool deleteAfter, const std::wstring_view deleteNameMarker, std::vector<uint8_t>& out) noexcept override;
+    Microsoft::Console::Utils::ReadSharedMemoryResult ReadSharedMemory(const std::wstring_view name, uint64_t offset, uint64_t size, std::vector<uint8_t>& out) noexcept override;
 
 private:
     Microsoft::Console::IIoProvider& _io;

--- a/src/inc/til/io.h
+++ b/src/inc/til/io.h
@@ -5,6 +5,7 @@
 
 #include <aclapi.h>
 #include <sddl.h>
+#include <winternl.h>
 #include <wil/token_helpers.h>
 
 namespace til // Terminal Implementation Library. Also: "Today I Learned"
@@ -263,4 +264,404 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             }
         }
     } // io
+
+    // Outcome of read_file_as_bytes. not_found: the path named no existing file.
+    // invalid: the request itself was malformed -- an empty path, an unsupported path
+    // form, or a byte range that cannot be satisfied. read_error: the file exists but
+    // could not be read, because it is not a regular file, sits on the wrong kind of
+    // volume, or the read failed. Callers map these onto whatever their own protocol
+    // reports; this says only what happened on disk.
+    enum class read_file_result : uint8_t
+    {
+        ok,
+        not_found,
+        invalid,
+        read_error,
+    };
+
+    // Reads up to a bounded number of bytes of a LOCAL file into 'out', starting at
+    // 'offset'. A caller that has been handed a path by something untrusted -- a
+    // terminal client, say -- wants all of the checks below and should not have to
+    // remember them, so they live here rather than at any one call site.
+    //
+    // Security model:
+    //  * Only LOCAL, FIXED-drive, drive-absolute files are read. A path that is not of
+    //    the form "X:\..." (relative, drive-relative, or rooted) is rejected, as is any
+    //    UNC / Win32-device path ("\\server\share", "\\.\dev", "\\?\..."). After the
+    //    handle is open the canonical path is re-checked: a UNC final path
+    //    ("\\?\UNC\...") or a non-DRIVE_FIXED volume (remote/removable/optical) is
+    //    rejected. This blocks SSRF / NTLM-hash theft via "\\attacker\share" and device
+    //    access, even when a junction or mapped drive is used to disguise the target.
+    //  * The read is hard-bounded to 32 MiB regardless of the caller's 'size', so a
+    //    hostile length can never force a large allocation.
+    //  * When 'deleteAfter' is requested the file is removed via its OPEN handle
+    //    (FILE_DISPOSITION) — never by re-opening a path, closing the TOCTOU window —
+    //    and ONLY when that handle's canonical path is under the system temp directory
+    //    AND its name contains 'deleteNameMarker'. The marker is the caller's, because
+    //    only the caller knows what it named the files it is entitled to remove; an
+    //    empty one deletes nothing, so a caller cannot opt out of the check by omission.
+    // Never throws.
+    _TIL_INLINEPREFIX read_file_result read_file_as_bytes(const std::wstring_view path, uint64_t offset, uint64_t size, bool deleteAfter, const std::wstring_view deleteNameMarker, std::vector<uint8_t>& out) noexcept
+    {
+        out.clear();
+
+        // A hard ceiling no caller can raise, so a bad 'size' cannot turn into a bad
+        // allocation. It also keeps a single ReadFile within DWORD range.
+        constexpr uint64_t maxBytes = 32ull * 1024 * 1024;
+
+        if (path.empty())
+        {
+            return read_file_result::invalid;
+        }
+
+        const auto isSep = [](const wchar_t c) noexcept { return c == L'\\' || c == L'/'; };
+
+        // Reject UNC and device-namespace paths before opening: any path whose first two
+        // characters are separators ("\\server\share", "\\.\dev", "\\?\...", "//host/..").
+        if (path.size() >= 2 && isSep(path[0]) && isSep(path[1]))
+        {
+            return read_file_result::invalid;
+        }
+
+        // Require a drive-absolute local path ("X:\..."): reject relative and drive-
+        // relative paths so a client cannot make the terminal read a file resolved
+        // against the terminal's own working directory.
+        const auto driveLetter = path[0];
+        const auto isAlpha = (driveLetter >= L'a' && driveLetter <= L'z') || (driveLetter >= L'A' && driveLetter <= L'Z');
+        if (path.size() < 3 || !isAlpha || path[1] != L':' || !isSep(path[2]))
+        {
+            return read_file_result::invalid;
+        }
+
+        // Defense in depth: reject a non-fixed drive letter BEFORE opening, so a mapped
+        // network drive (X: -> \\server\share) can't trigger an outbound SMB/NTLM auth
+        // inside CreateFileW. The post-open canonical check still catches junction/symlink
+        // redirects to other volumes; this closes the pre-handshake window for the common case.
+        const wchar_t driveRoot[]{ driveLetter, L':', L'\\', L'\0' };
+        if (GetDriveTypeW(driveRoot) != DRIVE_FIXED)
+        {
+            return read_file_result::invalid;
+        }
+
+        std::wstring pathStr;
+        const auto isReservedDosDevice = [](const std::wstring_view candidate) noexcept {
+            auto leaf = candidate.substr(candidate.find_last_of(L'\\') + 1);
+            while (!leaf.empty() && (leaf.back() == L' ' || leaf.back() == L'.'))
+            {
+                leaf.remove_suffix(1);
+            }
+            if (const auto suffix = leaf.find_first_of(L".:"); suffix != std::wstring_view::npos)
+            {
+                leaf = leaf.substr(0, suffix);
+            }
+            while (!leaf.empty() && leaf.back() == L' ')
+            {
+                leaf.remove_suffix(1);
+            }
+            const auto equalsLeaf = [&](const std::wstring_view value) noexcept {
+                return leaf.size() == value.size() &&
+                       CompareStringOrdinal(leaf.data(), static_cast<int>(leaf.size()), value.data(), static_cast<int>(value.size()), TRUE) == CSTR_EQUAL;
+            };
+            const auto isNumberedDevice = [&](const std::wstring_view prefix) noexcept {
+                if (leaf.size() != prefix.size() + 1)
+                {
+                    return false;
+                }
+                const auto suffix = leaf.back();
+                return ((suffix >= L'1' && suffix <= L'9') || suffix == L'\u00B9' || suffix == L'\u00B2' || suffix == L'\u00B3') &&
+                       CompareStringOrdinal(leaf.data(), static_cast<int>(prefix.size()), prefix.data(), static_cast<int>(prefix.size()), TRUE) == CSTR_EQUAL;
+            };
+            return equalsLeaf(L"CON") || equalsLeaf(L"PRN") || equalsLeaf(L"AUX") || equalsLeaf(L"NUL") ||
+                   equalsLeaf(L"CLOCK$") || equalsLeaf(L"CONIN$") || equalsLeaf(L"CONOUT$") ||
+                   isNumberedDevice(L"COM") || isNumberedDevice(L"LPT");
+        };
+        try
+        {
+            pathStr.assign(path);
+            std::replace(pathStr.begin(), pathStr.end(), L'/', L'\\');
+            if (isReservedDosDevice(pathStr))
+            {
+                return read_file_result::read_error;
+            }
+
+            // Apply the same lexical normalization as CreateFileW without touching the
+            // filesystem. This collapses ".", "..", duplicate separators, and trailing
+            // spaces/periods before the normalized path is opened relative to the drive.
+            const auto needed = GetFullPathNameW(pathStr.c_str(), 0, nullptr, nullptr);
+            if (needed == 0)
+            {
+                return read_file_result::invalid;
+            }
+            std::wstring normalized(needed, L'\0');
+            const auto written = GetFullPathNameW(pathStr.c_str(), needed, normalized.data(), nullptr);
+            if (written == 0 || written >= needed)
+            {
+                return read_file_result::invalid;
+            }
+            normalized.resize(written);
+            pathStr.swap(normalized);
+        }
+        catch (...)
+        {
+            return read_file_result::read_error;
+        }
+
+        if (pathStr.size() < 3 ||
+            CompareStringOrdinal(pathStr.data(), 1, &driveLetter, 1, TRUE) != CSTR_EQUAL ||
+            pathStr[1] != L':' || pathStr[2] != L'\\')
+        {
+            return read_file_result::invalid;
+        }
+
+        const auto relativePath = std::wstring_view{ pathStr }.substr(3);
+        if (relativePath.empty() || relativePath.size() > USHRT_MAX / sizeof(wchar_t))
+        {
+            return read_file_result::invalid;
+        }
+
+        // Resolve only the already-validated fixed drive root through Win32. The remaining
+        // untrusted path is opened relative to this handle so OBJ_DONT_REPARSE does not
+        // reject the Object Manager's normal \??\C: drive-letter symbolic link.
+        wil::unique_hfile drive{ CreateFileW(driveRoot,
+                                             FILE_READ_ATTRIBUTES,
+                                             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                             nullptr,
+                                             OPEN_EXISTING,
+                                             FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+                                             nullptr) };
+        if (!drive)
+        {
+            return read_file_result::read_error;
+        }
+
+        UNICODE_STRING objectName{
+            .Length = static_cast<USHORT>(relativePath.size() * sizeof(wchar_t)),
+            .MaximumLength = static_cast<USHORT>(relativePath.size() * sizeof(wchar_t)),
+            .Buffer = const_cast<wchar_t*>(relativePath.data()),
+        };
+        OBJECT_ATTRIBUTES objectAttributes{
+            .Length = sizeof(OBJECT_ATTRIBUTES),
+            .RootDirectory = drive.get(),
+            .ObjectName = &objectName,
+            .Attributes = OBJ_CASE_INSENSITIVE | OBJ_DONT_REPARSE,
+        };
+
+        // Open without following any reparse point in the path. The post-open canonical
+        // checks below are too late to prevent an intermediate junction or symlink from
+        // initiating an SMB/NTLM handshake, so this intentionally rejects all reparse
+        // traversal before the target is touched.
+        const auto openFile = [&](const ACCESS_MASK access, wil::unique_hfile& file) noexcept {
+            IO_STATUS_BLOCK status{};
+            return NtCreateFile(file.addressof(),
+                                access | SYNCHRONIZE,
+                                &objectAttributes,
+                                &status,
+                                nullptr,
+                                FILE_ATTRIBUTE_NORMAL,
+                                FILE_SHARE_READ | FILE_SHARE_DELETE,
+                                FILE_OPEN,
+                                FILE_NON_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT,
+                                nullptr,
+                                0);
+        };
+
+        // Request DELETE only when we might actually remove the file, so an ordinary read
+        // never needs delete rights. FILE_SHARE_DELETE lets the file be unlinked while open.
+        wil::unique_hfile file;
+        auto status = openFile(GENERIC_READ | (deleteAfter ? static_cast<ACCESS_MASK>(DELETE) : 0ul), file);
+        if (status < 0 && deleteAfter)
+        {
+            // The file may not grant DELETE (e.g. a read-only ACL); fall back to a pure
+            // read so rendering still works. We then simply cannot delete it.
+            deleteAfter = false;
+            status = openFile(GENERIC_READ, file);
+        }
+        if (status < 0)
+        {
+            const auto err = RtlNtStatusToDosError(status);
+            return (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND)
+                       ? read_file_result::not_found
+                       : read_file_result::read_error;
+        }
+
+        // Only REGULAR files may be read;
+        // device/pipe/socket "special" files must be refused. GetFileType on the open handle is
+        // FILE_TYPE_DISK only for a real on-disk file; a character device (e.g. a reserved name
+        // like NUL/CON resolved against a drive), a pipe, or an unknown type is rejected. The path
+        // checks above already block the device namespace and non-fixed volumes; this is the
+        // explicit, auditable form of the spec's "regular files only" rule and closes the
+        // reserved-name edge.
+        if (GetFileType(file.get()) != FILE_TYPE_DISK)
+        {
+            return read_file_result::read_error;
+        }
+
+        // Resolves the fully-normalized on-disk path for an open handle (following
+        // symlinks/junctions and 8.3 short names), or empty on failure. With
+        // VOLUME_NAME_DOS every result is prefixed with "\\?\" (e.g. "\\?\C:\dir\file",
+        // or "\\?\UNC\server\share\file" for a UNC target).
+        const auto finalPath = [](HANDLE handle) noexcept -> std::wstring {
+            const auto needed = GetFinalPathNameByHandleW(handle, nullptr, 0, FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
+            if (needed == 0)
+            {
+                return {};
+            }
+            std::wstring resolved;
+            try
+            {
+                resolved.resize(needed);
+            }
+            catch (...)
+            {
+                return {};
+            }
+            const auto written = GetFinalPathNameByHandleW(handle, resolved.data(), needed, FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
+            if (written == 0 || written >= needed)
+            {
+                return {};
+            }
+            resolved.resize(written);
+            return resolved;
+        };
+
+        const auto canonical = finalPath(file.get());
+        if (canonical.empty())
+        {
+            return read_file_result::read_error;
+        }
+
+        // Reject a UNC final path. A drive-absolute client path can still resolve through
+        // a junction/mapped drive to a UNC location, so this must be re-checked here.
+        static constexpr std::wstring_view uncPrefix{ L"\\\\?\\UNC\\" };
+        if (canonical.size() >= uncPrefix.size() &&
+            CompareStringOrdinal(canonical.c_str(), static_cast<int>(uncPrefix.size()), uncPrefix.data(), static_cast<int>(uncPrefix.size()), TRUE) == CSTR_EQUAL)
+        {
+            return read_file_result::read_error;
+        }
+
+        // Require a fixed local volume: reject network/removable/optical drives
+        // (DRIVE_REMOTE/REMOVABLE/CDROM, plus UNKNOWN/NO_ROOT_DIR).
+        wchar_t volumeRoot[MAX_PATH]{};
+        if (!GetVolumePathNameW(canonical.c_str(), volumeRoot, ARRAYSIZE(volumeRoot)) || GetDriveTypeW(volumeRoot) != DRIVE_FIXED)
+        {
+            return read_file_result::read_error;
+        }
+
+        LARGE_INTEGER fileSize{};
+        if (!GetFileSizeEx(file.get(), &fileSize) || fileSize.QuadPart < 0)
+        {
+            return read_file_result::read_error;
+        }
+        const auto total = static_cast<uint64_t>(fileSize.QuadPart);
+        if (offset > total)
+        {
+            return read_file_result::invalid; // offset past end of file
+        }
+
+        // Bytes to read: what remains after the offset, clamped by 'size' when nonzero,
+        // and always by the hard 32 MiB cap.
+        uint64_t toRead = total - offset;
+        if (size != 0)
+        {
+            toRead = std::min(toRead, size);
+        }
+        toRead = std::min(toRead, maxBytes);
+
+        if (offset != 0)
+        {
+            LARGE_INTEGER move{};
+            move.QuadPart = static_cast<LONGLONG>(offset);
+            if (!SetFilePointerEx(file.get(), move, nullptr, FILE_BEGIN))
+            {
+                return read_file_result::read_error;
+            }
+        }
+
+        try
+        {
+            out.resize(static_cast<size_t>(toRead));
+        }
+        catch (...)
+        {
+            out.clear();
+            return read_file_result::read_error;
+        }
+
+        DWORD read = 0;
+        if (toRead != 0 && !ReadFile(file.get(), out.data(), static_cast<DWORD>(toRead), &read, nullptr))
+        {
+            out.clear();
+            return read_file_result::read_error;
+        }
+        out.resize(read);
+
+        // Decide deletion only after a successful read, using the canonical path of the
+        // exact inode behind our handle.
+        if (deleteAfter)
+        {
+            // The canonical system temp directory, normalized through a handle so it is in
+            // the same "\\?\" form as 'canonical', with a trailing backslash. Prefers
+            // GetTempPath2W (Win11, per-process) and falls back to GetTempPathW.
+            const auto tempDir = [&finalPath]() noexcept -> std::wstring {
+                wchar_t raw[MAX_PATH + 2]{};
+                using PfnGetTempPath2W = DWORD(WINAPI*)(DWORD, LPWSTR);
+                static const auto pfnGetTempPath2W = []() noexcept {
+                    const auto k32 = GetModuleHandleW(L"kernel32.dll");
+#pragma warning(suppress : 26490) // Don't use reinterpret_cast (type.1) -- required for GetProcAddress.
+                    return k32 ? reinterpret_cast<PfnGetTempPath2W>(GetProcAddress(k32, "GetTempPath2W")) : nullptr;
+                }();
+                const auto len = pfnGetTempPath2W ? pfnGetTempPath2W(ARRAYSIZE(raw), raw) : GetTempPathW(ARRAYSIZE(raw), raw);
+                if (len == 0 || len >= ARRAYSIZE(raw))
+                {
+                    return {};
+                }
+                wil::unique_hfile dir{ CreateFileW(raw, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr) };
+                if (!dir)
+                {
+                    return {};
+                }
+                auto resolved = finalPath(dir.get());
+                if (!resolved.empty() && resolved.back() != L'\\')
+                {
+                    try
+                    {
+                        resolved.push_back(L'\\');
+                    }
+                    catch (...)
+                    {
+                        return {};
+                    }
+                }
+                return resolved;
+            }();
+
+            const auto underTemp = !tempDir.empty() && canonical.size() >= tempDir.size() &&
+                                   CompareStringOrdinal(canonical.c_str(), static_cast<int>(tempDir.size()), tempDir.c_str(), static_cast<int>(tempDir.size()), TRUE) == CSTR_EQUAL;
+
+            // Require the caller's marker in the file name (case-insensitively), so we
+            // only ever auto-delete files the caller created, never an arbitrary file
+            // something else happened to leave under temp. No marker, no deletion.
+            const auto marker = deleteNameMarker;
+            const auto separator = canonical.find_last_of(L'\\');
+            const auto filenameOffset = separator == std::wstring::npos ? 0 : separator + 1;
+            auto hasMarker = false;
+            for (auto i = filenameOffset; !marker.empty() && !hasMarker && i + marker.size() <= canonical.size(); ++i)
+            {
+                hasMarker = CompareStringOrdinal(canonical.c_str() + i, static_cast<int>(marker.size()), marker.data(), static_cast<int>(marker.size()), TRUE) == CSTR_EQUAL;
+            }
+
+            if (underTemp && hasMarker)
+            {
+                // Delete the exact open inode by setting its disposition, then closing the
+                // handle below. No path is re-resolved, so there is no window for a
+                // junction/symlink swap between validation and deletion (TOCTOU-safe).
+                FILE_DISPOSITION_INFO disposition{};
+                disposition.DeleteFile = TRUE;
+                std::ignore = SetFileInformationByHandle(file.get(), FileDispositionInfo, &disposition, sizeof(disposition));
+            }
+        }
+
+        return read_file_result::ok; // the handle closes here; a set disposition removes the inode.
+    }
+
 } // til

--- a/src/inc/til/io.h
+++ b/src/inc/til/io.h
@@ -300,7 +300,6 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     //    AND its name contains 'deleteNameMarker'. The marker is the caller's, because
     //    only the caller knows what it named the files it is entitled to remove; an
     //    empty one deletes nothing, so a caller cannot opt out of the check by omission.
-    // Never throws.
     _TIL_INLINEPREFIX read_file_result read_file_as_bytes(const std::wstring_view path, uint64_t offset, uint64_t size, bool deleteAfter, const std::wstring_view deleteNameMarker, std::vector<uint8_t>& out) noexcept
     {
         out.clear();

--- a/src/terminal/adapter/ITerminalApi.hpp
+++ b/src/terminal/adapter/ITerminalApi.hpp
@@ -16,6 +16,7 @@ Author(s):
 
 #include "../parser/stateMachine.hpp"
 #include "../../types/inc/IInputEvent.hpp"
+#include "../../types/inc/sharedMemory.hpp"
 #include "../../buffer/out/LineRendition.hpp"
 #include "../../buffer/out/textBuffer.hpp"
 #include "../../renderer/inc/RenderSettings.hpp"
@@ -26,6 +27,8 @@ Author(s):
 #include <memory>
 #include <optional>
 #include <span>
+
+#include <til/io.h>
 
 namespace Microsoft::Console::VirtualTerminal
 {
@@ -111,6 +114,19 @@ namespace Microsoft::Console::VirtualTerminal
         // host owns the render thread: the adapter says when it has work, not when to run.
         virtual void SetTimedContentHandler(std::function<void()> handler) = 0;
         virtual void RequestTimedContentUpdate(const std::optional<std::chrono::steady_clock::time_point> deadline) = 0;
+        // Reads up to 'size' bytes of a local file (or to EOF when size == 0) starting at
+        // byte 'offset'. The path came off the wire, so the host is expected to be strict
+        // about what it will open and to bound the read; til::read_file_as_bytes is the
+        // shared implementation of both. 'deleteAfter' asks for the file to be removed
+        // once read, which the host honours only for a temporary file whose name contains
+        // 'deleteNameMarker' -- the caller names its own files, so the caller supplies the
+        // marker. A host that cannot reach the filesystem at all returns read_error.
+        virtual til::read_file_result ReadLocalFile(const std::wstring_view path, uint64_t offset, uint64_t size, bool deleteAfter, const std::wstring_view deleteNameMarker, std::vector<uint8_t>& out) noexcept = 0;
+
+        // Copies bytes out of a named shared-memory object. As with a file path, the name
+        // came off the wire; Microsoft::Console::Utils::ReadSharedMemory is the shared
+        // implementation and documents which names are safe to open.
+        virtual Microsoft::Console::Utils::ReadSharedMemoryResult ReadSharedMemory(const std::wstring_view name, uint64_t offset, uint64_t size, std::vector<uint8_t>& out) noexcept = 0;
 
         // The pixel size of a text cell, for anything that has to lay pixels out against
         // the grid.

--- a/src/terminal/adapter/KittyParser.cpp
+++ b/src/terminal/adapter/KittyParser.cpp
@@ -18,6 +18,7 @@
 
 using namespace Microsoft::Console::Types;
 using namespace Microsoft::Console::VirtualTerminal;
+using Microsoft::Console::Utils::ReadSharedMemoryResult;
 
 KittyParser::KittyParser(AdaptDispatch& dispatcher) noexcept :
     _dispatcher{ dispatcher }
@@ -225,6 +226,17 @@ KittyParser::Control KittyParser::_ParseControl(const std::wstring_view control)
                 c.cellOffsetY = _ParseUint(value);
                 c.upperY = c.cellOffsetY;
                 break;
+            case L'O':
+                // Uppercase O is the byte offset into a transmitted file (t=f / t=t);
+                // lowercase keys s/v are the pixel width/height, so case matters here.
+                // Parsed as 64-bit so a real >4 GiB offset is preserved, not truncated.
+                c.fileOffset = _ParseUint64(value);
+                break;
+            case L'S':
+                // Uppercase S is the number of file bytes to read (0 = to EOF), 64-bit so
+                // a large request is not silently wrapped (the host caps the actual read).
+                c.fileSize = _ParseUint64(value);
+                break;
             case L'o':
                 c.compression = value.front();
                 break;
@@ -287,6 +299,7 @@ KittyParser::Control KittyParser::_ParseControl(const std::wstring_view control)
 void KittyParser::_HandleSequence(const std::wstring_view control, const std::string_view payload, const bool controlValid, const bool payloadValid, const bool payloadTooLarge)
 {
     const auto command = _ParseControl(control);
+    const auto isSharedMemory = command.medium == L's';
 
     // A control block that hit the length bound was truncated, so none of the keys parsed
     // out of it can be trusted -- not the action, not the image id, and not the quiet level.
@@ -309,13 +322,15 @@ void KittyParser::_HandleSequence(const std::wstring_view control, const std::st
     const auto repeatsActiveAction = _chunkActive &&
                                      command.action == _chunkControl.action &&
                                      !command.hasNonChunkKeyOtherThanAction;
-    const auto isContinuation = command.mPresent && (!command.hasNonChunkKey || repeatsActiveAction);
+    // Per the protocol, m= applies only to direct transmission and is ignored for
+    // shared-memory media, whose payload is already just a local resource name.
+    const auto isContinuation = command.mPresent && !isSharedMemory && (!command.hasNonChunkKey || repeatsActiveAction);
     if (_chunkActive && !isContinuation)
     {
         _clearChunk();
     }
 
-    if (_chunkActive || command.moreChunks)
+    if (_chunkActive || (command.moreChunks && !isSharedMemory))
     {
         if (!_chunkActive)
         {
@@ -700,10 +715,10 @@ void KittyParser::_ProcessCommand(const Control& command, const std::string_view
                 code = L"EINVAL:unsupported format";
                 break;
             }
-            if (medium != L'd')
+            if (medium != L'd' && medium != L'f' && medium != L't' && medium != L's')
             {
-                // Only t=d (direct) transmission is supported here; the file and
-                // shared-memory media arrive with the host I/O they require.
+                // t=d (direct), t=f (file), t=t (temporary file), and t=s (shared
+                // memory) are supported. Reject every unrecognized medium.
                 success = false;
                 code = L"EINVAL:unsupported transmission medium";
                 break;
@@ -733,6 +748,133 @@ void KittyParser::_ProcessCommand(const Control& command, const std::string_view
                 break;
             }
 
+            // File and shared-memory payloads carry a UTF-8 resource name rather than
+            // image bytes. Decode strictly and reject embedded NULs so Win32 cannot
+            // silently open a truncated name.
+            const auto decodeResourceName = [](const std::vector<uint8_t>& encodedName, const size_t maxBytes, std::wstring& result) {
+                if (encodedName.empty() || encodedName.size() > maxBytes ||
+                    std::find(encodedName.begin(), encodedName.end(), uint8_t{ 0 }) != encodedName.end())
+                {
+                    return false;
+                }
+
+                const std::string utf8(encodedName.begin(), encodedName.end());
+                const auto length = static_cast<int>(utf8.size());
+                const auto needed = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8.data(), length, nullptr, 0);
+                if (needed <= 0)
+                {
+                    return false;
+                }
+
+                result.resize(static_cast<size_t>(needed));
+                if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8.data(), length, result.data(), needed) != needed)
+                {
+                    result.clear();
+                    return false;
+                }
+                return true;
+            };
+
+            if (medium == L'f' || medium == L't')
+            {
+                // For file/temporary transmission the decoded payload is not image
+                // data but the image FILE PATH (UTF-8 bytes). Read the file contents
+                // into `bytes` so the format-specific validation/decode below treats
+                // it exactly like a direct payload. The host bounds the read to a safe
+                // size (MaxPayload), so a hostile S= cannot force a huge alloc, and
+                // restricts reads to local fixed-drive files (see ReadLocalFile).
+                //
+                // A temporary file (t=t) is deleted by the host after a successful read,
+                // but only when it resides under the system temp directory and carries the
+                // marker below. Kitty names its temporary files "tty-graphics-protocol-*",
+                // and this is the only layer that knows that, so this is where the marker
+                // lives. A query (a=q) validates the request without storing, so it must
+                // NOT delete: only a real transmit (a=t / a=T) of a t=t file requests it.
+                //
+                // Protocol (transmission media): https://sw.kovidgoyal.net/kitty/graphics-protocol/#transferring-data
+                //
+                // Convert the UTF-8 path with MB_ERR_INVALID_CHARS so a malformed path is
+                // rejected here (path stays empty -> EBADF below) rather than silently
+                // mangled into U+FFFD substitutions: unlike til::u8u16, which uses no
+                // flags and substitutes, this rejects invalid input deterministically.
+                static constexpr std::wstring_view temporaryFileMarker{ L"tty-graphics-protocol" };
+
+                std::wstring path;
+                std::ignore = decodeResourceName(bytes, static_cast<size_t>(INT_MAX), path);
+                const auto deleteAfter = (medium == L't') && (action != L'q');
+                std::vector<uint8_t> fileBytes;
+                // An empty path is a malformed request (EINVAL); otherwise the host reports
+                // whether the file was missing (ENOENT), the request was invalid (EINVAL), or
+                // it could not be read (EBADF). Map each to the kitty file error codes.
+                const auto readResult = path.empty()
+                                            ? til::read_file_result::invalid
+                                            : _dispatcher._api.ReadLocalFile(path, command.fileOffset, command.fileSize, deleteAfter, temporaryFileMarker, fileBytes);
+                if (readResult != til::read_file_result::ok)
+                {
+                    success = false;
+                    switch (readResult)
+                    {
+                    case til::read_file_result::not_found:
+                        code = L"ENOENT:image file not found";
+                        break;
+                    case til::read_file_result::invalid:
+                        code = L"EINVAL:invalid image file request";
+                        break;
+                    default:
+                        code = L"EBADF:could not read file";
+                        break;
+                    }
+                    break;
+                }
+                bytes = std::move(fileBytes);
+            }
+            else if (medium == L's')
+            {
+                // The payload names a Windows file mapping. The host accepts only the
+                // current-session namespace, opens FILE_MAP_READ, copies at most 32 MiB,
+                // and closes the view/handle before returning. Per the Kitty spec there
+                // is no unlink operation on Windows.
+                std::wstring name;
+                constexpr size_t maxMappingNameBytes = 32767;
+                if (!decodeResourceName(bytes, maxMappingNameBytes, name))
+                {
+                    success = false;
+                    code = L"EINVAL:invalid shared memory request";
+                    break;
+                }
+
+                auto readSize = command.fileSize;
+                if (readSize == 0 && compression != L'z' && (format == 24 || format == 32) && width != 0 && height != 0)
+                {
+                    // CreateFileMapping rounds section sizes to whole pages, so a mapping
+                    // has no discoverable byte-exact tail. For raw pixels the protocol's
+                    // dimensions provide that exact length when S= is omitted.
+                    const auto depth = format == 24 ? 3ull : 4ull;
+                    const auto area = static_cast<uint64_t>(width) * height;
+                    readSize = area <= UINT64_MAX / depth ? area * depth : UINT64_MAX;
+                }
+
+                std::vector<uint8_t> sharedBytes;
+                const auto readResult = _dispatcher._api.ReadSharedMemory(name, command.fileOffset, readSize, sharedBytes);
+                if (readResult != ReadSharedMemoryResult::ok)
+                {
+                    success = false;
+                    switch (readResult)
+                    {
+                    case ReadSharedMemoryResult::not_found:
+                        code = L"ENOENT:shared memory not found";
+                        break;
+                    case ReadSharedMemoryResult::invalid:
+                        code = L"EINVAL:invalid shared memory request";
+                        break;
+                    default:
+                        code = L"EBADF:could not read shared memory";
+                        break;
+                    }
+                    break;
+                }
+                bytes = std::move(sharedBytes);
+            }
             if (compression == L'z')
             {
                 // o=z: the bytes acquired above (from t=d base64, a t=f / t=t file,
@@ -743,7 +885,8 @@ void KittyParser::_ProcessCommand(const Control& command, const std::string_view
                 // The inflated size is bounded to MaxPayload, so a decompression
                 // bomb is rejected without ever allocating the expanded buffer.
                 std::vector<uint8_t> inflated;
-                if (!_inflateZlib(bytes, inflated, MaxPayload))
+                const auto allowSharedMemoryPadding = medium == L's' && command.fileSize == 0;
+                if (!_inflateZlib(bytes, inflated, MaxPayload, allowSharedMemoryPadding))
                 {
                     success = false;
                     code = L"EINVAL:invalid compressed data";
@@ -1199,6 +1342,29 @@ int32_t KittyParser::_ParseInt(const std::wstring_view value) noexcept
     return magnitude > 0x7FFFFFFFu ? INT32_MAX : static_cast<int32_t>(magnitude);
 }
 
+// Like _ParseUint but for the 64-bit file offset/size keys (O=/S=). Clamps to
+// UINT64_MAX on overflow so a hostile run of digits cannot wrap; the host bounds the
+// actual read and rejects an offset past EOF, so a clamped value just fails cleanly.
+uint64_t KittyParser::_ParseUint64(const std::wstring_view value) noexcept
+{
+    uint64_t result = 0;
+    for (const auto ch : value)
+    {
+        if (ch < L'0' || ch > L'9')
+        {
+            break;
+        }
+        const auto digit = static_cast<uint64_t>(ch - L'0');
+        // Detect overflow before it happens: clamp rather than wrap.
+        if (result > (UINT64_MAX - digit) / 10)
+        {
+            result = UINT64_MAX;
+            break;
+        }
+        result = result * 10 + digit;
+    }
+    return result;
+}
 
 // Returns an unused image id, skipping ids that are already registered.
 uint32_t KittyParser::_assignImageId()
@@ -4019,7 +4185,7 @@ bool KittyParser::_DecodeBase64(const std::string_view input, std::vector<uint8_
 //
 // Protocol: https://sw.kovidgoyal.net/kitty/graphics-protocol/#compression  (o=z)
 // zlib container format: https://www.rfc-editor.org/rfc/rfc1950
-bool KittyParser::_inflateZlib(const std::vector<uint8_t>& input, std::vector<uint8_t>& output, const size_t cap) noexcept
+bool KittyParser::_inflateZlib(const std::vector<uint8_t>& input, std::vector<uint8_t>& output, const size_t cap, const bool allowTrailingZeroPadding) noexcept
 try
 {
     output.clear();
@@ -4106,11 +4272,14 @@ try
     output.resize(produced);
 
     // inflatelib stops at the end of the DEFLATE stream, so whatever it did not consume
-    // is the 4-byte Adler-32. Require the stream to end exactly where that trailer ends,
-    // rejecting trailing garbage and multi-member streams.
+    // is the 4-byte Adler-32 plus any padding. Require the stream to end where that
+    // trailer begins, rejecting trailing garbage and multi-member streams. When an S=0
+    // shared-memory transfer includes page-rounded zero padding, only zeros may follow.
     const auto consumed = deflateAvailable - remainingInput.size();
     const auto streamEnd = 2u + consumed + 4u;
-    if (streamEnd != input.size())
+    if (streamEnd > input.size() ||
+        (!allowTrailingZeroPadding && streamEnd != input.size()) ||
+        (allowTrailingZeroPadding && !std::all_of(input.begin() + streamEnd, input.end(), [](const auto value) noexcept { return value == 0; })))
     {
         output.clear();
         return false;

--- a/src/terminal/adapter/KittyParser.hpp
+++ b/src/terminal/adapter/KittyParser.hpp
@@ -98,11 +98,13 @@ namespace Microsoft::Console::VirtualTerminal
             uint32_t cellOffsetY = 0; // Y=: y pixel offset of the image within the first cell
             uint32_t upperX = 0;  // X=: animation replacement mode or composition source x
             uint32_t upperY = 0;  // Y=: animation background RGBA or composition source y
+            uint64_t fileOffset = 0; // O=: byte offset into a file or shared-memory object
+            uint64_t fileSize = 0;   // S=: bytes to read (0 = to end, host-bounded)
             bool moreChunks = false;
             bool mPresent = false;
             bool haveId = false;
             bool haveNumber = false;
-            wchar_t medium = L'd';          // t=: transmission medium (only d, direct, is handled here)
+            wchar_t medium = L'd';          // t=: transmission medium (d/f/t/s)
             bool noCursorMovement = false;  // C=1: leave the cursor in place after a placement
             bool hasNonChunkKey = false;    // true if any key other than m/q was present
             bool hasNonChunkKeyOtherThanAction = false; // permits required a=f on frame continuations
@@ -237,8 +239,9 @@ namespace Microsoft::Console::VirtualTerminal
         void _clearChunk() noexcept;
         static uint32_t _ParseUint(const std::wstring_view value) noexcept;
         static int32_t _ParseInt(const std::wstring_view value) noexcept;
+        static uint64_t _ParseUint64(const std::wstring_view value) noexcept;
         static bool _DecodeBase64(const std::string_view input, std::vector<uint8_t>& output) noexcept;
-        static bool _inflateZlib(const std::vector<uint8_t>& input, std::vector<uint8_t>& output, size_t cap) noexcept;
+        static bool _inflateZlib(const std::vector<uint8_t>& input, std::vector<uint8_t>& output, size_t cap, bool allowTrailingZeroPadding = false) noexcept;
         static std::vector<RGBQUAD> _decodePixels(const uint32_t format, const std::vector<uint8_t>& bytes);
         static RGBQUAD _rgbaColor(uint32_t rgba) noexcept;
         static void _compositePixels(std::span<RGBQUAD> destination, std::span<const RGBQUAD> source, bool replace) noexcept;

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -271,6 +271,53 @@ public:
         return _cellSize;
     }
 
+    til::read_file_result ReadLocalFile(const std::wstring_view path, uint64_t offset, uint64_t size, bool deleteAfter, const std::wstring_view deleteNameMarker, std::vector<uint8_t>& out) noexcept override
+    {
+        Log::Comment(L"ReadLocalFile MOCK called...");
+        _readLocalFileCallCount++;
+        _lastKittyFilePath = std::wstring{ path };
+        _lastKittyFileOffset = offset;
+        _lastKittyFileSize = size;
+        _lastKittyFileDeleteAfter = deleteAfter;
+        _lastKittyFileDeleteNameMarker = std::wstring{ deleteNameMarker };
+        if (!_readLocalFileSucceeds)
+        {
+            return _readLocalFileResult;
+        }
+        // Return a synthetic image payload (not the real file contents) so unit tests
+        // never touch the filesystem. Tests set _kittyFileBytes to match their f=/s=/v=.
+        out = _kittyFileBytes;
+        return til::read_file_result::ok;
+    }
+
+    Microsoft::Console::Utils::ReadSharedMemoryResult ReadSharedMemory(const std::wstring_view name, uint64_t offset, uint64_t size, std::vector<uint8_t>& out) noexcept override
+    {
+        Log::Comment(L"ReadSharedMemory MOCK called...");
+        _readSharedMemoryCallCount++;
+        _lastKittySharedMemoryName = std::wstring{ name };
+        _lastKittySharedMemoryOffset = offset;
+        _lastKittySharedMemorySize = size;
+        if (!_readSharedMemorySucceeds)
+        {
+            return _readSharedMemoryResult;
+        }
+        if (offset > _kittySharedMemoryBytes.size())
+        {
+            out.clear();
+            return Microsoft::Console::Utils::ReadSharedMemoryResult::invalid;
+        }
+        const auto available = static_cast<uint64_t>(_kittySharedMemoryBytes.size()) - offset;
+        if (size != 0 && size > available)
+        {
+            out.clear();
+            return Microsoft::Console::Utils::ReadSharedMemoryResult::invalid;
+        }
+        const auto count = gsl::narrow_cast<size_t>(size == 0 ? available : size);
+        const auto begin = _kittySharedMemoryBytes.begin() + gsl::narrow_cast<size_t>(offset);
+        out.assign(begin, begin + count);
+        return Microsoft::Console::Utils::ReadSharedMemoryResult::ok;
+    }
+
     void PrepData()
     {
         PrepData(CursorDirection::UP); // if called like this, the cursor direction doesn't matter.
@@ -434,6 +481,28 @@ public:
     bool _decodeImageMismatched = false;
     int _decodeImageCallCount = 0;
     til::size _cellSize{ 10, 20 };
+
+    // Kitty file-transmission (t=f / t=t) mock state. The mock returns synthetic bytes
+    // instead of reading the filesystem, and records what the adapter requested so
+    // tests can assert path/offset/size/delete plumbing without touching real files.
+    bool _readLocalFileSucceeds = true;
+    til::read_file_result _readLocalFileResult{ til::read_file_result::read_error };
+    int _readLocalFileCallCount = 0;
+    std::wstring _lastKittyFilePath;
+    uint64_t _lastKittyFileOffset = 0;
+    uint64_t _lastKittyFileSize = 0;
+    bool _lastKittyFileDeleteAfter = false;
+    std::wstring _lastKittyFileDeleteNameMarker;
+    std::vector<uint8_t> _kittyFileBytes{ 255, 0, 0 }; // default: 1x1 red RGB (f=24,s=1,v=1)
+
+    // Kitty shared-memory transmission (t=s) mock state.
+    bool _readSharedMemorySucceeds = true;
+    Microsoft::Console::Utils::ReadSharedMemoryResult _readSharedMemoryResult{ Microsoft::Console::Utils::ReadSharedMemoryResult::read_error };
+    int _readSharedMemoryCallCount = 0;
+    std::wstring _lastKittySharedMemoryName;
+    uint64_t _lastKittySharedMemoryOffset = 0;
+    uint64_t _lastKittySharedMemorySize = 0;
+    std::vector<uint8_t> _kittySharedMemoryBytes{ 255, 0, 0 };
 
     til::enumset<Mode> _systemMode{ Mode::AutoWrap };
 
@@ -5738,6 +5807,78 @@ public:
         VERIFY_IS_TRUE(_testGetSet->_decodeImageCallCount > 0, L"o=z + f=100 must reach the host PNG decoder.");
     }
 
+    // o=z composes with file (t=f) and temporary-file (t=t) media: the compressed bytes
+    // come from the file read, then inflate, and t=t still requests deletion.
+    TEST_METHOD(KittyGraphicsZlibFileAndTempMediaInflate)
+    {
+        const std::vector<uint8_t> c12{ 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00, 0x01, 0x78, 0x00, 0x4f };
+
+        _testGetSet->PrepData();
+        _testGetSet->_kittyFileBytes = c12; // a file whose contents are the zlib stream
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=16,f=24,s=2,v=2,t=f,o=z;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=16;OK\x1b\\");
+        VERIFY_IS_FALSE(_testGetSet->_lastKittyFileDeleteAfter, L"t=f must not request deletion.");
+
+        _testGetSet->PrepData();
+        _testGetSet->_kittyFileBytes = c12;
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=17,f=24,s=2,v=2,t=t,o=z;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=17;OK\x1b\\");
+        VERIFY_IS_TRUE(_testGetSet->_lastKittyFileDeleteAfter, L"t=t must request deletion.");
+    }
+
+    // o=z also composes with shared memory: S= describes the compressed resource size,
+    // then format validation runs on the inflated bytes.
+    TEST_METHOD(KittyGraphicsZlibSharedMemoryInflates)
+    {
+        const std::vector<uint8_t> c12{ 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00, 0x01, 0x78, 0x00, 0x4f };
+
+        _testGetSet->PrepData();
+        _testGetSet->_kittySharedMemoryBytes = c12;
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=18,f=24,s=2,v=2,t=s,S=20,o=z;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=18;OK\x1b\\");
+        VERIFY_ARE_EQUAL(1, _testGetSet->_readSharedMemoryCallCount);
+        VERIFY_ARE_EQUAL(static_cast<uint64_t>(c12.size()), _testGetSet->_lastKittySharedMemorySize);
+
+        const auto it = _kitty()._images.find(18);
+        VERIFY_IS_TRUE(it != _kitty()._images.end());
+        VERIFY_ARE_EQUAL(static_cast<size_t>(4), it->second.pixels.size());
+        VERIFY_ARE_EQUAL(1, static_cast<int>(it->second.pixels[0].rgbRed));
+        VERIFY_ARE_EQUAL(12, static_cast<int>(it->second.pixels[3].rgbBlue));
+    }
+
+    // With S omitted, Windows exposes the mapping's page-rounded zero tail. Locate the
+    // complete zlib stream, verify its Adler-32, and ignore only that zero padding.
+    TEST_METHOD(KittyGraphicsZlibSharedMemoryWithoutSizeInflates)
+    {
+        const std::vector<uint8_t> c12{ 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00, 0x01, 0x78, 0x00, 0x4f };
+
+        _testGetSet->PrepData();
+        _testGetSet->_kittySharedMemoryBytes = c12;
+        _testGetSet->_kittySharedMemoryBytes.resize(4096);
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=19,f=24,s=2,v=2,t=s,o=z;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=19;OK\x1b\\");
+        VERIFY_ARE_EQUAL(1, _testGetSet->_readSharedMemoryCallCount);
+        VERIFY_ARE_EQUAL(static_cast<uint64_t>(0), _testGetSet->_lastKittySharedMemorySize);
+
+        const auto it = _kitty()._images.find(19);
+        VERIFY_IS_TRUE(it != _kitty()._images.end());
+        VERIFY_ARE_EQUAL(static_cast<size_t>(4), it->second.pixels.size());
+        VERIFY_ARE_EQUAL(1, static_cast<int>(it->second.pixels[0].rgbRed));
+        VERIFY_ARE_EQUAL(12, static_cast<int>(it->second.pixels[3].rgbBlue));
+    }
+
+    TEST_METHOD(KittyGraphicsZlibSharedMemoryRejectsNonzeroTrailingData)
+    {
+        const std::vector<uint8_t> c12{ 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00, 0x01, 0x78, 0x00, 0x4f };
+
+        _testGetSet->PrepData();
+        _testGetSet->_kittySharedMemoryBytes = c12;
+        _testGetSet->_kittySharedMemoryBytes.push_back(1);
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=19,f=24,s=2,v=2,t=s,o=z;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=19;EINVAL:invalid compressed data\x1b\\");
+        VERIFY_IS_TRUE(_kitty()._images.find(19) == _kitty()._images.end());
+    }
+
     // o=z that inflates SUCCESSFULLY but to the WRONG size for the declared geometry is
     // rejected by the post-inflate size check -- proving a compressed payload cannot smuggle
     // a wrong-sized image past validation (the size check runs on the INFLATED bytes, not the
@@ -5840,6 +5981,236 @@ public:
         _testGetSet->PrepData();
         _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24;AAAA\x1b\\");
         _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;EINVAL:missing dimensions\x1b\\");
+    }
+
+    // Direct (t=d), file (t=f), temporary-file (t=t), and shared-memory (t=s)
+    // media are supported; any other medium is rejected.
+    TEST_METHOD(KittyGraphicsUnsupportedMediumIsEinval)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1,t=x;AAAA\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;EINVAL:unsupported transmission medium\x1b\\");
+    }
+
+    // Shared-memory transmission decodes the mapping name, forwards O=/S= to the
+    // host, and processes the copied bytes through the normal pixel path.
+    TEST_METHOD(KittyGraphicsSharedMemoryTransmitRenders)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittySharedMemoryBytes.assign(10, 0);
+        _testGetSet->_kittySharedMemoryBytes.insert(_testGetSet->_kittySharedMemoryBytes.end(), { 255, 0, 0 });
+        // Base64 of "Local\\kitty-shm-test".
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=20,f=24,s=1,v=1,t=s,O=10,S=3;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=20;OK\x1b\\");
+        VERIFY_ARE_EQUAL(1, _testGetSet->_readSharedMemoryCallCount);
+        VERIFY_IS_TRUE(_testGetSet->_lastKittySharedMemoryName == L"Local\\kitty-shm-test");
+        VERIFY_ARE_EQUAL(static_cast<uint64_t>(10), _testGetSet->_lastKittySharedMemoryOffset);
+        VERIFY_ARE_EQUAL(static_cast<uint64_t>(3), _testGetSet->_lastKittySharedMemorySize);
+        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0));
+    }
+
+    // Windows rounds named mappings to pages. Without S=, raw dimensions provide the
+    // exact byte count and prevent page padding from becoming image data.
+    TEST_METHOD(KittyGraphicsSharedMemoryInfersRawSize)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittySharedMemoryBytes.assign(12, 0);
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=21,f=24,s=2,v=2,t=s;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=21;OK\x1b\\");
+        VERIFY_ARE_EQUAL(static_cast<uint64_t>(12), _testGetSet->_lastKittySharedMemorySize);
+
+        // S defaults to zero, so explicit S=0 is equivalent to omission. Both use the
+        // raw format's expected byte extent rather than page-rounded mapping padding.
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=22,f=24,s=2,v=2,t=s,S=0;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=22;OK\x1b\\");
+        VERIFY_ARE_EQUAL(static_cast<uint64_t>(12), _testGetSet->_lastKittySharedMemorySize);
+    }
+
+    // Shared-memory payloads carry one resource name, so m=1 must be ignored rather
+    // than delaying the read forever.
+    TEST_METHOD(KittyGraphicsSharedMemoryIgnoresMoreChunks)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittySharedMemoryBytes = { 255, 0, 0 };
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=23,f=24,s=1,v=1,t=s,S=3,m=1;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=23;OK\x1b\\");
+        VERIFY_ARE_EQUAL(1, _testGetSet->_readSharedMemoryCallCount);
+    }
+
+    // The adapter rejects malformed or NUL-truncated mapping names before any host
+    // IPC call, so Win32 never opens a different object than the client named.
+    TEST_METHOD(KittyGraphicsSharedMemoryRejectsInvalidNameEncoding)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=24,f=24,s=1,v=1,t=s;//79\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=24;EINVAL:invalid shared memory request\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=25,f=24,s=1,v=1,t=s;QQBC\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=25;EINVAL:invalid shared memory request\x1b\\");
+        VERIFY_ARE_EQUAL(0, _testGetSet->_readSharedMemoryCallCount);
+    }
+
+    // Host failures retain their protocol distinction and never register an image.
+    TEST_METHOD(KittyGraphicsSharedMemoryMissingIsEnoent)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_readSharedMemorySucceeds = false;
+        _testGetSet->_readSharedMemoryResult = Microsoft::Console::Utils::ReadSharedMemoryResult::not_found;
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=26,f=24,s=1,v=1,t=s;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=26;ENOENT:shared memory not found\x1b\\");
+        _stateMachine->ProcessString(L"\x1b_Ga=p,i=26;\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=26;ENOENT:image not found\x1b\\");
+    }
+
+    // File transmission (t=f): the base64 payload is the file PATH; the host reads the
+    // file and its contents render exactly like a direct payload (here, 1x1 red RGB).
+    TEST_METHOD(KittyGraphicsFileTransmitRendersFromFile)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittyFileBytes = { 255, 0, 0 }; // 1x1 red RGB == f=24,s=1,v=1
+        // "L3RtcC94" is base64 of the path "/tmp/x"; the mock ignores the path content.
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,t=f;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;OK\x1b\\");
+        VERIFY_IS_TRUE(_testGetSet->_readLocalFileCallCount > 0, L"t=f must invoke the host file read.");
+        VERIFY_IS_TRUE(_testGetSet->_lastKittyFilePath == L"/tmp/x", L"the UTF-8 payload path must reach the host as a wstring.");
+        const auto& buffer = *_testGetSet->_textBuffer;
+        til::CoordType imageRow = -1;
+        const auto slice = FindFirstImageSlice(buffer, imageRow);
+        VERIFY_IS_NOT_NULL(slice, L"t=f with a=T should place an image slice.");
+        VERIFY_IS_TRUE(SliceContainsColor(slice, 255, 0, 0), L"the file's pixels should render red.");
+    }
+
+    // Temporary file (t=t): the host is asked to delete the file after reading. The
+    // adapter must pass deleteAfter=true (the host enforces temp-dir containment).
+    TEST_METHOD(KittyGraphicsTempFileTransmitRequestsDelete)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittyFileBytes = { 255, 0, 0 };
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=2,f=24,s=1,v=1,t=t;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=2;OK\x1b\\");
+        VERIFY_IS_TRUE(_testGetSet->_lastKittyFileDeleteAfter, L"t=t must request deletion of the temporary file.");
+    }
+
+    // O= (byte offset) and S= (byte count) are forwarded to the host read; t=f must not
+    // request deletion.
+    TEST_METHOD(KittyGraphicsFileTransmitForwardsOffsetAndSize)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittyFileBytes = { 255, 0, 0 };
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=3,f=24,s=1,v=1,t=f,O=10,S=3;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=3;OK\x1b\\");
+        VERIFY_ARE_EQUAL(static_cast<uint64_t>(10), _testGetSet->_lastKittyFileOffset, L"O= must pass through as the file offset.");
+        VERIFY_ARE_EQUAL(static_cast<uint64_t>(3), _testGetSet->_lastKittyFileSize, L"S= must pass through as the byte count.");
+        VERIFY_IS_FALSE(_testGetSet->_lastKittyFileDeleteAfter, L"t=f must not request deletion.");
+    }
+
+    // A file that cannot be read (host returns false) reports EBADF and stores nothing.
+    TEST_METHOD(KittyGraphicsFileTransmitReadFailureIsEbadf)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_readLocalFileSucceeds = false;
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=4,f=24,s=1,v=1,t=f;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=4;EBADF:could not read file\x1b\\");
+        // The failed transfer must not register a phantom image.
+        _stateMachine->ProcessString(L"\x1b_Ga=p,i=4;\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=4;ENOENT:image not found\x1b\\");
+    }
+
+    // f=100 (PNG) over a file: the file bytes go through the host PNG decoder, exactly
+    // like a direct PNG payload.
+    TEST_METHOD(KittyGraphicsPngFileTransmitDecodes)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittyFileBytes = { 0x89, 0x50, 0x4E, 0x47 }; // arbitrary non-empty "PNG" bytes
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=5,f=100,t=f;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=5;OK\x1b\\");
+        VERIFY_IS_TRUE(_testGetSet->_decodeImageCallCount > 0, L"f=100 from a file must use the host PNG decoder.");
+        const auto& buffer = *_testGetSet->_textBuffer;
+        til::CoordType imageRow = -1;
+        const auto slice = FindFirstImageSlice(buffer, imageRow);
+        VERIFY_IS_NOT_NULL(slice, L"the decoded PNG should be placed.");
+        VERIFY_IS_TRUE(SliceContainsColor(slice, 0, 0, 255), L"the mock decoder returns a blue image.");
+    }
+
+    // O=/S= are 64-bit: a real >4 GiB size is preserved end-to-end, not truncated to
+    // 32 bits. The adapter never allocates from S (the host caps the actual read at
+    // 32 MiB), so the transfer still succeeds; only the value forwarded changes.
+    TEST_METHOD(KittyGraphicsFileTransmitLargeSizePassesThrough64Bit)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittyFileBytes = { 255, 0, 0 };
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=6,f=24,s=1,v=1,t=f,S=9999999999;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=6;OK\x1b\\");
+        VERIFY_ARE_EQUAL(static_cast<uint64_t>(9999999999ull), _testGetSet->_lastKittyFileSize, L"a >4 GiB S= must pass through as 64-bit, not truncate to 32 bits.");
+    }
+
+    // A digit run that overflows even 64 bits clamps to UINT64_MAX rather than wrapping;
+    // the host rejects such an offset (past EOF) so it fails cleanly, never wraps to a
+    // small in-range value.
+    TEST_METHOD(KittyGraphicsFileOffsetOverflowClampsTo64Max)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittyFileBytes = { 255, 0, 0 };
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=7,f=24,s=1,v=1,t=f,O=99999999999999999999999;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=7;OK\x1b\\");
+        VERIFY_ARE_EQUAL(UINT64_MAX, _testGetSet->_lastKittyFileOffset, L"an O= that overflows 64 bits must clamp to UINT64_MAX, not wrap.");
+    }
+
+    // An empty (or non-UTF-8) payload yields an empty path: the adapter reports EINVAL
+    // (a malformed request) WITHOUT ever calling the host (no filesystem access for a
+    // path it cannot form).
+    TEST_METHOD(KittyGraphicsFileTransmitEmptyPathIsEinval)
+    {
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=8,f=24,s=1,v=1,t=f;\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=8;EINVAL:invalid image file request\x1b\\");
+        VERIFY_ARE_EQUAL(0, _testGetSet->_readLocalFileCallCount, L"an empty path must not reach the host.");
+    }
+
+    // A payload that base64-decodes to invalid UTF-8 is rejected at conversion time
+    // (MB_ERR_INVALID_CHARS) -> empty path -> EINVAL, again without any host call.
+    TEST_METHOD(KittyGraphicsFileTransmitInvalidUtf8PathIsEinval)
+    {
+        _testGetSet->PrepData();
+        // "//79" is base64 of bytes {0xFF,0xFE,0xFD}, which is not valid UTF-8.
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=8,f=24,s=1,v=1,t=f;//79\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=8;EINVAL:invalid image file request\x1b\\");
+        VERIFY_ARE_EQUAL(0, _testGetSet->_readLocalFileCallCount, L"an invalid-UTF-8 path must not reach the host.");
+    }
+
+    // The file's contents are validated exactly like a direct payload: a raw size that
+    // does not match s=*v=*depth is EINVAL, after the (successful) host read.
+    TEST_METHOD(KittyGraphicsFileTransmitSizeMismatchIsEinval)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittyFileBytes = { 255, 0, 0 }; // 3 bytes, but s=2,v=2,f=24 needs 12
+        _stateMachine->ProcessString(L"\x1b_Ga=t,i=9,f=24,s=2,v=2,t=f;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=9;EINVAL:payload size mismatch\x1b\\");
+    }
+
+    // a=q over t=f validates the request (the host IS asked to read) but stores nothing,
+    // so a later put of that id is ENOENT.
+    TEST_METHOD(KittyGraphicsFileTransmitQueryValidatesWithoutStoring)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittyFileBytes = { 255, 0, 0 };
+        _stateMachine->ProcessString(L"\x1b_Ga=q,i=10,f=24,s=1,v=1,t=f;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=10;OK\x1b\\");
+        VERIFY_IS_TRUE(_testGetSet->_readLocalFileCallCount > 0, L"a=q must still validate by reading the file.");
+        // The query must not have registered an image.
+        _stateMachine->ProcessString(L"\x1b_Ga=p,i=10;\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=10;ENOENT:image not found\x1b\\");
+    }
+
+    // a=q over t=t must NOT request deletion: a query is not a real transmit, so the
+    // temporary file is left intact (only a=t/a=T of a t=t file deletes).
+    TEST_METHOD(KittyGraphicsTempFileQueryDoesNotDelete)
+    {
+        _testGetSet->PrepData();
+        _testGetSet->_kittyFileBytes = { 255, 0, 0 };
+        _stateMachine->ProcessString(L"\x1b_Ga=q,i=11,f=24,s=1,v=1,t=t;L3RtcC94\x1b\\");
+        _testGetSet->ValidateInputEvent(L"\x1b_Gi=11;OK\x1b\\");
+        VERIFY_IS_TRUE(_testGetSet->_readLocalFileCallCount > 0, L"a=q must still read the file to validate.");
+        VERIFY_IS_FALSE(_testGetSet->_lastKittyFileDeleteAfter, L"a=q,t=t must never request deletion.");
     }
 
     // Unknown deletion selectors are rejected.

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -521,6 +521,62 @@ private:
     HANDLE _hCon;
 };
 
+namespace
+{
+    // A Kitty graphics command paired with the exact acknowledgement it must produce.
+    // Whole families of these share one shape -- send the command, expect the ack -- so each
+    // family rides a single index-driven TEST_METHOD (see ArrayIndexTaefAdapterSource) instead
+    // of one near-identical method apiece.
+    struct KittyGraphicsCase
+    {
+        std::wstring_view name;
+        const wchar_t* input;
+        const wchar_t* expected;
+    };
+
+    // Malformed commands each report one specific error acknowledgement.
+    constexpr KittyGraphicsCase kittyErrorCases[] = {
+        { L"put unknown id", L"\x1b_Ga=p,i=50;\x1b\\", L"\x1b_Gi=50;ENOENT:image not found\x1b\\" },
+        { L"i and I together", L"\x1b_Ga=t,i=2,I=3;\x1b\\", L"\x1b_Gi=2;EINVAL:i and I are mutually exclusive\x1b\\" },
+        { L"unknown action", L"\x1b_Ga=z,i=4;\x1b\\", L"\x1b_Gi=4;EINVAL:unknown action\x1b\\" },
+        { L"payload size mismatch", L"\x1b_Ga=t,i=3,f=24,s=2,v=2;AQIDBA==\x1b\\", L"\x1b_Gi=3;EINVAL:payload size mismatch\x1b\\" },
+        { L"bad base64 length", L"\x1b_Ga=t,i=4,f=32,s=1,v=1;AAA\x1b\\", L"\x1b_Gi=4;EINVAL:bad payload\x1b\\" },
+        { L"invalid base64 char", L"\x1b_Ga=t,i=7,f=100;A@==\x1b\\", L"\x1b_Gi=7;EINVAL:bad payload\x1b\\" },
+        { L"non-ascii payload", L"\x1b_Ga=t,i=8,f=100;\u00FF\u00FF\u00FF\u00FF\x1b\\", L"\x1b_Gi=8;EINVAL:bad payload\x1b\\" },
+        { L"query invalid payload", L"\x1b_Ga=q,i=5,f=100;AAA\x1b\\", L"\x1b_Gi=5;EINVAL:bad payload\x1b\\" },
+        { L"unsupported format", L"\x1b_Ga=t,i=6,f=99;\x1b\\", L"\x1b_Gi=6;EINVAL:unsupported format\x1b\\" },
+        { L"unsupported compression", L"\x1b_Ga=t,i=7,o=x;\x1b\\", L"\x1b_Gi=7;EINVAL:unsupported compression\x1b\\" },
+        { L"overflow dimensions", L"\x1b_Ga=t,i=14,f=32,s=2147483648,v=2147483648;AQIDBA==\x1b\\", L"\x1b_Gi=14;EINVAL:payload size mismatch\x1b\\" },
+        { L"semicolon in payload", L"\x1b_Ga=t,i=1,f=100;AAAA;BBBB\x1b\\", L"\x1b_Gi=1;EINVAL:bad payload\x1b\\" },
+        { L"missing dimensions", L"\x1b_Ga=t,i=1,f=24;AAAA\x1b\\", L"\x1b_Gi=1;EINVAL:missing dimensions\x1b\\" },
+        { L"unsupported medium", L"\x1b_Ga=t,i=1,f=24,s=1,v=1,t=x;AAAA\x1b\\", L"\x1b_Gi=1;EINVAL:unsupported transmission medium\x1b\\" },
+        { L"malformed o=z stream", L"\x1b_Ga=T,i=1,f=100,o=z;iVBORw0K\x1b\\", L"\x1b_Gi=1;EINVAL:invalid compressed data\x1b\\" },
+        { L"unsupported delete target", L"\x1b_Ga=d,d=b,i=5;\x1b\\", L"\x1b_Gi=5;EINVAL:unsupported delete target\x1b\\" },
+        { L"delete by id needs i", L"\x1b_Ga=d,d=i;\x1b\\", L"\x1b_G;EINVAL:delete by id requires i\x1b\\" },
+    };
+
+    // Well-formed (or gracefully tolerated) requests each echo the expected OK acknowledgement.
+    constexpr KittyGraphicsCase kittyAcceptedCases[] = {
+        { L"explicit id echoed", L"\x1b_Gi=1,a=t,f=24,s=1,v=1;AAAA\x1b\\", L"\x1b_Gi=1;OK\x1b\\" },
+        { L"large id echoed", L"\x1b_Ga=t,i=42,f=24,s=1,v=1;AAAA\x1b\\", L"\x1b_Gi=42;OK\x1b\\" },
+        { L"number assigns id", L"\x1b_GI=7,a=t,f=24,s=1,v=1;AAAA\x1b\\", L"\x1b_Gi=1,I=7;OK\x1b\\" },
+        { L"query validates ok", L"\x1b_Ga=q,i=99,f=24,s=1,v=1;AAAA\x1b\\", L"\x1b_Gi=99;OK\x1b\\" },
+        { L"rgb payload size matches", L"\x1b_Ga=t,i=2,f=24,s=2,v=2;AAAAAAAAAAAAAAAA\x1b\\", L"\x1b_Gi=2;OK\x1b\\" },
+        { L"rgba payload size matches", L"\x1b_Ga=t,i=1,f=32,s=1,v=1;AQIDBA==\x1b\\", L"\x1b_Gi=1;OK\x1b\\" },
+        { L"multi-char keys ignored", L"\x1b_Ga=t,ab=5,zz,i=1,f=24,s=1,v=1;AAAA\x1b\\", L"\x1b_Gi=1;OK\x1b\\" },
+    };
+}
+
+extern "C" HRESULT __declspec(dllexport) __cdecl KittyGraphicsErrorDataSource(IDataSource** ppDataSource, void*)
+{
+    return Microsoft::WRL::MakeAndInitialize<ArrayIndexTaefAdapterSource>(ppDataSource, std::size(kittyErrorCases));
+}
+
+extern "C" HRESULT __declspec(dllexport) __cdecl KittyGraphicsAcceptedDataSource(IDataSource** ppDataSource, void*)
+{
+    return Microsoft::WRL::MakeAndInitialize<ArrayIndexTaefAdapterSource>(ppDataSource, std::size(kittyAcceptedCases));
+}
+
 class AdapterTest
 {
 public:
@@ -4689,30 +4745,6 @@ public:
         VERIFY_IS_TRUE(BufferContainsColor(buffer, 0, 0, 255), L"Bare #1 must select the blue register.");
     }
 
-    // Kitty graphics transmit (a=t) with an explicit id registers the image and echoes its id.
-    TEST_METHOD(KittyGraphicsApcAcknowledged)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Gi=1,a=t,f=24,s=1,v=1;AAAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;OK\x1b\\");
-    }
-
-    // A larger image id is parsed and echoed (as decimal) in the acknowledgement.
-    TEST_METHOD(KittyGraphicsEchoesImageId)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=42,f=24,s=1,v=1;AAAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=42;OK\x1b\\");
-    }
-
-    // Transmitting by image number (I=) auto-assigns an id, echoed alongside the number.
-    TEST_METHOD(KittyGraphicsTransmitByNumberAssignsId)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_GI=7,a=t,f=24,s=1,v=1;AAAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1,I=7;OK\x1b\\");
-    }
-
     // An anonymous transmit (no id and no number) succeeds silently (no response).
     TEST_METHOD(KittyGraphicsAnonymousTransmitIsSilent)
     {
@@ -4729,20 +4761,42 @@ public:
         VERIFY_IS_TRUE(_testGetSet->_response.empty(), L"q=1 should suppress the success acknowledgement.");
     }
 
-    // A query (a=q) validates the request and reports OK without checking presence.
-    TEST_METHOD(KittyGraphicsQueryValidatesOk)
+    // Malformed Kitty graphics commands each report a specific error acknowledgement.
+    // One index-driven method walks the file-scope kittyErrorCases table (exported through
+    // KittyGraphicsErrorDataSource) so a new rejection is a table row, not another method.
+    TEST_METHOD(KittyGraphicsProtocolErrors)
     {
+        BEGIN_TEST_METHOD_PROPERTIES()
+            TEST_METHOD_PROPERTY(L"DataSource", L"Export:KittyGraphicsErrorDataSource")
+        END_TEST_METHOD_PROPERTIES()
+
+        size_t i{};
+        TestData::TryGetValue(L"index", i);
+        const auto& tc = kittyErrorCases[i];
+        Log::Comment(NoThrowString().Format(L"[%zu] %.*s", i, static_cast<int>(tc.name.size()), tc.name.data()));
+
         _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=q,i=99,f=24,s=1,v=1;AAAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=99;OK\x1b\\");
+        _stateMachine->ProcessString(tc.input);
+        _testGetSet->ValidateInputEvent(tc.expected);
     }
 
-    // Putting (a=p) an image that was never transmitted reports ENOENT.
-    TEST_METHOD(KittyGraphicsPutUnknownIsEnoent)
+    // Well-formed or gracefully tolerated requests each echo the expected OK acknowledgement.
+    // Same shape as the error table above -- one index-driven method walks the file-scope
+    // kittyAcceptedCases table (exported through KittyGraphicsAcceptedDataSource).
+    TEST_METHOD(KittyGraphicsAccepted)
     {
+        BEGIN_TEST_METHOD_PROPERTIES()
+            TEST_METHOD_PROPERTY(L"DataSource", L"Export:KittyGraphicsAcceptedDataSource")
+        END_TEST_METHOD_PROPERTIES()
+
+        size_t i{};
+        TestData::TryGetValue(L"index", i);
+        const auto& tc = kittyAcceptedCases[i];
+        Log::Comment(NoThrowString().Format(L"[%zu] %.*s", i, static_cast<int>(tc.name.size()), tc.name.data()));
+
         _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=p,i=50;\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=50;ENOENT:image not found\x1b\\");
+        _stateMachine->ProcessString(tc.input);
+        _testGetSet->ValidateInputEvent(tc.expected);
     }
 
     // After transmitting an image, putting it reports OK (found).
@@ -5003,22 +5057,6 @@ public:
         VERIFY_ARE_EQUAL(static_cast<size_t>(0), _kitty()._images.count(9));
     }
 
-    // Specifying both an id and a number is invalid (EINVAL).
-    TEST_METHOD(KittyGraphicsIdAndNumberIsEinval)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=2,I=3;\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=2;EINVAL:i and I are mutually exclusive\x1b\\");
-    }
-
-    // An unrecognized action reports EINVAL.
-    TEST_METHOD(KittyGraphicsUnknownActionIsEinval)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=z,i=4;\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=4;EINVAL:unknown action\x1b\\");
-    }
-
     // q=1 does not suppress error responses (only successes).
     TEST_METHOD(KittyGraphicsQuietOneKeepsErrors)
     {
@@ -5041,42 +5079,6 @@ public:
         _testGetSet->PrepData();
         _stateMachine->ProcessString(L"\x1b_Gi=1,a=t\x18");
         VERIFY_IS_TRUE(_testGetSet->_response.empty(), L"CAN should abort the APC without an acknowledgement.");
-    }
-
-    // An RGB (f=24) transmit whose base64 payload matches s*v*3 bytes is accepted.
-    TEST_METHOD(KittyGraphicsRgbPayloadSizeMatches)
-    {
-        _testGetSet->PrepData();
-        // "AAAAAAAAAAAAAAAA" decodes to 12 zero bytes == 2*2*3.
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=2,f=24,s=2,v=2;AAAAAAAAAAAAAAAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=2;OK\x1b\\");
-    }
-
-    // An RGBA (f=32) transmit whose base64 payload matches s*v*4 bytes is accepted.
-    TEST_METHOD(KittyGraphicsRgbaPayloadSizeMatches)
-    {
-        _testGetSet->PrepData();
-        // "AQIDBA==" decodes to 4 bytes == 1*1*4.
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=32,s=1,v=1;AQIDBA==\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;OK\x1b\\");
-    }
-
-    // A direct-pixel transmit whose payload size does not match the dimensions is EINVAL.
-    TEST_METHOD(KittyGraphicsPayloadSizeMismatchIsEinval)
-    {
-        _testGetSet->PrepData();
-        // 4 decoded bytes != 2*2*3 = 12.
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=3,f=24,s=2,v=2;AQIDBA==\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=3;EINVAL:payload size mismatch\x1b\\");
-    }
-
-    // A transmit with a malformed base64 payload is EINVAL.
-    TEST_METHOD(KittyGraphicsBadBase64IsEinval)
-    {
-        _testGetSet->PrepData();
-        // "AAA" is not a multiple of four base64 characters.
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=4,f=32,s=1,v=1;AAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=4;EINVAL:bad payload\x1b\\");
     }
 
     // A PNG (f=100) transmit skips the direct-pixel size check (only base64 is validated).
@@ -5434,17 +5436,6 @@ public:
         VERIFY_ARE_EQUAL(0, _testGetSet->_decodeImageCallCount);
     }
 
-    // A malformed o=z payload (not a valid zlib stream) is rejected. f=100 + o=z now
-    // reaches the inflate step, and "iVBORw0K" decodes to a PNG signature, not a zlib
-    // stream, so the RFC 1950 header check fails.
-    // kitty spec (compression): https://sw.kovidgoyal.net/kitty/graphics-protocol/#compression
-    TEST_METHOD(KittyGraphicsZlibMalformedIsEinval)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=100,o=z;iVBORw0K\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;EINVAL:invalid compressed data\x1b\\");
-    }
-
     // PNG transmit-by-number assigns a fresh id and displays the decoded image.
     TEST_METHOD(KittyGraphicsPngTransmitByNumberDisplays)
     {
@@ -5493,23 +5484,6 @@ public:
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_ARE_EQUAL((til::size{ 5, 10 }), slice->CellSize()); // host cell, not {10,20}
         VERIFY_ARE_EQUAL(5, slice->PixelWidth()); // 1 cell * 5px
-    }
-
-    // A base64 payload containing a character outside the alphabet is EINVAL.
-    TEST_METHOD(KittyGraphicsInvalidBase64CharIsEinval)
-    {
-        _testGetSet->PrepData();
-        // '@' is not part of the base64 alphabet.
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=7,f=100;A@==\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=7;EINVAL:bad payload\x1b\\");
-    }
-
-    // A non-ASCII byte in the payload (invalid for base64) is EINVAL.
-    TEST_METHOD(KittyGraphicsNonAsciiPayloadIsEinval)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=8,f=100;\u00FF\u00FF\u00FF\u00FF\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=8;EINVAL:bad payload\x1b\\");
     }
 
     // Each transmit by image number assigns a fresh id; the number tracks the newest.
@@ -5601,30 +5575,6 @@ public:
             VERIFY_ARE_EQUAL(static_cast<int>(expected[i][2]), static_cast<int>(it->second.pixels[i].rgbBlue));
             VERIFY_ARE_EQUAL(255, static_cast<int>(it->second.pixels[i].rgbReserved));
         }
-    }
-
-    // A query (a=q) validates the payload like a transmit; malformed base64 is EINVAL.
-    TEST_METHOD(KittyGraphicsQueryInvalidPayloadIsEinval)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=q,i=5,f=100;AAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=5;EINVAL:bad payload\x1b\\");
-    }
-
-    // An unsupported pixel format is EINVAL.
-    TEST_METHOD(KittyGraphicsUnsupportedFormatIsEinval)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=6,f=99;\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=6;EINVAL:unsupported format\x1b\\");
-    }
-
-    // An unsupported compression value is EINVAL.
-    TEST_METHOD(KittyGraphicsUnsupportedCompressionIsEinval)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=7,o=x;\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=7;EINVAL:unsupported compression\x1b\\");
     }
 
     // --- o=z (zlib) inflate: direct unit tests of KittyParser::_inflateZlib. ---
@@ -5917,31 +5867,6 @@ public:
         }
     }
 
-    // Hostile dimensions cannot overflow the size check; they report a mismatch.
-    TEST_METHOD(KittyGraphicsOverflowDimsIsMismatch)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=14,f=32,s=2147483648,v=2147483648;AQIDBA==\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=14;EINVAL:payload size mismatch\x1b\\");
-    }
-
-    // Multi-character keys and tokens without '=' are ignored.
-    TEST_METHOD(KittyGraphicsMultiCharKeyIgnored)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,ab=5,zz,i=1,f=24,s=1,v=1;AAAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;OK\x1b\\");
-    }
-
-    // Only the first ';' separates control from payload; a later ';' is part of the
-    // (now invalid) payload rather than being silently stripped.
-    TEST_METHOD(KittyGraphicsSemicolonInPayloadIsBad)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=100;AAAA;BBBB\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;EINVAL:bad payload\x1b\\");
-    }
-
     // The registry is bounded; transmitting past MaxImages evicts the oldest.
     TEST_METHOD(KittyGraphicsRegistryEvictsOldest)
     {
@@ -5973,23 +5898,6 @@ public:
         _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;OK\x1b\\"); // survived
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=2;\x1b\\");
         _testGetSet->ValidateInputEvent(L"\x1b_Gi=2;ENOENT:image not found\x1b\\"); // evicted
-    }
-
-    // A raw (f=24/32) transmit without dimensions is rejected, not stored empty.
-    TEST_METHOD(KittyGraphicsMissingDimensionsIsEinval)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24;AAAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;EINVAL:missing dimensions\x1b\\");
-    }
-
-    // Direct (t=d), file (t=f), temporary-file (t=t), and shared-memory (t=s)
-    // media are supported; any other medium is rejected.
-    TEST_METHOD(KittyGraphicsUnsupportedMediumIsEinval)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=1,f=24,s=1,v=1,t=x;AAAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1;EINVAL:unsupported transmission medium\x1b\\");
     }
 
     // Shared-memory transmission decodes the mapping name, forwards O=/S= to the
@@ -6213,14 +6121,6 @@ public:
         VERIFY_IS_FALSE(_testGetSet->_lastKittyFileDeleteAfter, L"a=q,t=t must never request deletion.");
     }
 
-    // Unknown deletion selectors are rejected.
-    TEST_METHOD(KittyGraphicsDeleteUnsupportedTargetIsEinval)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=d,d=b,i=5;\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=5;EINVAL:unsupported delete target\x1b\\");
-    }
-
     // d=r deletes every image whose id is in the inclusive range [x, y]; ids outside survive.
     TEST_METHOD(KittyGraphicsDeleteByIdRange)
     {
@@ -6322,14 +6222,6 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=y,y=6;\x1b\\"); // protocol row 6 -> buffer row 25
         VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"the image on viewport row 6 must be deleted");
         VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0), L"the image on row 27 must survive");
-    }
-
-    // Delete-by-id (d=i) without an id is rejected.
-    TEST_METHOD(KittyGraphicsDeleteByIdRequiresId)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=d,d=i;\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_G;EINVAL:delete by id requires i\x1b\\");
     }
 
     // With C=1 the cursor stays put after a placement, but the image still renders.
@@ -6495,21 +6387,6 @@ public:
         _stateMachine->ProcessString(L"\x1b_Gm=0;AAAA\x1b\\");
         _testGetSet->ValidateInputEvent(L"\x1b_Gi=92;OK\x1b\\");
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._images.count(92), L"A normal chunked transfer must still work.");
-    }
-
-    // Deleting an image erases its on-screen pixels (id-tagged slice clear),
-    // and deleting one image preserves another's.
-    TEST_METHOD(KittyDeleteOnePreservesOtherOnSameRow)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,c=1,r=1,C=1;/wAA\x1b\\"); // red, C=1 don't move cursor
-        _stateMachine->ProcessString(L"\x1b[2C"); // move cursor right
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,f=24,s=1,v=1,c=1,r=1,C=1;AP8A\x1b\\"); // green, C=1 don't move cursor
-        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0));
-        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0));
-        _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1;\x1b\\");
-        VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"deleted image must be erased");
-        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0), L"other image must survive");
     }
 
     // Delete-by-id must erase the image's on-screen PIXELS, not just drop the registry entry --
@@ -7531,16 +7408,31 @@ public:
 
     // Delete-by-id is targeted: removing image 1 must erase only its pixels and leave a
     // co-resident image (2) intact -- guards per-image cell ownership, not a blanket clear.
+    // Both layouts are covered: images on different rows (per-row ownership) and images
+    // sharing one row (per-column ownership), which fail differently if ownership leaks.
     TEST_METHOD(KittyGraphicsDeleteOnePreservesOther)
     {
+        // Different rows: the default cursor advance drops image 2 onto a later row.
         _testGetSet->PrepData();
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1;/wAA\x1b\\"); // red
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,f=24,s=1,v=1;AP8A\x1b\\"); // green
         VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0));
         VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0));
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1;\x1b\\");
-        VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"deleted image must be erased");
-        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0), L"other image must survive");
+        VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"deleted image must be erased (different rows)");
+        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0), L"other image must survive (different rows)");
+
+        // Same row: C=1 pins the cursor so both placements land on one row; deleting one
+        // must spare the other's columns -- per-column ownership, not a per-row clear.
+        _testGetSet->PrepData();
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,c=1,r=1,C=1;/wAA\x1b\\"); // red, C=1 don't move cursor
+        _stateMachine->ProcessString(L"\x1b[2C"); // move cursor right, staying on the same row
+        _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,f=24,s=1,v=1,c=1,r=1,C=1;AP8A\x1b\\"); // green, C=1 don't move cursor
+        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0));
+        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0));
+        _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1;\x1b\\");
+        VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"deleted image must be erased (same row)");
+        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0), L"other image must survive (same row)");
     }
 
     // delete-all (a=d,d=a) must erase Kitty placements but leave co-resident Sixel

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -553,6 +553,9 @@ namespace
         { L"malformed o=z stream", L"\x1b_Ga=T,i=1,f=100,o=z;iVBORw0K\x1b\\", L"\x1b_Gi=1;EINVAL:invalid compressed data\x1b\\" },
         { L"unsupported delete target", L"\x1b_Ga=d,d=b,i=5;\x1b\\", L"\x1b_Gi=5;EINVAL:unsupported delete target\x1b\\" },
         { L"delete by id needs i", L"\x1b_Ga=d,d=i;\x1b\\", L"\x1b_G;EINVAL:delete by id requires i\x1b\\" },
+        { L"q=1 does not suppress error", L"\x1b_Ga=p,i=77,q=1;\x1b\\", L"\x1b_Gi=77;ENOENT:image not found\x1b\\" },
+        { L"relative missing parent", L"\x1b_Ga=T,i=2,p=1,P=99,Q=1,H=0,V=0,f=24,s=1,v=1;/wAA\x1b\\", L"\x1b_Gi=2,p=1;ENOPARENT:relative parent not found\x1b\\" },
+        { L"virtual cannot be relative", L"\x1b_Ga=T,i=1,p=1,U=1,P=2,Q=1,f=24,s=1,v=1;/wAA\x1b\\", L"\x1b_Gi=1,p=1;EINVAL:virtual placements cannot be relative\x1b\\" },
     };
 
     // Well-formed (or gracefully tolerated) requests each echo the expected OK acknowledgement.
@@ -564,6 +567,33 @@ namespace
         { L"rgb payload size matches", L"\x1b_Ga=t,i=2,f=24,s=2,v=2;AAAAAAAAAAAAAAAA\x1b\\", L"\x1b_Gi=2;OK\x1b\\" },
         { L"rgba payload size matches", L"\x1b_Ga=t,i=1,f=32,s=1,v=1;AQIDBA==\x1b\\", L"\x1b_Gi=1;OK\x1b\\" },
         { L"multi-char keys ignored", L"\x1b_Ga=t,ab=5,zz,i=1,f=24,s=1,v=1;AAAA\x1b\\", L"\x1b_Gi=1;OK\x1b\\" },
+        { L"PNG f=100 skips raw size check", L"\x1b_Ga=t,i=5,f=100,s=1,v=1;AQIDBA==\x1b\\", L"\x1b_Gi=5;OK\x1b\\" },
+        { L"overflow id clamped to uint32 max", L"\x1b_Ga=t,i=99999999999999999999,f=24,s=1,v=1;AAAA\x1b\\", L"\x1b_Gi=4294967295;OK\x1b\\" },
+        { L"single-pad base64 accepted", L"\x1b_Ga=t,i=12,f=32,s=2,v=1;AAAAAAAAAAA=\x1b\\", L"\x1b_Gi=12;OK\x1b\\" },
+    };
+
+    // Malformed zlib (RFC 1950) streams that _inflateZlib must reject. Each row is the raw
+    // resource bytes; the shared shape -- feed the bytes, expect false -- rides one
+    // index-driven TEST_METHOD instead of one method apiece.
+    struct KittyInflateRejectCase
+    {
+        std::wstring_view name;
+        std::vector<uint8_t> bytes;
+    };
+
+    const std::vector<KittyInflateRejectCase> kittyInflateRejectCases = {
+        { L"raw deflate, no zlib wrapper", { 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00 } },
+        // c12 with the low byte of the trailing Adler-32 flipped (0x4f ^ 0xff == 0xb0).
+        { L"corrupt adler-32 trailer", { 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00, 0x01, 0x78, 0x00, 0xb0 } },
+        { L"header too short", { 0x78, 0xda, 0x00 } },
+        // CMF=0x78, FLG=0x00 -> (0x7800 % 31) != 0 -> FCHECK fails.
+        { L"bad FCHECK header", { 0x78, 0x00, 0x01, 0x00, 0x00, 0x00 } },
+        // c12 with an extra 0x00 spliced in before the 4-byte checksum.
+        { L"trailing garbage before adler", { 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00, 0x00, 0x01, 0x78, 0x00, 0x4f } },
+        { L"inflates to zero bytes", { 0x78, 0x9c, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01 } },
+        { L"six-byte empty deflate body", { 0x78, 0x9c, 0x00, 0x00, 0x00, 0x01 } },
+        { L"FDICT preset-dictionary header", { 0x78, 0xbb, 0x04, 0x09, 0x01, 0xa5, 0x63, 0x64, 0x62, 0x06, 0x00, 0x00, 0x0d, 0x00, 0x07 } },
+        { L"truncated deflate stream", { 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x01, 0x78, 0x00, 0x4f } },
     };
 }
 
@@ -575,6 +605,11 @@ extern "C" HRESULT __declspec(dllexport) __cdecl KittyGraphicsErrorDataSource(ID
 extern "C" HRESULT __declspec(dllexport) __cdecl KittyGraphicsAcceptedDataSource(IDataSource** ppDataSource, void*)
 {
     return Microsoft::WRL::MakeAndInitialize<ArrayIndexTaefAdapterSource>(ppDataSource, std::size(kittyAcceptedCases));
+}
+
+extern "C" HRESULT __declspec(dllexport) __cdecl KittyInflateRejectDataSource(IDataSource** ppDataSource, void*)
+{
+    return Microsoft::WRL::MakeAndInitialize<ArrayIndexTaefAdapterSource>(ppDataSource, kittyInflateRejectCases.size());
 }
 
 class AdapterTest
@@ -5057,14 +5092,6 @@ public:
         VERIFY_ARE_EQUAL(static_cast<size_t>(0), _kitty()._images.count(9));
     }
 
-    // q=1 does not suppress error responses (only successes).
-    TEST_METHOD(KittyGraphicsQuietOneKeepsErrors)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=p,i=77,q=1;\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=77;ENOENT:image not found\x1b\\");
-    }
-
     // q=2 suppresses error responses as well as successes.
     TEST_METHOD(KittyGraphicsQuietTwoSuppressesErrors)
     {
@@ -5079,14 +5106,6 @@ public:
         _testGetSet->PrepData();
         _stateMachine->ProcessString(L"\x1b_Gi=1,a=t\x18");
         VERIFY_IS_TRUE(_testGetSet->_response.empty(), L"CAN should abort the APC without an acknowledgement.");
-    }
-
-    // A PNG (f=100) transmit skips the direct-pixel size check (only base64 is validated).
-    TEST_METHOD(KittyGraphicsPngTransmitSkipsSizeCheck)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=5,f=100,s=1,v=1;AQIDBA==\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=5;OK\x1b\\");
     }
 
     // A chunked transmission (m=1 ... m=0) assembles the payload across sequences;
@@ -5532,23 +5551,6 @@ public:
         _testGetSet->ValidateInputEvent(L"\x9fGi=1;OK\x9c");
     }
 
-    // An out-of-range image id is clamped to the uint32 maximum.
-    TEST_METHOD(KittyGraphicsParseUintClamps)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=99999999999999999999,f=24,s=1,v=1;AAAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=4294967295;OK\x1b\\");
-    }
-
-    // A single-pad (one '=') base64 group decodes to a two-byte final group.
-    TEST_METHOD(KittyGraphicsSinglePadBase64)
-    {
-        _testGetSet->PrepData();
-        // "AAAAAAAAAAA=" decodes to 8 bytes == 2*1*4.
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=12,f=32,s=2,v=1;AAAAAAAAAAA=\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=12;OK\x1b\\");
-    }
-
     // o=z (zlib) transmit: a real zlib stream of a 2x2 f=24 image inflates to exactly
     // 12 bytes (s*v*3) and is accepted. The payload is base64(zlib.deflate([1..12])).
     // If the inflate produced the wrong length the f=24 size check would report a
@@ -5681,59 +5683,22 @@ public:
         VERIFY_ARE_EQUAL(expectedSize, out.size());
     }
 
-    // Raw DEFLATE (no RFC 1950 zlib header/trailer) is rejected: kitty o=z is
-    // zlib-wrapped, not raw deflate.
-    TEST_METHOD(KittyInflateZlibRejectsRawDeflate)
+    // Malformed zlib streams each reject cleanly. One index-driven method walks the
+    // file-scope kittyInflateRejectCases table (exported through KittyInflateRejectDataSource)
+    // so a new malformed edge is a table row, not another method.
+    TEST_METHOD(KittyInflateZlibRejectsMalformed)
     {
-        const std::vector<uint8_t> rawDef{ 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00 };
-        std::vector<uint8_t> out;
-        VERIFY_IS_FALSE(KittyParser::_inflateZlib(rawDef, out, 32 * 1024 * 1024));
-    }
+        BEGIN_TEST_METHOD_PROPERTIES()
+            TEST_METHOD_PROPERTY(L"DataSource", L"Export:KittyInflateRejectDataSource")
+        END_TEST_METHOD_PROPERTIES()
 
-    // A corrupted Adler-32 trailer is rejected (integrity check over the inflated data).
-    TEST_METHOD(KittyInflateZlibRejectsCorruptAdler)
-    {
-        std::vector<uint8_t> c12{ 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00, 0x01, 0x78, 0x00, 0x4f };
-        c12.back() ^= 0xff; // flip the low byte of the trailing Adler-32
-        std::vector<uint8_t> out;
-        VERIFY_IS_FALSE(KittyParser::_inflateZlib(c12, out, 32 * 1024 * 1024));
-    }
+        size_t i{};
+        TestData::TryGetValue(L"index", i);
+        const auto& tc = kittyInflateRejectCases[i];
+        Log::Comment(NoThrowString().Format(L"[%zu] %.*s", i, static_cast<int>(tc.name.size()), tc.name.data()));
 
-    // Too-short and bad-FCHECK headers are rejected before any inflate work.
-    TEST_METHOD(KittyInflateZlibRejectsBadHeader)
-    {
         std::vector<uint8_t> out;
-        const std::vector<uint8_t> tooShort{ 0x78, 0xda, 0x00 };
-        VERIFY_IS_FALSE(KittyParser::_inflateZlib(tooShort, out, 32 * 1024 * 1024));
-        // CMF=0x78, FLG=0x00 -> (0x7800 % 31) != 0 -> FCHECK fails.
-        const std::vector<uint8_t> badCheck{ 0x78, 0x00, 0x01, 0x00, 0x00, 0x00 };
-        VERIFY_IS_FALSE(KittyParser::_inflateZlib(badCheck, out, 32 * 1024 * 1024));
-    }
-
-    // Trailing bytes between the DEFLATE stream and the Adler-32 are rejected (the
-    // inflater must consume exactly the deflate body): this is c12 with an extra 0x00
-    // spliced in before the 4-byte checksum.
-    TEST_METHOD(KittyInflateZlibRejectsTrailingGarbageBeforeAdler)
-    {
-        const std::vector<uint8_t> garbage{ 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00, 0x00, 0x01, 0x78, 0x00, 0x4f };
-        std::vector<uint8_t> out;
-        VERIFY_IS_FALSE(KittyParser::_inflateZlib(garbage, out, 32 * 1024 * 1024));
-    }
-
-    // More malformed edges all reject cleanly: a stream that inflates to zero bytes, a
-    // 6-byte stream with an empty deflate body, an FDICT (preset-dictionary) header, and
-    // a truncated deflate stream.
-    TEST_METHOD(KittyInflateZlibRejectsMoreMalformedEdges)
-    {
-        std::vector<uint8_t> out;
-        const std::vector<uint8_t> emptyOut{ 0x78, 0x9c, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01 };
-        VERIFY_IS_FALSE(KittyParser::_inflateZlib(emptyOut, out, 32 * 1024 * 1024));
-        const std::vector<uint8_t> sixByte{ 0x78, 0x9c, 0x00, 0x00, 0x00, 0x01 };
-        VERIFY_IS_FALSE(KittyParser::_inflateZlib(sixByte, out, 32 * 1024 * 1024));
-        const std::vector<uint8_t> fdict{ 0x78, 0xbb, 0x04, 0x09, 0x01, 0xa5, 0x63, 0x64, 0x62, 0x06, 0x00, 0x00, 0x0d, 0x00, 0x07 };
-        VERIFY_IS_FALSE(KittyParser::_inflateZlib(fdict, out, 32 * 1024 * 1024));
-        const std::vector<uint8_t> truncated{ 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x01, 0x78, 0x00, 0x4f };
-        VERIFY_IS_FALSE(KittyParser::_inflateZlib(truncated, out, 32 * 1024 * 1024));
+        VERIFY_IS_FALSE(KittyParser::_inflateZlib(tc.bytes, out, 32 * 1024 * 1024));
     }
 
     // o=z over a chunked (m=1) transmission: the inflate must run on the REASSEMBLED
@@ -5776,45 +5741,47 @@ public:
         VERIFY_IS_TRUE(_testGetSet->_lastKittyFileDeleteAfter, L"t=t must request deletion.");
     }
 
-    // o=z also composes with shared memory: S= describes the compressed resource size,
-    // then format validation runs on the inflated bytes.
+    // o=z also composes with shared memory: format validation runs on the inflated bytes.
+    // With S= the adapter is told the compressed resource size; with S omitted it must
+    // locate the complete zlib stream inside the mapping's page-rounded zero tail itself.
     TEST_METHOD(KittyGraphicsZlibSharedMemoryInflates)
     {
         const std::vector<uint8_t> c12{ 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00, 0x01, 0x78, 0x00, 0x4f };
 
-        _testGetSet->PrepData();
-        _testGetSet->_kittySharedMemoryBytes = c12;
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=18,f=24,s=2,v=2,t=s,S=20,o=z;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=18;OK\x1b\\");
-        VERIFY_ARE_EQUAL(1, _testGetSet->_readSharedMemoryCallCount);
-        VERIFY_ARE_EQUAL(static_cast<uint64_t>(c12.size()), _testGetSet->_lastKittySharedMemorySize);
+        // S=20 describes the compressed resource size.
+        {
+            _testGetSet->PrepData();
+            _testGetSet->_kittySharedMemoryBytes = c12;
+            _stateMachine->ProcessString(L"\x1b_Ga=t,i=18,f=24,s=2,v=2,t=s,S=20,o=z;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
+            _testGetSet->ValidateInputEvent(L"\x1b_Gi=18;OK\x1b\\");
+            VERIFY_ARE_EQUAL(1, _testGetSet->_readSharedMemoryCallCount);
+            VERIFY_ARE_EQUAL(static_cast<uint64_t>(c12.size()), _testGetSet->_lastKittySharedMemorySize);
 
-        const auto it = _kitty()._images.find(18);
-        VERIFY_IS_TRUE(it != _kitty()._images.end());
-        VERIFY_ARE_EQUAL(static_cast<size_t>(4), it->second.pixels.size());
-        VERIFY_ARE_EQUAL(1, static_cast<int>(it->second.pixels[0].rgbRed));
-        VERIFY_ARE_EQUAL(12, static_cast<int>(it->second.pixels[3].rgbBlue));
-    }
+            const auto it = _kitty()._images.find(18);
+            VERIFY_IS_TRUE(it != _kitty()._images.end());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(4), it->second.pixels.size());
+            VERIFY_ARE_EQUAL(1, static_cast<int>(it->second.pixels[0].rgbRed));
+            VERIFY_ARE_EQUAL(12, static_cast<int>(it->second.pixels[3].rgbBlue));
+        }
 
-    // With S omitted, Windows exposes the mapping's page-rounded zero tail. Locate the
-    // complete zlib stream, verify its Adler-32, and ignore only that zero padding.
-    TEST_METHOD(KittyGraphicsZlibSharedMemoryWithoutSizeInflates)
-    {
-        const std::vector<uint8_t> c12{ 0x78, 0xda, 0x63, 0x64, 0x62, 0x66, 0x61, 0x65, 0x63, 0xe7, 0xe0, 0xe4, 0xe2, 0xe6, 0x01, 0x00, 0x01, 0x78, 0x00, 0x4f };
+        // With S omitted, Windows exposes the mapping's page-rounded zero tail. Locate the
+        // complete zlib stream, verify its Adler-32, and ignore only that zero padding.
+        {
+            _testGetSet->PrepData();
+            _testGetSet->_readSharedMemoryCallCount = 0; // count this block's read alone
+            _testGetSet->_kittySharedMemoryBytes = c12;
+            _testGetSet->_kittySharedMemoryBytes.resize(4096);
+            _stateMachine->ProcessString(L"\x1b_Ga=t,i=19,f=24,s=2,v=2,t=s,o=z;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
+            _testGetSet->ValidateInputEvent(L"\x1b_Gi=19;OK\x1b\\");
+            VERIFY_ARE_EQUAL(1, _testGetSet->_readSharedMemoryCallCount);
+            VERIFY_ARE_EQUAL(static_cast<uint64_t>(0), _testGetSet->_lastKittySharedMemorySize);
 
-        _testGetSet->PrepData();
-        _testGetSet->_kittySharedMemoryBytes = c12;
-        _testGetSet->_kittySharedMemoryBytes.resize(4096);
-        _stateMachine->ProcessString(L"\x1b_Ga=t,i=19,f=24,s=2,v=2,t=s,o=z;TG9jYWxca2l0dHktc2htLXRlc3Q=\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=19;OK\x1b\\");
-        VERIFY_ARE_EQUAL(1, _testGetSet->_readSharedMemoryCallCount);
-        VERIFY_ARE_EQUAL(static_cast<uint64_t>(0), _testGetSet->_lastKittySharedMemorySize);
-
-        const auto it = _kitty()._images.find(19);
-        VERIFY_IS_TRUE(it != _kitty()._images.end());
-        VERIFY_ARE_EQUAL(static_cast<size_t>(4), it->second.pixels.size());
-        VERIFY_ARE_EQUAL(1, static_cast<int>(it->second.pixels[0].rgbRed));
-        VERIFY_ARE_EQUAL(12, static_cast<int>(it->second.pixels[3].rgbBlue));
+            const auto it = _kitty()._images.find(19);
+            VERIFY_IS_TRUE(it != _kitty()._images.end());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(4), it->second.pixels.size());
+            VERIFY_ARE_EQUAL(1, static_cast<int>(it->second.pixels[0].rgbRed));
+            VERIFY_ARE_EQUAL(12, static_cast<int>(it->second.pixels[3].rgbBlue));
+        }
     }
 
     TEST_METHOD(KittyGraphicsZlibSharedMemoryRejectsNonzeroTrailingData)
@@ -6063,23 +6030,19 @@ public:
         VERIFY_ARE_EQUAL(UINT64_MAX, _testGetSet->_lastKittyFileOffset, L"an O= that overflows 64 bits must clamp to UINT64_MAX, not wrap.");
     }
 
-    // An empty (or non-UTF-8) payload yields an empty path: the adapter reports EINVAL
-    // (a malformed request) WITHOUT ever calling the host (no filesystem access for a
-    // path it cannot form).
-    TEST_METHOD(KittyGraphicsFileTransmitEmptyPathIsEinval)
+    // A path the adapter cannot form -- an empty payload, or base64 that decodes to
+    // invalid UTF-8 -- is a malformed request: EINVAL, and the host is never asked to
+    // read a file it could not name.
+    TEST_METHOD(KittyGraphicsFileTransmitUnreadablePathIsEinval)
     {
+        // An empty payload yields an empty path.
         _testGetSet->PrepData();
         _stateMachine->ProcessString(L"\x1b_Ga=t,i=8,f=24,s=1,v=1,t=f;\x1b\\");
         _testGetSet->ValidateInputEvent(L"\x1b_Gi=8;EINVAL:invalid image file request\x1b\\");
         VERIFY_ARE_EQUAL(0, _testGetSet->_readLocalFileCallCount, L"an empty path must not reach the host.");
-    }
 
-    // A payload that base64-decodes to invalid UTF-8 is rejected at conversion time
-    // (MB_ERR_INVALID_CHARS) -> empty path -> EINVAL, again without any host call.
-    TEST_METHOD(KittyGraphicsFileTransmitInvalidUtf8PathIsEinval)
-    {
+        // "//79" is base64 of bytes {0xFF,0xFE,0xFD} -> MB_ERR_INVALID_CHARS -> empty path.
         _testGetSet->PrepData();
-        // "//79" is base64 of bytes {0xFF,0xFE,0xFD}, which is not valid UTF-8.
         _stateMachine->ProcessString(L"\x1b_Ga=t,i=8,f=24,s=1,v=1,t=f;//79\x1b\\");
         _testGetSet->ValidateInputEvent(L"\x1b_Gi=8;EINVAL:invalid image file request\x1b\\");
         VERIFY_ARE_EQUAL(0, _testGetSet->_readLocalFileCallCount, L"an invalid-UTF-8 path must not reach the host.");
@@ -6194,34 +6157,36 @@ public:
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._images.count(1));
     }
 
-    // d=x deletes placements intersecting column x (1-based) within the viewport; an image in
-    // another column survives. Images sit at buffer row 25 (inside the top=20 viewport).
-    TEST_METHOD(KittyGraphicsDeleteByColumn)
+    // Positional deletion selects by viewport geometry: d=x deletes placements intersecting
+    // column x (1-based) and d=y deletes those intersecting row y (1-based, viewport-relative).
+    // In each case an image elsewhere survives. Images sit inside the top=20 viewport.
+    TEST_METHOD(KittyGraphicsDeleteByColumnOrRow)
     {
-        _testGetSet->PrepData();
-        _testGetSet->_cellSize = { 1, 1 };
-        _testGetSet->_textBuffer->GetCursor().SetPosition({ 0, 25 });
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\"); // red at col 0
-        _testGetSet->_textBuffer->GetCursor().SetPosition({ 3, 25 });
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,f=24,s=1,v=1,C=1;AP8A\x1b\\"); // green at col 3
-        _stateMachine->ProcessString(L"\x1b_Ga=d,d=x,x=1;\x1b\\"); // column 1 (1-based) = col 0
-        VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"the image in column 0 must be deleted");
-        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0), L"the image in column 3 must survive");
-    }
+        // d=x,x=1 deletes column 0 (1-based col 1); an image in another column survives.
+        {
+            _testGetSet->PrepData();
+            _testGetSet->_cellSize = { 1, 1 };
+            _testGetSet->_textBuffer->GetCursor().SetPosition({ 0, 25 });
+            _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\"); // red at col 0
+            _testGetSet->_textBuffer->GetCursor().SetPosition({ 3, 25 });
+            _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,f=24,s=1,v=1,C=1;AP8A\x1b\\"); // green at col 3
+            _stateMachine->ProcessString(L"\x1b_Ga=d,d=x,x=1;\x1b\\"); // column 1 (1-based) = col 0
+            VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"the image in column 0 must be deleted");
+            VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0), L"the image in column 3 must survive");
+        }
 
-    // d=y deletes placements intersecting row y (1-based, VIEWPORT-relative); an image on another
-    // row survives. Viewport top is 20, so protocol y=6 -> buffer row 25.
-    TEST_METHOD(KittyGraphicsDeleteByRow)
-    {
-        _testGetSet->PrepData();
-        _testGetSet->_cellSize = { 1, 1 };
-        _testGetSet->_textBuffer->GetCursor().SetPosition({ 0, 25 });
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\"); // red on buffer row 25 (viewport row 6)
-        _testGetSet->_textBuffer->GetCursor().SetPosition({ 0, 27 });
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,f=24,s=1,v=1,C=1;AP8A\x1b\\"); // green on buffer row 27
-        _stateMachine->ProcessString(L"\x1b_Ga=d,d=y,y=6;\x1b\\"); // protocol row 6 -> buffer row 25
-        VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"the image on viewport row 6 must be deleted");
-        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0), L"the image on row 27 must survive");
+        // d=y,y=6 deletes viewport row 6 (buffer row 25); an image on another row survives.
+        {
+            _testGetSet->PrepData();
+            _testGetSet->_cellSize = { 1, 1 };
+            _testGetSet->_textBuffer->GetCursor().SetPosition({ 0, 25 });
+            _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\"); // red on buffer row 25 (viewport row 6)
+            _testGetSet->_textBuffer->GetCursor().SetPosition({ 0, 27 });
+            _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,f=24,s=1,v=1,C=1;AP8A\x1b\\"); // green on buffer row 27
+            _stateMachine->ProcessString(L"\x1b_Ga=d,d=y,y=6;\x1b\\"); // protocol row 6 -> buffer row 25
+            VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"the image on viewport row 6 must be deleted");
+            VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 0, 255, 0), L"the image on row 27 must survive");
+        }
     }
 
     // With C=1 the cursor stays put after a placement, but the image still renders.
@@ -6391,13 +6356,28 @@ public:
 
     // Delete-by-id must erase the image's on-screen PIXELS, not just drop the registry entry --
     // a delete that left the drawn cells behind would ghost the image after it was "deleted".
+    // This holds for a scaled placement too: its larger on-screen footprint must go entirely.
     TEST_METHOD(KittyGraphicsDeleteErasesPixels)
     {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1;/wAA\x1b\\");
-        VERIFY_IS_TRUE(CountImageRows(*_testGetSet->_textBuffer) >= 1, L"image should render");
-        _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1;\x1b\\");
-        VERIFY_ARE_EQUAL(0, CountImageRows(*_testGetSet->_textBuffer), L"delete must erase on-screen pixels");
+        // A 1x1 placement.
+        {
+            _testGetSet->PrepData();
+            _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1;/wAA\x1b\\");
+            VERIFY_IS_TRUE(CountImageRows(*_testGetSet->_textBuffer) >= 1, L"image should render");
+            _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1;\x1b\\");
+            VERIFY_ARE_EQUAL(0, CountImageRows(*_testGetSet->_textBuffer), L"delete must erase on-screen pixels");
+        }
+
+        // A scaled 3-col x 2-row placement: the larger footprint must be fully erased.
+        {
+            _testGetSet->PrepData();
+            _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,c=3,r=2;/wAA\x1b\\"); // 3 cols x 2 rows
+            VERIFY_ARE_EQUAL(2, CountImageRows(*_testGetSet->_textBuffer));
+            VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0));
+            _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1;\x1b\\");
+            VERIFY_ARE_EQUAL(0, CountImageRows(*_testGetSet->_textBuffer));
+            VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"scaled placement must be fully erased");
+        }
     }
 
     // ---- Kitty Unicode placeholders (U=1 virtual placement) -------------------
@@ -7634,31 +7614,34 @@ public:
         VERIFY_ARE_EQUAL(2, CountImageRows(buffer)); // 2*40/2 = 40px => 2 rows
     }
 
-    // x/w crop a source sub-rect in pixels: a 2px image (red|green) cropped x=1,w=1
-    // renders only the green pixel, never the cropped-out red.
+    // x/w crop a source sub-rect in pixels on a 2px image (red|green): an explicit width
+    // (x=1,w=1) and a width that extends to the right edge (x=1,w=0) both render only the
+    // green pixel, never the cropped-out red.
     TEST_METHOD(KittyGraphicsCropSelectsSubRect)
     {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=2,v=1,x=1,w=1;/wAAAP8A\x1b\\"); // red|green, crop right
-        const auto& buffer = *_testGetSet->_textBuffer;
-        til::CoordType imageRow = -1;
-        const auto slice = FindFirstImageSlice(buffer, imageRow);
-        VERIFY_IS_NOT_NULL(slice);
-        VERIFY_IS_TRUE(SliceContainsColor(slice, 0, 255, 0), L"cropped sub-rect is the green pixel");
-        VERIFY_IS_FALSE(SliceContainsColor(slice, 255, 0, 0), L"cropped-out red must not render");
-    }
+        // x=1,w=1: an explicit one-pixel crop.
+        {
+            _testGetSet->PrepData();
+            _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=2,v=1,x=1,w=1;/wAAAP8A\x1b\\"); // red|green, crop right
+            const auto& buffer = *_testGetSet->_textBuffer;
+            til::CoordType imageRow = -1;
+            const auto slice = FindFirstImageSlice(buffer, imageRow);
+            VERIFY_IS_NOT_NULL(slice);
+            VERIFY_IS_TRUE(SliceContainsColor(slice, 0, 255, 0), L"cropped sub-rect is the green pixel");
+            VERIFY_IS_FALSE(SliceContainsColor(slice, 255, 0, 0), L"cropped-out red must not render");
+        }
 
-    // w=0 extends the crop to the right edge: x=1,w=0 on a 2px image still yields green.
-    TEST_METHOD(KittyGraphicsCropWidthZeroToEdge)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=2,v=1,x=1;/wAAAP8A\x1b\\"); // crop x=1 to edge
-        const auto& buffer = *_testGetSet->_textBuffer;
-        til::CoordType imageRow = -1;
-        const auto slice = FindFirstImageSlice(buffer, imageRow);
-        VERIFY_IS_NOT_NULL(slice);
-        VERIFY_IS_TRUE(SliceContainsColor(slice, 0, 255, 0));
-        VERIFY_IS_FALSE(SliceContainsColor(slice, 255, 0, 0));
+        // x=1,w=0: width zero extends the crop to the right edge, still yielding green.
+        {
+            _testGetSet->PrepData();
+            _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=2,v=1,x=1;/wAAAP8A\x1b\\"); // crop x=1 to edge
+            const auto& buffer = *_testGetSet->_textBuffer;
+            til::CoordType imageRow = -1;
+            const auto slice = FindFirstImageSlice(buffer, imageRow);
+            VERIFY_IS_NOT_NULL(slice);
+            VERIFY_IS_TRUE(SliceContainsColor(slice, 0, 255, 0));
+            VERIFY_IS_FALSE(SliceContainsColor(slice, 255, 0, 0));
+        }
     }
 
     // A hostile column count clamps to the page rather than overflowing; the slice
@@ -7674,18 +7657,6 @@ public:
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(slice->PixelWidth() <= width * slice->CellSize().width, L"a huge c must stay page-bounded");
         VERIFY_ARE_EQUAL(width - 1, buffer.GetCursor().GetPosition().x);
-    }
-
-    // Deleting a scaled placement still erases its (larger) on-screen footprint.
-    TEST_METHOD(KittyGraphicsDeleteErasesScaledPlacement)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,c=3,r=2;/wAA\x1b\\"); // 3 cols x 2 rows
-        VERIFY_ARE_EQUAL(2, CountImageRows(*_testGetSet->_textBuffer));
-        VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0));
-        _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1;\x1b\\");
-        VERIFY_ARE_EQUAL(0, CountImageRows(*_testGetSet->_textBuffer));
-        VERIFY_IS_FALSE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0), L"scaled placement must be fully erased");
     }
 
     // An oversized c clips off-screen, not squashes: a 2px red|green at c=200 on a
@@ -7839,14 +7810,6 @@ public:
         VERIFY_ARE_EQUAL(3u, child2Slice->ColumnOwner(parentPos.x - 2), L"-offset child anchored at parent+(-2,-1)");
     }
 
-    // Referencing a parent that was never placed reports ENOPARENT.
-    TEST_METHOD(KittyRelativeMissingParentIsEnoparent)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,P=99,Q=1,H=0,V=0,f=24,s=1,v=1;/wAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=2,p=1;ENOPARENT:relative parent not found\x1b\\");
-    }
-
     // A re-put that makes A relative to B while B is relative to A closes a cycle: ECYCLE.
     TEST_METHOD(KittyRelativeCycleIsEcycle)
     {
@@ -7874,14 +7837,6 @@ public:
         // Depth 9 (id 10, parent id 9) exceeds the maximum.
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=10,p=1,P=9,Q=1,H=0,V=0,f=24,s=1,v=1,C=1;/wAA\x1b\\");
         _testGetSet->ValidateInputEvent(L"\x1b_Gi=10,p=1;ETOODEEP:relative placement chain too deep\x1b\\");
-    }
-
-    // A virtual (U=1) placement cannot itself be relative => EINVAL.
-    TEST_METHOD(KittyRelativeOnVirtualIsEinval)
-    {
-        _testGetSet->PrepData();
-        _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,U=1,P=2,Q=1,f=24,s=1,v=1;/wAA\x1b\\");
-        _testGetSet->ValidateInputEvent(L"\x1b_Gi=1,p=1;EINVAL:virtual placements cannot be relative\x1b\\");
     }
 
     // A relative placement MAY refer to a virtual parent; that parent's position is derived from

--- a/src/types/inc/sharedMemory.hpp
+++ b/src/types/inc/sharedMemory.hpp
@@ -1,0 +1,40 @@
+/*++
+Copyright (c) Microsoft Corporation
+
+Module Name:
+- sharedMemory.hpp
+
+Abstract:
+- Reading a named shared-memory object handed to us by a terminal client.
+--*/
+
+#pragma once
+
+namespace Microsoft::Console::Utils
+{
+    // What ReadSharedMemory managed to do. not_found: no object of that name exists.
+    // invalid: the request was malformed -- an empty or over-long name, a name we will
+    // not open, or a byte range the mapping cannot satisfy. read_error: the object
+    // exists but could not be mapped or copied.
+    enum class ReadSharedMemoryResult : uint8_t
+    {
+        ok,
+        not_found,
+        invalid,
+        read_error,
+    };
+
+    // Copies bytes out of a named shared-memory object into 'out'.
+    //
+    // The name arrives from outside, so this is deliberately narrow about what it will
+    // open. Windows file mappings are session-local by default; only unprefixed names
+    // and an explicit Local\ prefix are accepted, so a terminal client cannot reach a
+    // service's Global\ object. The mapping is opened read-only, never inherited, copied
+    // into memory we own, and closed immediately. Unlike POSIX shm there is no unlink
+    // step: the object goes away once every process has closed its handles.
+    //
+    // 'size' of 0 means "to the end of the mapping". Windows rounds paging-file sections
+    // up to a page boundary, so a caller that needs an exact non-page-aligned length has
+    // to know it and pass it. Never throws.
+    ReadSharedMemoryResult ReadSharedMemory(const std::wstring_view name, uint64_t offset, uint64_t size, std::vector<uint8_t>& out) noexcept;
+}

--- a/src/types/inc/sharedMemory.hpp
+++ b/src/types/inc/sharedMemory.hpp
@@ -35,6 +35,6 @@ namespace Microsoft::Console::Utils
     //
     // 'size' of 0 means "to the end of the mapping". Windows rounds paging-file sections
     // up to a page boundary, so a caller that needs an exact non-page-aligned length has
-    // to know it and pass it. Never throws.
+    // to know it and pass it.
     ReadSharedMemoryResult ReadSharedMemory(const std::wstring_view name, uint64_t offset, uint64_t size, std::vector<uint8_t>& out) noexcept;
 }

--- a/src/types/lib/types.vcxproj
+++ b/src/types/lib/types.vcxproj
@@ -18,6 +18,7 @@
     <ClCompile Include="..\GlyphWidth.cpp" />
     <ClCompile Include="..\ScreenInfoUiaProviderBase.cpp" />
     <ClCompile Include="..\sgrStack.cpp" />
+    <ClCompile Include="..\sharedMemory.cpp" />
     <ClCompile Include="..\ThemeUtils.cpp" />
     <ClCompile Include="..\UiaTextRangeBase.cpp" />
     <ClCompile Include="..\UiaTracing.cpp" />
@@ -38,6 +39,7 @@
     <ClInclude Include="..\inc\GlyphWidth.hpp" />
     <ClInclude Include="..\inc\IInputEvent.hpp" />
     <ClInclude Include="..\inc\sgrStack.hpp" />
+    <ClInclude Include="..\inc\sharedMemory.hpp" />
     <ClInclude Include="..\inc\ThemeUtils.h" />
     <ClInclude Include="..\inc\utils.hpp" />
     <ClInclude Include="..\inc\Viewport.hpp" />

--- a/src/types/sharedMemory.cpp
+++ b/src/types/sharedMemory.cpp
@@ -1,0 +1,274 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "precomp.h"
+#include "inc/sharedMemory.hpp"
+
+using namespace Microsoft::Console::Utils;
+
+// These two exist because the pages behind a client-supplied mapping can be
+// decommitted at any moment; a plain memcpy would take an access violation on
+// memory we do not control the lifetime of.
+namespace
+{
+    bool is_readable_range(const void* source, const size_t size) noexcept
+    {
+        if (size == 0)
+        {
+            return true;
+        }
+
+        const auto begin = reinterpret_cast<uintptr_t>(source);
+        if (size > UINTPTR_MAX - begin)
+        {
+            return false;
+        }
+
+        const auto end = begin + size;
+        auto current = begin;
+        while (current < end)
+        {
+            MEMORY_BASIC_INFORMATION info{};
+            if (VirtualQuery(reinterpret_cast<const void*>(current), &info, sizeof(info)) != sizeof(info) ||
+                info.State != MEM_COMMIT)
+            {
+                return false;
+            }
+
+            const auto protection = info.Protect & 0xff;
+            const auto readable = protection == PAGE_READONLY ||
+                                  protection == PAGE_READWRITE ||
+                                  protection == PAGE_WRITECOPY ||
+                                  protection == PAGE_EXECUTE_READ ||
+                                  protection == PAGE_EXECUTE_READWRITE ||
+                                  protection == PAGE_EXECUTE_WRITECOPY;
+            if (!readable || (info.Protect & PAGE_GUARD) != 0)
+            {
+                return false;
+            }
+
+            const auto regionBegin = reinterpret_cast<uintptr_t>(info.BaseAddress);
+            if (info.RegionSize > UINTPTR_MAX - regionBegin)
+            {
+                return false;
+            }
+            const auto regionEnd = regionBegin + info.RegionSize;
+            if (regionEnd <= current)
+            {
+                return false;
+            }
+            current = std::min(regionEnd, end);
+        }
+
+        return true;
+    }
+
+    // A file-backed section can fault after it has been mapped (for example if its
+    // backing file is truncated). Keep SEH in a leaf with no C++ objects requiring
+    // unwinding, then translate the fault into a normal protocol read error.
+    bool guarded_copy(void* destination, const void* source, const size_t size) noexcept
+    {
+        __try
+        {
+            memcpy(destination, source, size);
+            return true;
+        }
+        __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ||
+                      GetExceptionCode() == EXCEPTION_IN_PAGE_ERROR ||
+                      GetExceptionCode() == EXCEPTION_GUARD_PAGE ?
+                  EXCEPTION_EXECUTE_HANDLER :
+                  EXCEPTION_CONTINUE_SEARCH)
+        {
+            return false;
+        }
+    }
+}
+
+ReadSharedMemoryResult Microsoft::Console::Utils::ReadSharedMemory(const std::wstring_view name, uint64_t offset, uint64_t size, std::vector<uint8_t>& out) noexcept
+{
+    out.clear();
+
+    constexpr uint64_t maxBytes = 32ull * 1024 * 1024;
+    constexpr size_t maxNameChars = 32767;
+
+    const auto hasControlCharacter = std::any_of(name.begin(), name.end(), [](const wchar_t value) noexcept {
+        return value < L' ' || value == 0x7f;
+    });
+    if (name.empty() || name.size() > maxNameChars || hasControlCharacter)
+    {
+        return ReadSharedMemoryResult::invalid;
+    }
+
+    // Kernel object prefixes are case-sensitive. Permit the current-session
+    // namespace, either implicitly or via Local\, and reject every other backslash
+    // (including Global\, Session\, and nested object-manager paths).
+    auto remainder = name;
+    if (remainder.starts_with(L"Local\\"))
+    {
+        remainder.remove_prefix(6);
+    }
+    if (remainder.empty() || remainder.find(L'\\') != std::wstring_view::npos)
+    {
+        return ReadSharedMemoryResult::invalid;
+    }
+
+    std::wstring nameStr;
+    try
+    {
+        nameStr.assign(name);
+    }
+    catch (...)
+    {
+        return ReadSharedMemoryResult::read_error;
+    }
+
+    wil::unique_handle mapping{ OpenFileMappingW(FILE_MAP_READ, FALSE, nameStr.c_str()) };
+    if (!mapping)
+    {
+        const auto error = GetLastError();
+        if (error == ERROR_FILE_NOT_FOUND)
+        {
+            return ReadSharedMemoryResult::not_found;
+        }
+        if (error == ERROR_INVALID_NAME || error == ERROR_INVALID_PARAMETER)
+        {
+            return ReadSharedMemoryResult::invalid;
+        }
+        return ReadSharedMemoryResult::read_error;
+    }
+
+    SYSTEM_INFO systemInfo{};
+    GetSystemInfo(&systemInfo);
+    const auto granularity = static_cast<uint64_t>(systemInfo.dwAllocationGranularity);
+    if (granularity == 0)
+    {
+        return ReadSharedMemoryResult::read_error;
+    }
+
+    const auto alignedOffset = offset - (offset % granularity);
+    const auto delta = static_cast<size_t>(offset - alignedOffset);
+    const auto offsetHigh = static_cast<DWORD>(alignedOffset >> 32);
+    const auto offsetLow = static_cast<DWORD>(alignedOffset);
+
+    const auto map = [&](const size_t bytes) noexcept {
+        return MapViewOfFile(mapping.get(), FILE_MAP_READ, offsetHigh, offsetLow, bytes);
+    };
+    const auto mapFailure = []() noexcept {
+        const auto error = GetLastError();
+        return (error == ERROR_NOT_ENOUGH_MEMORY || error == ERROR_OUTOFMEMORY)
+                   ? ReadSharedMemoryResult::read_error
+                   : ReadSharedMemoryResult::invalid;
+    };
+
+    auto toRead = static_cast<size_t>(std::min(size, maxBytes));
+    void* view = nullptr;
+
+    if (size != 0)
+    {
+        view = map(delta + toRead);
+        if (!view)
+        {
+            return mapFailure();
+        }
+    }
+    else
+    {
+        // Avoid mapping an attacker-sized section merely to discover its end. A
+        // bounded view succeeds for large sections; only smaller sections need the
+        // map-to-end fallback whose extent is then measured with VirtualQuery.
+        view = map(delta + static_cast<size_t>(maxBytes));
+        if (view)
+        {
+            toRead = static_cast<size_t>(maxBytes);
+        }
+        else
+        {
+            view = map(0);
+            if (!view)
+            {
+                return mapFailure();
+            }
+
+            const auto viewBegin = reinterpret_cast<uintptr_t>(view);
+            const auto maximumExtent = delta + static_cast<size_t>(maxBytes);
+            if (maximumExtent > UINTPTR_MAX - viewBegin)
+            {
+                UnmapViewOfFile(view);
+                return ReadSharedMemoryResult::read_error;
+            }
+
+            const auto limit = viewBegin + maximumExtent;
+            auto current = viewBegin;
+            while (current < limit)
+            {
+                MEMORY_BASIC_INFORMATION info{};
+                if (VirtualQuery(reinterpret_cast<const void*>(current), &info, sizeof(info)) != sizeof(info))
+                {
+                    UnmapViewOfFile(view);
+                    return ReadSharedMemoryResult::read_error;
+                }
+                if (info.AllocationBase != view)
+                {
+                    break;
+                }
+
+                const auto regionBegin = reinterpret_cast<uintptr_t>(info.BaseAddress);
+                if (regionBegin > current || info.RegionSize > UINTPTR_MAX - regionBegin)
+                {
+                    UnmapViewOfFile(view);
+                    return ReadSharedMemoryResult::read_error;
+                }
+                const auto regionEnd = regionBegin + info.RegionSize;
+                if (regionEnd <= current)
+                {
+                    UnmapViewOfFile(view);
+                    return ReadSharedMemoryResult::read_error;
+                }
+                current = std::min(regionEnd, limit);
+            }
+
+            const auto viewExtent = current - viewBegin;
+            if (viewExtent <= delta)
+            {
+                UnmapViewOfFile(view);
+                return ReadSharedMemoryResult::read_error;
+            }
+            toRead = std::min(viewExtent - delta, static_cast<size_t>(maxBytes));
+        }
+    }
+
+    struct mapped_view
+    {
+        void* value;
+        ~mapped_view()
+        {
+            if (value)
+            {
+                UnmapViewOfFile(value);
+            }
+        }
+    } viewGuard{ view };
+
+    const auto first = static_cast<const uint8_t*>(view) + delta;
+    if (!is_readable_range(first, toRead))
+    {
+        return ReadSharedMemoryResult::read_error;
+    }
+
+    try
+    {
+        out.resize(toRead);
+    }
+    catch (...)
+    {
+        out.clear();
+        return ReadSharedMemoryResult::read_error;
+    }
+    if (!guarded_copy(out.data(), first, toRead))
+    {
+        out.clear();
+        return ReadSharedMemoryResult::read_error;
+    }
+
+    return ReadSharedMemoryResult::ok;
+}


### PR DESCRIPTION
| Stack | |
|---|---|
| #54 | Give `ImageSlice` identified, z-ordered layers |
| #55 | Paint a row's images in z-order around its text |
| #56 | Route APC strings to the engine by identifier |
| #57 | Add the Kitty graphics protocol to the VT adapter |
| #58 | Add Kitty graphics animation |
| **&rarr; #59** | **Add file and shared-memory transmission** |

## TL;DR

`t=f` local file · `t=t` temp file deleted after reading · `t=s` shared memory. Most of this PR is the fence around them, because a client-supplied path is the most dangerous input in the protocol.

![An image transmitted by local file path rather than by escape sequence](https://github.com/user-attachments/assets/0447ad08-746c-403c-9f04-02643d2d1f9f)

![What a file-transmission escape sequence is not allowed to do](https://github.com/user-attachments/assets/24e6d5ad-4ce6-4a57-a550-91712e228f73)

## The fence

- **Only local, fixed-drive, drive-absolute paths** (`X:\...`). Relative and drive-relative paths are rejected, so a client can't make the terminal resolve a path against the *terminal's* working directory. UNC and device-namespace paths (`\\server\share`, `\\.\dev`, `\\?\...`, `//host/...`) are rejected **before `CreateFileW` is ever called** — that's what closes the NTLM-leak window, since a post-open check is already too late.
- **Checked before opening and again after.** A pre-open `GetDriveType` rejects a mapped network drive; a post-open `GetFinalPathNameByHandle` rejects a UNC final path or a non-`DRIVE_FIXED` volume, catching a junction or symlink that redirects across volumes.
- **No reparse-point traversal.** The drive root is resolved through Win32, then the remaining untrusted path is opened *relative to that handle* with `OBJ_DONT_REPARSE`. Applying that to the whole path would fail on the Object Manager's own `\??\C:` drive-letter symlink.
- **`..` is collapsed lexically, before opening**, so the path that gets validated is the path that gets opened.
- **`t=t` deletes through the open handle, never by re-opening a path.** `FILE_DISPOSITION_INFO` on the already-validated handle closes the TOCTOU window. It only happens when that handle's canonical path is under the system temp directory *and* its name contains the marker the caller supplied. A `t=t` pointed at `C:\Users\you\Documents\taxes.pdf` reads nothing and deletes nothing. Under ConPTY the delete is suppressed outright — conhost isn't the process that owns that decision.
- **Reads are hard-capped at 32 MiB** regardless of `S=`, matching the direct base64 limit. `O=`/`S=` arithmetic is checked against the real file size in 64-bit before any truncation to `DWORD`.
- **A mapped view can fault after it's mapped** if its owner truncates the section. `is_readable_range` checks against `VirtualQuery` first; `guarded_copy` is an SEH backstop in a leaf with no C++ objects requiring unwinding, translating the fault into an ordinary protocol read error.

## Notes for the rest of the stack — why this code moved

The first version put both readers in `til/io.h` and called one of them `read_image_file`. Both were wrong in the same way.

- **It doesn't read an image file. It reads *a* file** — a byte range of one, with rules about which files it will open. Nothing in it knows the bytes will be decoded as a PNG. It's now `til::read_file_as_bytes`, and its comments no longer explain themselves in terms of `t=f` / `t=t` / `S=`. A reviewer of `til` shouldn't have to learn a graphics protocol to review a file read.
- **The literal `tty-graphics-protocol` is now a parameter, not a `static constexpr`.** It gates whether a temp file may be deleted, and it's kitty's naming convention — so only a caller knows what it named the files it's entitled to remove. An empty marker deletes nothing, which `ReadLocalFileEmptyMarkerNeverDeletes` proves by failing when the guard is removed; without it an empty marker matches every filename.
- **`read_shared_memory` left `til` altogether.** Reading a byte range of a file is a general-purpose thing a "today I learned" library can own. Opening a named Windows section object a terminal client asked for, with the session-namespace and page-commitment care that needs, is console-specific IPC — it's now `Microsoft::Console::Utils::ReadSharedMemory` in `src/types`, which both hosts already link.
- **The interface reflects it.** `ITerminalApi` asks the host to `ReadLocalFile` and `ReadSharedMemory`, not `ReadKittyImageFile`. Which protocol wanted the bytes is the adapter's business. Both are pure virtual, like everything else on that interface.

## Tests

Path-rejection coverage for each class above (relative, drive-relative, UNC, device namespace, mapped drive, cross-volume symlink, `..` traversal), plus the empty-marker delete guard and the truncated-section fault path. All suites at baseline.

---

**Builds alone.** Built without any PR above it — zero C++ errors.