### PR TITLE
Own rectangular image lifecycle in TextBuffer

### DIFF
--- a/src/buffer/out/Image.cpp
+++ b/src/buffer/out/Image.cpp
@@ -29,7 +29,8 @@ namespace
         return width * height;
     }
 
-    bool imageLess(const ImagePlacement* lhs, const ImagePlacement* rhs) noexcept
+    template<typename T>
+    bool imageLess(const T& lhs, const T& rhs) noexcept
     {
         if (lhs->Position() != rhs->Position())
         {
@@ -139,20 +140,41 @@ ImagePlacement::ImagePlacement(const Key key,
     THROW_HR_IF(E_INVALIDARG, _geometry.targetWidth > INT64_MAX || _geometry.targetHeight > INT64_MAX);
 }
 
+ImagePlacement ImagePlacement::FromFragment(const Key key,
+                                            Image::Pointer image,
+                                            const til::rect cellBounds,
+                                            const til::rect originalCellBounds,
+                                            const int32_t zIndex,
+                                            const til::rect sourceInPixels,
+                                            const PixelGeometry geometry)
+{
+    THROW_HR_IF(E_INVALIDARG, originalCellBounds.right <= originalCellBounds.left ||
+                                      originalCellBounds.bottom <= originalCellBounds.top ||
+                                      cellBounds.left < originalCellBounds.left ||
+                                      cellBounds.top < originalCellBounds.top ||
+                                      cellBounds.right > originalCellBounds.right ||
+                                      cellBounds.bottom > originalCellBounds.bottom);
+    auto placement = ImagePlacement{ key, std::move(image), cellBounds, zIndex, sourceInPixels, geometry };
+    placement._originalCellBounds = originalCellBounds;
+    return placement;
+}
+
 ImagePlacement::ImagePlacement(const Key key,
                                Image::Pointer image,
                                const til::rect cellBounds,
                                const til::rect originalCellBounds,
                                const int32_t zIndex,
                                const til::rect sourceInPixels,
-                               const PixelGeometry geometry) noexcept :
+                               const PixelGeometry geometry,
+                               const uint64_t rowEpoch) noexcept :
     _key{ key },
     _image{ std::move(image) },
     _cellBounds{ cellBounds },
     _originalCellBounds{ originalCellBounds },
     _zIndex{ zIndex },
     _sourceInPixels{ sourceInPixels },
-    _geometry{ geometry }
+    _geometry{ geometry },
+    _rowEpoch{ rowEpoch }
 {
 }
 
@@ -212,7 +234,7 @@ std::optional<ImagePlacement> ImagePlacement::Crop(const til::rect cellBounds) c
     {
         return std::nullopt;
     }
-    return ImagePlacement{ _key, _image, clipped, _originalCellBounds, _zIndex, _sourceInPixels, _geometry };
+    return ImagePlacement{ _key, _image, clipped, _originalCellBounds, _zIndex, _sourceInPixels, _geometry, _rowEpoch };
 }
 
 ImagePlacement ImagePlacement::Translated(const til::point delta) const
@@ -225,6 +247,7 @@ ImagePlacement ImagePlacement::Translated(const til::point delta) const
         _zIndex,
         _sourceInPixels,
         _geometry,
+        _rowEpoch,
     };
 }
 
@@ -301,20 +324,80 @@ bool ImagePlacement::RasterizeRow(const til::CoordType row,
     return true;
 }
 
+ImageCollection::LogicalPlacement::LogicalPlacement(const ImagePlacement* const placement,
+                                                    const til::CoordType rowOffset,
+                                                    const til::CoordType bufferHeight) noexcept :
+    _placement{ placement },
+    _rowOffset{ rowOffset },
+    _bufferHeight{ bufferHeight }
+{
+}
+
+const ImageCollection::LogicalPlacement* ImageCollection::LogicalPlacement::operator->() const noexcept
+{
+    return this;
+}
+
+ImagePlacement::Key ImageCollection::LogicalPlacement::Identity() const noexcept
+{
+    return _placement->Identity();
+}
+
+const Image& ImageCollection::LogicalPlacement::Surface() const noexcept
+{
+    return _placement->Surface();
+}
+
+til::rect ImageCollection::LogicalPlacement::CellBounds() const noexcept
+{
+    auto bounds = _placement->CellBounds() + til::point{ 0, _rowOffset };
+    bounds.top = std::max(bounds.top, til::CoordType{ 0 });
+    bounds.bottom = std::min(bounds.bottom, _bufferHeight);
+    return bounds;
+}
+
+til::rect ImageCollection::LogicalPlacement::OriginalCellBounds() const noexcept
+{
+    return _placement->OriginalCellBounds() + til::point{ 0, _rowOffset };
+}
+
+const ImagePlacement::PixelGeometry& ImageCollection::LogicalPlacement::Geometry() const noexcept
+{
+    return _placement->Geometry();
+}
+
+int32_t ImageCollection::LogicalPlacement::ZIndex() const noexcept
+{
+    return _placement->ZIndex();
+}
+
+ImagePlacement::RenderPosition ImageCollection::LogicalPlacement::Position() const noexcept
+{
+    return _placement->Position();
+}
+
+std::optional<ImagePlacement> ImageCollection::LogicalPlacement::Crop(const til::rect cellBounds) const
+{
+    const auto logical = _placement->Translated({ 0, _rowOffset });
+    return logical.Crop(cellBounds & CellBounds());
+}
+
+bool ImageCollection::LogicalPlacement::RasterizeRow(const til::CoordType row,
+                                                     const til::CoordType columnBegin,
+                                                     const til::CoordType columnEnd,
+                                                     ImageSlice& destination) const
+{
+    const auto storedRow = gsl::narrow<til::CoordType>(static_cast<int64_t>(row) - _rowOffset);
+    return _placement->RasterizeRow(storedRow, columnBegin, columnEnd, destination);
+}
+
 struct ImageCollection::RowIndex
 {
-    using Tree = interval_tree::IntervalTree<til::CoordType, size_t>;
+    using Tree = interval_tree::IntervalTree<uint64_t, size_t>;
 
-    explicit RowIndex(const std::vector<ImagePlacement>& images)
+    explicit RowIndex(Tree::interval_vector intervals) :
+        tree{ std::move(intervals) }
     {
-        Tree::interval_vector intervals;
-        intervals.reserve(images.size());
-        for (size_t i = 0; i < images.size(); ++i)
-        {
-            const auto bounds = images[i].CellBounds();
-            intervals.emplace_back(bounds.top, bounds.bottom - 1, i);
-        }
-        tree = Tree{ std::move(intervals) };
     }
 
     Tree tree;
@@ -325,8 +408,61 @@ ImageCollection::~ImageCollection() = default;
 ImageCollection::ImageCollection(ImageCollection&&) noexcept = default;
 ImageCollection& ImageCollection::operator=(ImageCollection&&) noexcept = default;
 
+std::vector<ImagePlacement> ImageCollection::_eraseAreas(const std::span<const ImagePlacement> images, const std::span<const til::rect> areas)
+{
+    std::vector<ImagePlacement> remaining{ images.begin(), images.end() };
+    for (const auto area : areas)
+    {
+        if (area.empty())
+        {
+            continue;
+        }
+
+        const auto intersects = [&](const auto& image) {
+            return !(image.CellBounds() & area).empty();
+        };
+        if (std::none_of(remaining.begin(), remaining.end(), intersects))
+        {
+            continue;
+        }
+
+        std::vector<ImagePlacement> next;
+        next.reserve(remaining.size());
+        for (const auto& image : remaining)
+        {
+            const auto bounds = image.CellBounds();
+            if ((bounds & area).empty())
+            {
+                next.emplace_back(image);
+                continue;
+            }
+
+            for (const auto fragment : bounds - area)
+            {
+                if (auto cropped = image.Crop(fragment))
+                {
+                    next.emplace_back(std::move(*cropped));
+                }
+            }
+        }
+        remaining = std::move(next);
+    }
+    return remaining;
+}
+
+void ImageCollection::_replace(std::vector<ImagePlacement> images) noexcept
+{
+    for (auto& image : images)
+    {
+        image._rowEpoch = _rowEpoch;
+    }
+    _images = std::move(images);
+    _markIndexDirty();
+}
+
 void ImageCollection::Add(ImagePlacement image)
 {
+    image._rowEpoch = _rowEpoch;
     _images.emplace_back(std::move(image));
     _markIndexDirty();
 }
@@ -334,6 +470,7 @@ void ImageCollection::Add(ImagePlacement image)
 void ImageCollection::AddOrReplace(ImagePlacement image)
 {
     const auto key = image.Identity();
+    image._rowEpoch = _rowEpoch;
     const auto existing = std::find_if(_images.begin(), _images.end(), [&](const auto& candidate) {
         return candidate.Identity() == key;
     });
@@ -350,6 +487,34 @@ void ImageCollection::AddOrReplace(ImagePlacement image)
         _images.emplace_back(std::move(image));
     }
     _markIndexDirty();
+}
+
+void ImageCollection::AddOrReplaceArea(ImagePlacement image)
+{
+    const auto key = image.Identity();
+    const auto area = image.CellBounds();
+    const auto current = All();
+    std::vector<ImagePlacement> remaining;
+    remaining.reserve(current.size() + 1);
+    for (const auto& candidate : current)
+    {
+        const auto bounds = candidate.CellBounds();
+        if (candidate.Identity() != key || (bounds & area).empty())
+        {
+            remaining.emplace_back(candidate);
+            continue;
+        }
+
+        for (const auto fragment : bounds - area)
+        {
+            if (auto cropped = candidate.Crop(fragment))
+            {
+                remaining.emplace_back(std::move(*cropped));
+            }
+        }
+    }
+    remaining.emplace_back(std::move(image));
+    _replace(std::move(remaining));
 }
 
 void ImageCollection::Clear() noexcept
@@ -391,41 +556,29 @@ size_t ImageCollection::EraseImage(const uint32_t imageId)
 
 void ImageCollection::EraseArea(const til::rect area)
 {
-    if (area.empty() || _images.empty())
+    const std::array areas{ area };
+    EraseAreas(areas);
+}
+
+void ImageCollection::EraseAreas(const std::span<const til::rect> areas)
+{
+    if (areas.empty() || _images.empty())
     {
         return;
     }
 
-    const auto intersects = [&](const auto& image) {
-        return !(image.CellBounds() & area).empty();
-    };
-    if (std::none_of(_images.begin(), _images.end(), intersects))
+    const auto current = All();
+    const auto intersects = std::any_of(current.begin(), current.end(), [&](const auto& image) {
+        return std::any_of(areas.begin(), areas.end(), [&](const auto area) {
+            return !area.empty() && !(image.CellBounds() & area).empty();
+        });
+    });
+    if (!intersects)
     {
         return;
     }
 
-    std::vector<ImagePlacement> remaining;
-    remaining.reserve(_images.size());
-    for (auto& image : _images)
-    {
-        const auto bounds = image.CellBounds();
-        if ((bounds & area).empty())
-        {
-            remaining.emplace_back(std::move(image));
-            continue;
-        }
-
-        for (const auto fragment : bounds - area)
-        {
-            if (auto cropped = image.Crop(fragment))
-            {
-                remaining.emplace_back(std::move(*cropped));
-            }
-        }
-    }
-
-    _images = std::move(remaining);
-    _markIndexDirty();
+    _replace(_eraseAreas(current, areas));
 }
 
 void ImageCollection::CopyArea(const til::rect source, const til::point target, ImageCollection& destination) const
@@ -437,9 +590,9 @@ void ImageCollection::CopyArea(const til::rect source, const til::point target, 
 
     std::vector<ImagePlacement> copied;
     const til::point delta{ target.x - source.left, target.y - source.top };
-    for (const auto& image : _images)
+    for (const auto image : IntersectingRows(source.top, source.bottom))
     {
-        if (auto fragment = image.Crop(source))
+        if (auto fragment = image->Crop(source))
         {
             copied.emplace_back(fragment->Translated(delta));
         }
@@ -451,11 +604,23 @@ void ImageCollection::CopyArea(const til::rect source, const til::point target, 
         target.x + source.width(),
         target.y + source.height(),
     };
-    destination.EraseArea(targetArea);
-    for (auto& image : copied)
+    const auto destinationCandidates = destination.IntersectingRows(targetArea.top, targetArea.bottom);
+    const auto destinationIntersects = std::any_of(
+        destinationCandidates.begin(),
+        destinationCandidates.end(),
+        [&](const auto& image) {
+            return !(image->CellBounds() & targetArea).empty();
+        });
+    if (copied.empty() && !destinationIntersects)
     {
-        destination.Add(std::move(image));
+        return;
     }
+
+    const std::array targetAreas{ targetArea };
+    auto remaining = _eraseAreas(destination.All(), targetAreas);
+    remaining.reserve(remaining.size() + copied.size());
+    std::move(copied.begin(), copied.end(), std::back_inserter(remaining));
+    destination._replace(std::move(remaining));
 }
 
 void ImageCollection::Translate(const til::point delta)
@@ -465,32 +630,85 @@ void ImageCollection::Translate(const til::point delta)
         return;
     }
 
-    for (auto& image : _images)
+    const auto current = All();
+    std::vector<ImagePlacement> translated;
+    translated.reserve(current.size());
+    for (const auto& image : current)
     {
-        image = image.Translated(delta);
+        translated.emplace_back(image.Translated(delta));
     }
-    _markIndexDirty();
+    _replace(std::move(translated));
 }
 
 void ImageCollection::ClipArea(const til::rect area)
 {
+    const auto current = All();
     std::vector<ImagePlacement> clipped;
-    clipped.reserve(_images.size());
-    for (const auto& image : _images)
+    clipped.reserve(current.size());
+    auto changed = false;
+    for (const auto& image : current)
     {
         if (auto fragment = image.Crop(area))
         {
+            changed = changed || fragment->CellBounds() != image.CellBounds();
             clipped.emplace_back(std::move(*fragment));
+        }
+        else
+        {
+            changed = true;
         }
     }
 
-    if (clipped.size() != _images.size() ||
-        !std::equal(clipped.begin(), clipped.end(), _images.begin(), [](const auto& lhs, const auto& rhs) {
-            return lhs.CellBounds() == rhs.CellBounds();
-        }))
+    if (changed)
     {
-        _images = std::move(clipped);
-        _markIndexDirty();
+        _replace(std::move(clipped));
+    }
+}
+
+void ImageCollection::AdvanceRows(const til::CoordType rowCount, const til::CoordType bufferHeight)
+{
+    if (rowCount <= 0)
+    {
+        return;
+    }
+    THROW_HR_IF(E_INVALIDARG, bufferHeight <= 0);
+
+    const auto count = static_cast<uint64_t>(rowCount);
+    constexpr auto coordinateHeadroom = static_cast<uint64_t>(til::CoordTypeMax);
+    if (_rowEpoch > std::numeric_limits<uint64_t>::max() - coordinateHeadroom - count)
+    {
+        auto rebased = std::vector<ImagePlacement>{};
+        if (!_images.empty())
+        {
+            const auto current = All();
+            rebased.assign(current.begin(), current.end());
+        }
+        _rowEpoch = 0;
+        _lastPurgeEpoch = 0;
+        _images = std::move(rebased);
+        for (auto& image : _images)
+        {
+            image._rowEpoch = 0;
+        }
+        _rowIndexDirty = true;
+    }
+    _rowEpoch += count;
+    _bufferHeight = bufferHeight;
+    _markLogicalImagesDirty();
+
+    if (_rowEpoch - _lastPurgeEpoch >= static_cast<uint64_t>(bufferHeight))
+    {
+        const auto oldSize = _images.size();
+        std::erase_if(_images, [&](const auto& image) {
+            const auto bounds = image.CellBounds();
+            return image._rowEpoch > _rowEpoch ||
+                   _rowEpoch - image._rowEpoch >= static_cast<uint64_t>(bounds.bottom);
+        });
+        _lastPurgeEpoch = _rowEpoch;
+        if (_images.size() != oldSize)
+        {
+            _rowIndexDirty = true;
+        }
     }
 }
 
@@ -502,44 +720,134 @@ void ImageCollection::PrepareRowIndex() const
 ImageCollection::RowQuery ImageCollection::IntersectingRows(const til::CoordType rowBegin, const til::CoordType rowEnd) const
 {
     RowQuery result;
-    if (rowBegin >= rowEnd || _images.empty())
+    if (rowBegin < 0 || rowBegin >= rowEnd || _images.empty())
     {
         return result;
     }
 
     _ensureRowIndex();
-    _rowIndex->tree.visit_overlapping(rowBegin, rowEnd - 1, [&](const auto& interval) {
-        result.emplace_back(&_images[interval.value]);
+    const auto absoluteBegin = _rowEpoch + static_cast<uint64_t>(rowBegin);
+    const auto absoluteEnd = _rowEpoch + static_cast<uint64_t>(rowEnd);
+    _rowIndex->tree.visit_overlapping(absoluteBegin, absoluteEnd - 1, [&](const auto& interval) {
+        const auto& image = _images[interval.value];
+        if (const auto rowOffset = _logicalRowOffset(image))
+        {
+            result.push_back(LogicalPlacement{ &image, *rowOffset, _bufferHeight });
+        }
     });
-    std::sort(result.begin(), result.end(), imageLess);
+    std::sort(result.begin(), result.end(), [](const auto& lhs, const auto& rhs) {
+        return imageLess(lhs, rhs);
+    });
     return result;
 }
 
-std::span<const ImagePlacement> ImageCollection::All() const noexcept
+std::span<const ImagePlacement> ImageCollection::All() const
 {
-    return _images;
+    _ensureLogicalImages();
+    return _logicalImages;
 }
 
 size_t ImageCollection::Size() const noexcept
 {
-    return _images.size();
+    return std::count_if(_images.begin(), _images.end(), [&](const auto& image) {
+        return _logicalRowOffset(image).has_value();
+    });
 }
 
 bool ImageCollection::Empty() const noexcept
 {
-    return _images.empty();
+    return std::none_of(_images.begin(), _images.end(), [&](const auto& image) {
+        return _logicalRowOffset(image).has_value();
+    });
+}
+
+uint64_t ImageCollection::RowEpoch() const noexcept
+{
+    return _rowEpoch;
+}
+
+std::optional<til::CoordType> ImageCollection::_logicalRowOffset(const ImagePlacement& image) const noexcept
+{
+    if (image._rowEpoch > _rowEpoch)
+    {
+        return std::nullopt;
+    }
+
+    const auto elapsedRows = _rowEpoch - image._rowEpoch;
+    if (elapsedRows > static_cast<uint64_t>(til::CoordTypeMax))
+    {
+        return std::nullopt;
+    }
+
+    const auto offset = -static_cast<til::CoordType>(elapsedRows);
+    const auto bounds = image.CellBounds();
+    const auto logicalTop = static_cast<int64_t>(bounds.top) + offset;
+    const auto logicalBottom = static_cast<int64_t>(bounds.bottom) + offset;
+    if (logicalBottom <= 0 || logicalTop >= _bufferHeight)
+    {
+        return std::nullopt;
+    }
+    return offset;
+}
+
+void ImageCollection::_markLogicalImagesDirty() noexcept
+{
+    _logicalImagesDirty = true;
 }
 
 void ImageCollection::_markIndexDirty() noexcept
 {
+    _markLogicalImagesDirty();
     _rowIndexDirty = true;
+}
+
+void ImageCollection::_ensureLogicalImages() const
+{
+    if (_logicalImagesDirty)
+    {
+        std::vector<ImagePlacement> logicalImages;
+        logicalImages.reserve(_images.size());
+        for (const auto& image : _images)
+        {
+            const auto rowOffset = _logicalRowOffset(image);
+            if (!rowOffset)
+            {
+                continue;
+            }
+
+            auto logical = image.Translated({ 0, *rowOffset });
+            const auto bounds = logical.CellBounds();
+            logical = *logical.Crop({
+                bounds.left,
+                std::max(bounds.top, til::CoordType{ 0 }),
+                bounds.right,
+                std::min(bounds.bottom, _bufferHeight),
+            });
+            logical._rowEpoch = _rowEpoch;
+            logicalImages.emplace_back(std::move(logical));
+        }
+        _logicalImages = std::move(logicalImages);
+        _logicalImagesDirty = false;
+    }
 }
 
 void ImageCollection::_ensureRowIndex() const
 {
     if (_rowIndexDirty)
     {
-        _rowIndex = std::make_unique<RowIndex>(_images);
+        RowIndex::Tree::interval_vector intervals;
+        intervals.reserve(_images.size());
+        for (size_t i = 0; i < _images.size(); ++i)
+        {
+            const auto& image = _images[i];
+            const auto bounds = image.CellBounds();
+            THROW_HR_IF(E_UNEXPECTED, image._rowEpoch > std::numeric_limits<uint64_t>::max() - static_cast<uint64_t>(bounds.bottom));
+            intervals.emplace_back(
+                image._rowEpoch + static_cast<uint64_t>(bounds.top),
+                image._rowEpoch + static_cast<uint64_t>(bounds.bottom) - 1,
+                i);
+        }
+        _rowIndex = std::make_unique<RowIndex>(std::move(intervals));
         _rowIndexDirty = false;
     }
 }

--- a/src/buffer/out/Image.hpp
+++ b/src/buffer/out/Image.hpp
@@ -73,6 +73,13 @@ public:
                    int32_t zIndex,
                    til::rect sourceInPixels = {},
                    PixelGeometry geometry = {});
+    static ImagePlacement FromFragment(Key key,
+                                       Image::Pointer image,
+                                       til::rect cellBounds,
+                                       til::rect originalCellBounds,
+                                       int32_t zIndex,
+                                       til::rect sourceInPixels = {},
+                                       PixelGeometry geometry = {});
 
     Key Identity() const noexcept;
     const Image& Surface() const noexcept;
@@ -95,7 +102,10 @@ private:
                    til::rect originalCellBounds,
                    int32_t zIndex,
                    til::rect sourceInPixels,
-                   PixelGeometry geometry) noexcept;
+                   PixelGeometry geometry,
+                   uint64_t rowEpoch) noexcept;
+
+    friend class ImageCollection;
 
     Key _key;
     Image::Pointer _image;
@@ -104,12 +114,38 @@ private:
     int32_t _zIndex = 0;
     til::rect _sourceInPixels;
     PixelGeometry _geometry;
+    uint64_t _rowEpoch = 0;
 };
 
 class ImageCollection final
 {
 public:
-    using RowQuery = til::small_vector<const ImagePlacement*, 16>;
+    class LogicalPlacement final
+    {
+    public:
+        const LogicalPlacement* operator->() const noexcept;
+
+        ImagePlacement::Key Identity() const noexcept;
+        const Image& Surface() const noexcept;
+        til::rect CellBounds() const noexcept;
+        til::rect OriginalCellBounds() const noexcept;
+        const ImagePlacement::PixelGeometry& Geometry() const noexcept;
+        int32_t ZIndex() const noexcept;
+        ImagePlacement::RenderPosition Position() const noexcept;
+        std::optional<ImagePlacement> Crop(til::rect cellBounds) const;
+        bool RasterizeRow(til::CoordType row, til::CoordType columnBegin, til::CoordType columnEnd, ImageSlice& destination) const;
+
+    private:
+        friend class ImageCollection;
+
+        LogicalPlacement(const ImagePlacement* placement, til::CoordType rowOffset, til::CoordType bufferHeight) noexcept;
+
+        const ImagePlacement* _placement = nullptr;
+        til::CoordType _rowOffset = 0;
+        til::CoordType _bufferHeight = til::CoordTypeMax;
+    };
+
+    using RowQuery = til::small_vector<LogicalPlacement, 16>;
 
     ImageCollection();
     ~ImageCollection();
@@ -120,29 +156,44 @@ public:
 
     void Add(ImagePlacement image);
     void AddOrReplace(ImagePlacement image);
+    void AddOrReplaceArea(ImagePlacement image);
     void Clear() noexcept;
     bool Erase(ImagePlacement::Key key);
     size_t EraseImage(uint32_t imageId);
     void EraseArea(til::rect area);
+    void EraseAreas(std::span<const til::rect> areas);
     void CopyArea(til::rect source, til::point target, ImageCollection& destination) const;
     void Translate(til::point delta);
     void ClipArea(til::rect area);
+    void AdvanceRows(til::CoordType rowCount, til::CoordType bufferHeight);
     void PrepareRowIndex() const;
 
     // Preparing the index after a batch of mutations keeps its allocations out
-    // of the render query. Returned pointers remain valid until the next mutation.
+    // of the render query. RowQuery entries and All() spans are frame-local and
+    // remain valid only until the next collection mutation.
     RowQuery IntersectingRows(til::CoordType rowBegin, til::CoordType rowEnd) const;
-    std::span<const ImagePlacement> All() const noexcept;
+    std::span<const ImagePlacement> All() const;
     size_t Size() const noexcept;
     bool Empty() const noexcept;
+    uint64_t RowEpoch() const noexcept;
 
 private:
     struct RowIndex;
 
+    static std::vector<ImagePlacement> _eraseAreas(std::span<const ImagePlacement> images, std::span<const til::rect> areas);
+    void _replace(std::vector<ImagePlacement> images) noexcept;
+    std::optional<til::CoordType> _logicalRowOffset(const ImagePlacement& image) const noexcept;
+    void _markLogicalImagesDirty() noexcept;
     void _markIndexDirty() noexcept;
+    void _ensureLogicalImages() const;
     void _ensureRowIndex() const;
 
     std::vector<ImagePlacement> _images;
+    uint64_t _rowEpoch = 0;
+    uint64_t _lastPurgeEpoch = 0;
+    til::CoordType _bufferHeight = til::CoordTypeMax;
+    mutable std::vector<ImagePlacement> _logicalImages;
     mutable std::unique_ptr<RowIndex> _rowIndex;
+    mutable bool _logicalImagesDirty = true;
     mutable bool _rowIndexDirty = true;
 };

--- a/src/buffer/out/ImageSlice.cpp
+++ b/src/buffer/out/ImageSlice.cpp
@@ -247,26 +247,54 @@ RGBQUAD* ImageSlice::MutablePixels(const til::CoordType columnBegin, const til::
 
 void ImageSlice::CopyBlock(const TextBuffer& srcBuffer, const til::rect srcRect, TextBuffer& dstBuffer, const til::rect dstRect)
 {
-    // If the top of the source is less than the top of the destination, we copy
-    // the rows from the bottom upwards, to avoid the possibility of the source
-    // being overwritten if it were to overlap the destination range.
-    if (srcRect.top < dstRect.top)
+    struct StagedRow
     {
-        for (auto y = srcRect.height(); y-- > 0;)
+        til::CoordType row = 0;
+        ImageSlice::Pointer slice;
+    };
+
+    std::vector<StagedRow> stagedRows;
+    stagedRows.reserve(srcRect.height());
+    for (auto y = 0; y < srcRect.height(); ++y)
+    {
+        const auto& srcRow = srcBuffer.GetRowByOffset(srcRect.top + y);
+        const auto& dstRow = dstBuffer.GetRowByOffset(dstRect.top + y);
+        const auto srcSlice = srcRow.GetImageSlice();
+        const auto dstExisting = dstRow.GetImageSlice();
+        auto staged = dstExisting ? std::make_unique<ImageSlice>(*dstExisting) : nullptr;
+
+        if (!srcSlice || srcRow.GetLineRendition() != dstRow.GetLineRendition() ||
+            (dstExisting && dstExisting->CellSize() != srcSlice->CellSize()))
         {
-            const auto& srcRow = srcBuffer.GetRowByOffset(srcRect.top + y);
-            auto& dstRow = dstBuffer.GetMutableRowByOffset(dstRect.top + y);
-            CopyCells(srcRow, srcRect.left, dstRow, dstRect.left, dstRect.right);
+            if (staged)
+            {
+                const auto scale = dstRow.GetLineRendition() != LineRendition::SingleWidth ? 1 : 0;
+                if (staged->_eraseCells(dstRect.left << scale, dstRect.right << scale))
+                {
+                    staged.reset();
+                }
+            }
         }
+        else
+        {
+            if (!staged)
+            {
+                staged = std::make_unique<ImageSlice>(srcSlice->CellSize());
+            }
+            const auto scale = srcRow.GetLineRendition() != LineRendition::SingleWidth ? 1 : 0;
+            if (staged->_copyCells(*srcSlice, srcRect.left << scale, dstRect.left << scale, dstRect.right << scale))
+            {
+                staged.reset();
+            }
+        }
+
+        stagedRows.push_back({ dstRect.top + y, std::move(staged) });
     }
-    else
+
+    srcBuffer.GetImages().CopyArea(srcRect, dstRect.origin(), dstBuffer.GetMutableImages());
+    for (auto& staged : stagedRows)
     {
-        for (auto y = 0; y < srcRect.height(); y++)
-        {
-            const auto& srcRow = srcBuffer.GetRowByOffset(srcRect.top + y);
-            auto& dstRow = dstBuffer.GetMutableRowByOffset(dstRect.top + y);
-            CopyCells(srcRow, srcRect.left, dstRow, dstRect.left, dstRect.right);
-        }
+        dstBuffer.GetMutableRowByOffset(staged.row).SetImageSlice(std::move(staged.slice));
     }
 }
 
@@ -383,6 +411,7 @@ bool ImageSlice::_copyCells(const ImageSlice& srcSlice, const til::CoordType src
 
 void ImageSlice::EraseBlock(TextBuffer& buffer, const til::rect rect)
 {
+    buffer.GetMutableImages().EraseArea(rect);
     for (auto y = rect.top; y < rect.bottom; y++)
     {
         auto& row = buffer.GetMutableRowByOffset(y);
@@ -392,16 +421,24 @@ void ImageSlice::EraseBlock(TextBuffer& buffer, const til::rect rect)
 
 void ImageSlice::EraseCells(TextBuffer& buffer, const til::point at, const til::CoordType distance)
 {
+    std::vector<til::rect> areas;
     auto x = at.x;
     auto y = at.y;
     auto distanceRemaining = distance;
     while (distanceRemaining > 0)
     {
-        auto& row = buffer.GetMutableRowByOffset(y);
-        EraseCells(row, x, x + distanceRemaining);
-        distanceRemaining -= (static_cast<til::CoordType>(row.size()) - x);
+        const auto& row = buffer.GetRowByOffset(y);
+        const auto available = static_cast<til::CoordType>(row.size()) - x;
+        const auto width = std::min(distanceRemaining, available);
+        areas.emplace_back(x, y, x + width, y + 1);
+        distanceRemaining -= available;
         x = 0;
         y++;
+    }
+    buffer.GetMutableImages().EraseAreas(areas);
+    for (const auto area : areas)
+    {
+        EraseCells(buffer.GetMutableRowByOffset(area.top), area.left, area.right);
     }
 }
 

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -58,6 +58,73 @@ static uint64_t imageCellRefLayerId(const ROW& row, const til::CoordType column)
     return metadata ? metadata->layerId : 0;
 }
 
+struct StagedImageRow
+{
+    til::CoordType row = 0;
+    ImageSlice::Pointer slice;
+};
+
+static std::vector<StagedImageRow> stageImageSlices(TextBuffer& buffer,
+                                                   const ImageCollection& images,
+                                                   const std::span<const ImagePlacement> previousImages)
+{
+    std::vector<ImagePlacement::Key> keys;
+    keys.reserve(previousImages.size());
+    for (const auto& image : previousImages)
+    {
+        keys.emplace_back(image.Identity());
+    }
+    std::sort(keys.begin(), keys.end(), [](const auto lhs, const auto rhs) {
+        return std::tie(lhs.imageId, lhs.layerId) < std::tie(rhs.imageId, rhs.layerId);
+    });
+    keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
+
+    std::vector<StagedImageRow> stagedRows;
+    images.PrepareRowIndex();
+    const auto height = buffer.GetSize().Height();
+    for (auto rowIndex = 0; rowIndex < height; ++rowIndex)
+    {
+        const auto placements = images.IntersectingRows(rowIndex, rowIndex + 1);
+        const auto existing = buffer.GetRowByOffset(rowIndex).GetImageSlice();
+        const auto removesPlacement = existing && std::any_of(keys.begin(), keys.end(), [&](const auto key) {
+            return existing->Contains({ key.imageId, key.layerId });
+        });
+        if (!removesPlacement && placements.empty())
+        {
+            continue;
+        }
+
+        auto staged = existing ? std::make_unique<ImageSlice>(*existing) : nullptr;
+        for (const auto key : keys)
+        {
+            if (staged && staged->Contains({ key.imageId, key.layerId }) && staged->EraseLayer({ key.imageId, key.layerId }))
+            {
+                staged.reset();
+            }
+        }
+        for (const auto placement : placements)
+        {
+            if (!staged || staged->CellSize() != placement->Geometry().cellSize)
+            {
+                auto replacement = std::make_unique<ImageSlice>(placement->Geometry().cellSize);
+                staged = std::move(replacement);
+            }
+            const auto bounds = placement->CellBounds();
+            THROW_HR_IF(E_UNEXPECTED, !placement->RasterizeRow(rowIndex, bounds.left, bounds.right, *staged));
+        }
+        stagedRows.push_back({ rowIndex, std::move(staged) });
+    }
+    return stagedRows;
+}
+
+static void commitImageSlices(TextBuffer& buffer, std::vector<StagedImageRow> stagedRows) noexcept
+{
+    for (auto& staged : stagedRows)
+    {
+        buffer.GetMutableRowByOffset(staged.row).SetImageSlice(std::move(staged.slice));
+    }
+}
+
 static std::atomic<uint64_t> s_lastMutationIdInitialValue;
 
 // Routine Description:
@@ -170,6 +237,7 @@ __declspec(noinline) void TextBuffer::_commit(const std::byte* row)
 // You can use this (or rather the Reset() method) to fully clear the TextBuffer.
 void TextBuffer::_decommit() noexcept
 {
+    _images.Clear();
     _destroy();
     VirtualFree(_buffer.get(), 0, MEM_DECOMMIT);
     _commitWatermark = _buffer.get();
@@ -576,6 +644,7 @@ void TextBuffer::Replace(til::CoordType row, const TextAttribute& attributes, Ro
     auto& r = GetMutableRowByOffset(row);
     r.ReplaceText(state);
     r.ReplaceAttributes(state.columnBegin, state.columnEnd, attributes);
+    _images.EraseArea({ state.columnBegin, row, state.columnEnd, row + 1 });
     ImageSlice::EraseCells(r, state.columnBegin, state.columnEnd);
     TriggerRedraw(Viewport::FromExclusive({ state.columnBeginDirty, row, state.columnEndDirty, row + 1 }));
 }
@@ -606,10 +675,15 @@ void TextBuffer::Insert(til::CoordType row, const TextAttribute& attributes, Row
         const auto restoreAttr = scratchAttr.slice(gsl::narrow<uint16_t>(state.columnBegin), gsl::narrow<uint16_t>(state.columnBegin + copyAmount));
         rowAttr.replace(gsl::narrow<uint16_t>(restoreState.columnBegin), gsl::narrow<uint16_t>(restoreState.columnEnd), restoreAttr);
         r.CopyImageCellRefs(scratch, state.columnBegin, restoreState.columnBegin, restoreState.columnEnd);
+        _images.CopyArea(
+            { state.columnBegin, row, state.columnBegin + copyAmount, row + 1 },
+            { restoreState.columnBegin, row },
+            _images);
         // If there is any image content, that needs to be copied too.
         ImageSlice::CopyCells(r, state.columnBegin, r, restoreState.columnBegin, restoreState.columnEnd);
     }
     // Image content at the insert position needs to be erased.
+    _images.EraseArea({ state.columnBegin, row, restoreState.columnBegin, row + 1 });
     ImageSlice::EraseCells(r, state.columnBegin, restoreState.columnBegin);
 
     TriggerRedraw(Viewport::FromExclusive({ state.columnBeginDirty, row, restoreState.columnEndDirty, row + 1 }));
@@ -622,6 +696,8 @@ void TextBuffer::FillRect(const til::rect& rect, const std::wstring_view& fill, 
     {
         return;
     }
+
+    _images.EraseArea(rect);
 
     auto& scratchpad = GetScratchpadRow(attributes);
 
@@ -766,6 +842,8 @@ void TextBuffer::IncrementCircularBuffer(const TextAttribute& fillAttributes)
     // Prune hyperlinks to delete obsolete references
     _PruneHyperlinks();
 
+    _images.AdvanceRows(1, _height);
+
     // Second, clean out the old "first row" as it will become the "last row" of the buffer after the circle is performed.
     GetMutableRowByOffset(0).Reset(fillAttributes);
     {
@@ -841,6 +919,11 @@ void TextBuffer::_SetFirstRowIndex(const til::CoordType FirstRowIndex) noexcept
 
 void TextBuffer::ScrollRows(const til::CoordType firstRow, til::CoordType size, const til::CoordType delta)
 {
+    _scrollRows(firstRow, size, delta, true);
+}
+
+void TextBuffer::_scrollRows(const til::CoordType firstRow, til::CoordType size, const til::CoordType delta, const bool copyImages)
+{
     if (delta == 0)
     {
         return;
@@ -905,16 +988,38 @@ void TextBuffer::ScrollRows(const til::CoordType firstRow, til::CoordType size, 
 
     for (; y != end; y += step)
     {
-        CopyRow(y, y + delta, *this);
+        if (copyImages)
+        {
+            CopyRow(y, y + delta, *this);
+        }
+        else
+        {
+            _copyRowData(y, y + delta, *this);
+        }
     }
 }
 
 void TextBuffer::CopyRow(const til::CoordType srcRowIndex, const til::CoordType dstRowIndex, TextBuffer& dstBuffer) const
 {
+    const auto width = std::min<til::CoordType>(_width, dstBuffer._width);
+    _images.CopyArea(
+        { 0, srcRowIndex, width, srcRowIndex + 1 },
+        { 0, dstRowIndex },
+        dstBuffer._images);
+    _copyRowData(srcRowIndex, dstRowIndex, dstBuffer);
+}
+
+void TextBuffer::_copyRowData(const til::CoordType srcRowIndex, const til::CoordType dstRowIndex, TextBuffer& dstBuffer) const
+{
     auto& dstRow = dstBuffer.GetMutableRowByOffset(dstRowIndex);
     const auto& srcRow = GetRowByOffset(srcRowIndex);
     dstRow.CopyFrom(srcRow);
     ImageSlice::CopyRow(srcRow, dstRow);
+}
+
+void TextBuffer::_rebuildImageSlices(const std::span<const ImagePlacement> previousImages)
+{
+    commitImageSlices(*this, stageImageSlices(*this, _images, previousImages));
 }
 
 Cursor& TextBuffer::GetCursor() noexcept
@@ -954,6 +1059,7 @@ void TextBuffer::SetCurrentLineRendition(const LineRendition lineRendition, cons
     auto& row = GetMutableRowByOffset(rowIndex);
     if (row.GetLineRendition() != lineRendition)
     {
+        _images.EraseArea({ 0, rowIndex, _width, rowIndex + 1 });
         row.SetLineRendition(lineRendition);
         // If the line rendition has changed, the row can no longer be wrapped.
         row.SetWrapForced(false);
@@ -1046,6 +1152,13 @@ void TextBuffer::ClearScrollback(const til::CoordType newFirstRow, const til::Co
         return;
     }
 
+    ImageCollection retainedImages;
+    _images.CopyArea(
+        { 0, newFirstRow, _width, newFirstRow + rowsToKeep },
+        {},
+        retainedImages);
+    retainedImages.ClipArea({ 0, 0, _width, rowsToKeep });
+
     ClearMarksInRange(til::point{ 0, 0 }, til::point{ _width, std::max(0, newFirstRow - 1) });
 
     // Our goal is to move the viewport to the absolute start of the underlying memory buffer so that we can
@@ -1056,13 +1169,14 @@ void TextBuffer::ClearScrollback(const til::CoordType newFirstRow, const til::Co
     // operates modulo the buffer height and so the possibly-too-large startAbsolute won't be an issue.
     const auto startAbsolute = _firstRow + newFirstRow;
     _firstRow = 0;
-    ScrollRows(startAbsolute, rowsToKeep, -startAbsolute);
+    _scrollRows(startAbsolute, rowsToKeep, -startAbsolute, false);
 
     const auto end = _estimateOffsetOfLastCommittedRow();
     for (auto y = rowsToKeep; y <= end; ++y)
     {
         GetMutableRowByOffset(y).Reset(_initialAttributes);
     }
+    _images = std::move(retainedImages);
 }
 
 // Routine Description:
@@ -1078,6 +1192,7 @@ void TextBuffer::ResizeTraditional(til::size newSize)
     newSize.height = std::max(newSize.height, 1);
 
     TextBuffer newBuffer{ newSize, _currentAttributes, 0, false, _renderer };
+    const auto oldImages = _images.All();
     const auto cursorRow = GetCursor().GetPosition().y;
     const auto copyableRows = std::min<til::CoordType>(_height, newSize.height);
     til::CoordType srcRow = 0;
@@ -1092,8 +1207,11 @@ void TextBuffer::ResizeTraditional(til::size newSize)
     {
         CopyRow(srcRow, dstRow, newBuffer);
     }
+    newBuffer._images.ClipArea({ 0, 0, newSize.width, newSize.height });
+    newBuffer._rebuildImageSlices(oldImages);
 
     // NOTE: Keep this in sync with _reserve().
+    _images = std::move(newBuffer._images);
     _buffer = std::move(newBuffer._buffer);
     _bufferEnd = newBuffer._bufferEnd;
     _commitWatermark = newBuffer._commitWatermark;
@@ -2755,6 +2873,7 @@ void TextBuffer::Reflow(TextBuffer& oldBuffer, TextBuffer& newBuffer, const View
 {
     const auto& oldCursor = oldBuffer.GetCursor();
     auto& newCursor = newBuffer.GetCursor();
+    const auto oldImages = oldBuffer._images.All();
 
     til::point oldCursorPos = oldCursor.GetPosition();
     til::point newCursorPos;
@@ -2779,7 +2898,12 @@ void TextBuffer::Reflow(TextBuffer& oldBuffer, TextBuffer& newBuffer, const View
     til::CoordType newWidth = newBuffer.GetSize().Width();
     til::CoordType newYLimit = til::CoordTypeMax;
 
-    const auto oldHeight = std::max(lastRowWithText, oldCursorPos.y) + 1;
+    auto imageRowsEnd = til::CoordType{ 0 };
+    for (const auto& image : oldImages)
+    {
+        imageRowsEnd = std::max(imageRowsEnd, std::clamp(image.CellBounds().bottom, til::CoordType{ 0 }, static_cast<til::CoordType>(oldBuffer._height)));
+    }
+    const auto oldHeight = std::max(std::max(lastRowWithText, oldCursorPos.y) + 1, imageRowsEnd);
     const auto newHeight = newBuffer.GetSize().Height();
     const auto newWidthU16 = gsl::narrow_cast<uint16_t>(newWidth);
 
@@ -2791,6 +2915,12 @@ void TextBuffer::Reflow(TextBuffer& oldBuffer, TextBuffer& newBuffer, const View
         uint64_t layerId = 0;
     };
     std::vector<ImageCellMove> imageCellMoves;
+    struct ImageSegmentMove
+    {
+        til::rect source;
+        til::point destination;
+    };
+    std::vector<ImageSegmentMove> imageSegmentMoves;
 
     // Copy oldBuffer into newBuffer until oldBuffer has been fully consumed.
     for (; oldY < oldHeight && newY < newYLimit; ++oldY)
@@ -2820,6 +2950,30 @@ void TextBuffer::Reflow(TextBuffer& oldBuffer, TextBuffer& newBuffer, const View
 
             newRow.CopyFrom(oldRow);
             newRow.SetWrapForced(false);
+            const auto copiedColumns = std::min(oldRow.GetReadableColumnCount(), newRow.GetReadableColumnCount());
+            if (copiedColumns > 0)
+            {
+                imageSegmentMoves.push_back({
+                    .source = { 0, oldY, copiedColumns, oldY + 1 },
+                    .destination = { 0, newY },
+                });
+            }
+            for (auto column = 0; column < copiedColumns; ++column)
+            {
+                if (oldRow.GetImageCellRef(column))
+                {
+                    const auto layerId = imageCellRefLayerId(oldRow, column);
+                    if (layerId != 0)
+                    {
+                        imageCellMoves.push_back({
+                            .source = { column, oldY },
+                            .destination = { column, newY },
+                            .imageId = imageCellRefImageId(oldRow, column),
+                            .layerId = layerId,
+                        });
+                    }
+                }
+            }
 
             if (oldY == oldCursorPos.y)
             {
@@ -2843,6 +2997,10 @@ void TextBuffer::Reflow(TextBuffer& oldBuffer, TextBuffer& newBuffer, const View
         // Rows don't store any information for what column the last written character is in.
         // We simply truncate all trailing whitespace in this implementation.
         auto oldRowLimit = oldRow.MeasureRight();
+        for (const auto placement : oldBuffer._images.IntersectingRows(oldY, oldY + 1))
+        {
+            oldRowLimit = std::max(oldRowLimit, std::min(placement->CellBounds().right, oldRow.GetReadableColumnCount()));
+        }
         if (oldY == oldCursorPos.y)
         {
             // REFLOW_JANK_CURSOR_WRAP:
@@ -2937,7 +3095,17 @@ void TextBuffer::Reflow(TextBuffer& oldBuffer, TextBuffer& newBuffer, const View
                 }
             }
 
-            for (auto sourceColumn = oldX; sourceColumn < state.sourceColumnEnd; ++sourceColumn)
+            const auto mappedColumns = std::min(state.sourceColumnEnd - oldX, state.columnEnd - newX);
+            const auto mappedSourceEnd = oldX + std::max(mappedColumns, til::CoordType{ 0 });
+            if (mappedSourceEnd > oldX)
+            {
+                imageSegmentMoves.push_back({
+                    .source = { oldX, oldY, mappedSourceEnd, oldY + 1 },
+                    .destination = { newX, newY },
+                });
+            }
+
+            for (auto sourceColumn = oldX; sourceColumn < mappedSourceEnd; ++sourceColumn)
             {
                 if (oldRow.GetImageCellRef(sourceColumn))
                 {
@@ -3046,6 +3214,105 @@ void TextBuffer::Reflow(TextBuffer& oldBuffer, TextBuffer& newBuffer, const View
         newCursorPos.y = (newCursorPos.y - newBuffer._firstRow + newHeight) % newHeight;
     }
 
+    const auto firstRetainedRow = newY > newHeight ? newY - newHeight : 0;
+    const til::rect newBounds{ 0, 0, newWidth, newHeight };
+    const auto finalDestination = [&](const til::point destination) -> std::optional<til::point> {
+        if (destination.x < 0 || destination.x >= newWidth ||
+            destination.y < firstRetainedRow || destination.y >= firstRetainedRow + newHeight)
+        {
+            return std::nullopt;
+        }
+        return til::point{ destination.x, destination.y - firstRetainedRow };
+    };
+
+    std::vector<ImagePlacement::Key> placeholderKeys;
+    placeholderKeys.reserve(imageCellMoves.size());
+    for (const auto& move : imageCellMoves)
+    {
+        placeholderKeys.push_back({ move.imageId, move.layerId });
+    }
+    std::sort(placeholderKeys.begin(), placeholderKeys.end(), [](const auto lhs, const auto rhs) {
+        return std::tie(lhs.imageId, lhs.layerId) < std::tie(rhs.imageId, rhs.layerId);
+    });
+    placeholderKeys.erase(std::unique(placeholderKeys.begin(), placeholderKeys.end()), placeholderKeys.end());
+    const auto isPlaceholder = [&](const ImagePlacement::Key key) {
+        return std::binary_search(placeholderKeys.begin(), placeholderKeys.end(), key, [](const auto lhs, const auto rhs) {
+            return std::tie(lhs.imageId, lhs.layerId) < std::tie(rhs.imageId, rhs.layerId);
+        });
+    };
+
+    ImageCollection reflowedImages;
+    // Direct placements follow the exact source-cell segments copied by reflow.
+    // Wrapping can split one rectangle into multiple fragments with the same key.
+    for (const auto& move : imageSegmentMoves)
+    {
+        const auto destination = finalDestination(move.destination);
+        if (!destination)
+        {
+            continue;
+        }
+
+        for (const auto placement : oldBuffer._images.IntersectingRows(move.source.top, move.source.bottom))
+        {
+            if (isPlaceholder(placement->Identity()))
+            {
+                continue;
+            }
+
+            if (auto sourceFragment = placement->Crop(move.source))
+            {
+                const auto translated = sourceFragment->Translated(*destination - move.source.origin());
+                if (auto clipped = translated.Crop(newBounds))
+                {
+                    reflowedImages.Add(std::move(*clipped));
+                }
+            }
+        }
+    }
+
+    // Placeholder-backed fragments follow the exact text-cell move. Cropping
+    // the old one-cell fragment before translating retains its source-grid
+    // identity and original sampling transform.
+    for (const auto& move : imageCellMoves)
+    {
+        const auto destination = finalDestination(move.destination);
+        if (!destination)
+        {
+            continue;
+        }
+
+        const auto& destinationRow = newBuffer.GetRowByOffset(destination->y);
+        if (!destinationRow.GetImageCellRef(destination->x) ||
+            imageCellRefImageId(destinationRow, destination->x) != move.imageId ||
+            imageCellRefLayerId(destinationRow, destination->x) != move.layerId)
+        {
+            continue;
+        }
+
+        for (const auto placement : oldBuffer._images.IntersectingRows(move.source.y, move.source.y + 1))
+        {
+            const auto bounds = placement->CellBounds();
+            if (placement->Identity() != ImagePlacement::Key{ move.imageId, move.layerId } ||
+                move.source.x < bounds.left || move.source.x >= bounds.right)
+            {
+                continue;
+            }
+
+            if (auto sourceFragment = placement->Crop({ move.source.x, move.source.y, move.source.x + 1, move.source.y + 1 }))
+            {
+                auto translated = sourceFragment->Translated(*destination - move.source);
+                if (auto clipped = translated.Crop(newBounds))
+                {
+                    reflowedImages.Add(std::move(*clipped));
+                }
+            }
+            break;
+        }
+    }
+
+    auto stagedImageRows = stageImageSlices(newBuffer, reflowedImages, oldImages);
+    newBuffer._images = std::move(reflowedImages);
+    commitImageSlices(newBuffer, std::move(stagedImageRows));
     newBuffer.CopyProperties(oldBuffer);
     newBuffer.CopyHyperlinkMaps(oldBuffer);
 

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -326,6 +326,9 @@ private:
     ROW& _getRow(til::CoordType y) const;
     til::CoordType _estimateOffsetOfLastCommittedRow() const noexcept;
     bool _isRowCommitted(til::CoordType y) const noexcept;
+    void _copyRowData(til::CoordType srcRow, til::CoordType dstRow, TextBuffer& dstBuffer) const;
+    void _scrollRows(til::CoordType firstRow, til::CoordType size, til::CoordType delta, bool copyImages);
+    void _rebuildImageSlices(std::span<const ImagePlacement> previousImages);
 
     void _SetFirstRowIndex(const til::CoordType FirstRowIndex) noexcept;
     void _ExpandTextRow(til::inclusive_rect& selectionRow) const;

--- a/src/buffer/out/ut_textbuffer/ImageTests.cpp
+++ b/src/buffer/out/ut_textbuffer/ImageTests.cpp
@@ -26,6 +26,12 @@ class ImageTests
     TEST_METHOD(BatchSurfaceUpdateResamplesMultipleImages);
     TEST_METHOD(RasterizeUsesCropScaleAndOffset);
     TEST_METHOD(TextBufferOwnsImagesOutsideRows);
+    TEST_METHOD(CircularAndRegionalScrollUseLogicalRows);
+    TEST_METHOD(RectangularCopyAndErasePreserveSampling);
+    TEST_METHOD(CrossBufferBlankCopyErasesPlacement);
+    TEST_METHOD(TraditionalResizeClipsAndRetainsImages);
+    TEST_METHOD(ResizeRebuildHandlesMixedCellSizes);
+    TEST_METHOD(ReflowAppliesDirectPlacementPolicy);
 
     static constexpr til::size CellSize{ 2, 3 };
 
@@ -53,6 +59,22 @@ class ImageTests
                 .targetHeight = gsl::narrow_cast<uint64_t>(bounds.height() * CellSize.height),
             },
         };
+    }
+
+    static void AddPlacement(TextBuffer& buffer, ImagePlacement placement)
+    {
+        const auto bounds = placement.CellBounds() & buffer.GetSize().ToExclusive();
+        for (auto rowIndex = bounds.top; rowIndex < bounds.bottom; ++rowIndex)
+        {
+            auto& row = buffer.GetMutableRowByOffset(rowIndex);
+            auto slice = row.GetMutableImageSlice();
+            if (!slice)
+            {
+                slice = row.SetImageSlice(std::make_unique<ImageSlice>(placement.Geometry().cellSize));
+            }
+            THROW_HR_IF(E_UNEXPECTED, !placement.RasterizeRow(rowIndex, bounds.left, bounds.right, *slice));
+        }
+        buffer.GetMutableImages().Add(std::move(placement));
     }
 };
 
@@ -245,4 +267,226 @@ void ImageTests::TextBufferOwnsImagesOutsideRows()
 
     VERIFY_ARE_EQUAL(size_t{ 1 }, buffer.GetImages().Size());
     VERIFY_IS_NULL(buffer.GetRowByOffset(0).GetImageSlice());
+}
+
+void ImageTests::CircularAndRegionalScrollUseLogicalRows()
+{
+    DummyRenderer renderer;
+    TextBuffer buffer{ til::size{ 8, 4 }, TextAttribute{}, 0, false, &renderer };
+    auto placement = MakePlacement({ 1, 1 }, { 1, 0, 5, 3 });
+    const auto surface = placement.SurfacePointer();
+    AddPlacement(buffer, std::move(placement));
+
+    buffer.IncrementCircularBuffer(TextAttribute{});
+
+    VERIFY_ARE_EQUAL(uint64_t{ 1 }, buffer.GetImages().RowEpoch());
+    VERIFY_ARE_EQUAL(size_t{ 1 }, buffer.GetImages().Size());
+    const til::rect afterCircularBounds{ 1, 0, 5, 2 };
+    const til::rect afterCircularOriginal{ 1, -1, 5, 2 };
+    VERIFY_ARE_EQUAL(afterCircularBounds, buffer.GetImages().All()[0].CellBounds());
+    VERIFY_ARE_EQUAL(afterCircularOriginal, buffer.GetImages().All()[0].OriginalCellBounds());
+
+    buffer.ScrollRows(0, 1, 1);
+
+    VERIFY_ARE_EQUAL(size_t{ 2 }, buffer.GetImages().Size());
+    for (const auto& fragment : buffer.GetImages().All())
+    {
+        VERIFY_ARE_EQUAL(surface.get(), fragment.SurfacePointer().get());
+    }
+    const auto* copiedRow = buffer.GetRowByOffset(1).GetImageSlice();
+    VERIFY_IS_NOT_NULL(copiedRow);
+    VERIFY_ARE_EQUAL(1u, copiedRow->ColumnOwner(2));
+
+    buffer.IncrementCircularBuffer(TextAttribute{});
+
+    VERIFY_ARE_EQUAL(uint64_t{ 2 }, buffer.GetImages().RowEpoch());
+    VERIFY_ARE_EQUAL(size_t{ 1 }, buffer.GetImages().Size());
+    const til::rect finalBounds{ 1, 0, 5, 1 };
+    const til::rect finalOriginal{ 1, -1, 5, 2 };
+    VERIFY_ARE_EQUAL(finalBounds, buffer.GetImages().All()[0].CellBounds());
+    VERIFY_ARE_EQUAL(finalOriginal, buffer.GetImages().All()[0].OriginalCellBounds());
+    VERIFY_ARE_EQUAL(surface.get(), buffer.GetImages().All()[0].SurfacePointer().get());
+
+    buffer.IncrementCircularBuffer(TextAttribute{});
+    VERIFY_IS_TRUE(buffer.GetImages().Empty());
+}
+
+void ImageTests::RectangularCopyAndErasePreserveSampling()
+{
+    DummyRenderer renderer;
+    TextBuffer buffer{ til::size{ 10, 4 }, TextAttribute{}, 0, false, &renderer };
+    auto placement = MakePlacement({ 1, 1 }, { 1, 0, 6, 3 });
+    const auto surface = placement.SurfacePointer();
+    AddPlacement(buffer, std::move(placement));
+
+    ImageSlice::CopyBlock(buffer, { 2, 1, 5, 3 }, buffer, { 6, 0, 9, 2 });
+
+    VERIFY_ARE_EQUAL(size_t{ 2 }, buffer.GetImages().Size());
+    const til::rect copiedBounds{ 6, 0, 9, 2 };
+    const til::rect copiedOriginal{ 5, -1, 10, 2 };
+    auto foundCopy = false;
+    for (const auto& fragment : buffer.GetImages().All())
+    {
+        if (fragment.CellBounds() == copiedBounds)
+        {
+            foundCopy = true;
+            VERIFY_ARE_EQUAL(copiedOriginal, fragment.OriginalCellBounds());
+            VERIFY_ARE_EQUAL(surface.get(), fragment.SurfacePointer().get());
+        }
+    }
+    VERIFY_IS_TRUE(foundCopy);
+    VERIFY_ARE_EQUAL(1u, buffer.GetRowByOffset(0).GetImageSlice()->ColumnOwner(7));
+    VERIFY_ARE_EQUAL(1u, buffer.GetRowByOffset(1).GetImageSlice()->ColumnOwner(7));
+
+    ImageSlice::EraseBlock(buffer, { 7, 0, 8, 2 });
+
+    VERIFY_ARE_EQUAL(size_t{ 3 }, buffer.GetImages().Size());
+    for (const auto& fragment : buffer.GetImages().All())
+    {
+        VERIFY_ARE_EQUAL(surface.get(), fragment.SurfacePointer().get());
+        if (fragment.CellBounds().left >= 6)
+        {
+            VERIFY_ARE_EQUAL(copiedOriginal, fragment.OriginalCellBounds());
+        }
+        VERIFY_IS_TRUE((fragment.CellBounds() & til::rect{ 7, 0, 8, 2 }).empty());
+    }
+    for (auto rowIndex = 0; rowIndex < 2; ++rowIndex)
+    {
+        const auto* slice = buffer.GetRowByOffset(rowIndex).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(6));
+        VERIFY_ARE_EQUAL(0u, slice->ColumnOwner(7));
+        VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(8));
+    }
+}
+
+void ImageTests::CrossBufferBlankCopyErasesPlacement()
+{
+    DummyRenderer renderer;
+    TextBuffer source{ til::size{ 8, 2 }, TextAttribute{}, 0, false, &renderer };
+    TextBuffer destination{ til::size{ 8, 2 }, TextAttribute{}, 0, false, &renderer };
+    AddPlacement(destination, MakePlacement({ 1, 1 }, { 1, 0, 4, 1 }));
+
+    source.CopyRow(0, 0, destination);
+
+    VERIFY_IS_TRUE(destination.GetImages().Empty());
+    VERIFY_IS_NULL(destination.GetRowByOffset(0).GetImageSlice());
+}
+
+void ImageTests::TraditionalResizeClipsAndRetainsImages()
+{
+    DummyRenderer renderer;
+    TextBuffer buffer{ til::size{ 8, 4 }, TextAttribute{}, 0, false, &renderer };
+    auto placement = MakePlacement({ 1, 1 }, { 4, 1, 8, 4 });
+    const auto surface = placement.SurfacePointer();
+    AddPlacement(buffer, std::move(placement));
+
+    buffer.ResizeTraditional({ 6, 3 });
+
+    VERIFY_ARE_EQUAL(size_t{ 2 }, buffer.GetImages().Size());
+    const til::rect originalBounds{ 4, 1, 8, 4 };
+    size_t coveredArea = 0;
+    for (const auto& fragment : buffer.GetImages().All())
+    {
+        VERIFY_ARE_EQUAL(originalBounds, fragment.OriginalCellBounds());
+        VERIFY_ARE_EQUAL(surface.get(), fragment.SurfacePointer().get());
+        coveredArea += static_cast<size_t>(fragment.CellBounds().width()) * fragment.CellBounds().height();
+    }
+    VERIFY_ARE_EQUAL(size_t{ 4 }, coveredArea);
+    VERIFY_IS_NULL(buffer.GetRowByOffset(0).GetImageSlice());
+    for (auto rowIndex = 1; rowIndex < 3; ++rowIndex)
+    {
+        const auto* slice = buffer.GetRowByOffset(rowIndex).GetImageSlice();
+        VERIFY_IS_NOT_NULL(slice);
+        VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(4));
+        VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(5));
+        VERIFY_ARE_EQUAL(0u, slice->ColumnOwner(6));
+    }
+}
+
+void ImageTests::ResizeRebuildHandlesMixedCellSizes()
+{
+    DummyRenderer renderer;
+    TextBuffer buffer{ til::size{ 8, 2 }, TextAttribute{}, 0, false, &renderer };
+    buffer.GetMutableImages().Add(MakePlacement({ 1, 1 }, { 0, 0, 2, 1 }, -1));
+
+    const til::size smallCell{ 1, 1 };
+    auto smallSurface = std::make_shared<Image>(til::size{ 2, 1 }, std::vector<RGBQUAD>(2));
+    buffer.GetMutableImages().Add(ImagePlacement{
+        { 2, 2 },
+        std::move(smallSurface),
+        { 0, 0, 2, 1 },
+        1,
+        {},
+        {
+            .cellSize = smallCell,
+            .targetWidth = 2,
+            .targetHeight = 1,
+        },
+    });
+
+    buffer.ResizeTraditional({ 6, 2 });
+
+    VERIFY_ARE_EQUAL(size_t{ 2 }, buffer.GetImages().Size());
+    const auto* slice = buffer.GetRowByOffset(0).GetImageSlice();
+    VERIFY_IS_NOT_NULL(slice);
+    VERIFY_ARE_EQUAL(smallCell, slice->CellSize());
+    VERIFY_IS_FALSE(slice->Contains({ 1, 1 }));
+    VERIFY_IS_TRUE(slice->Contains({ 2, 2 }));
+}
+
+void ImageTests::ReflowAppliesDirectPlacementPolicy()
+{
+    DummyRenderer renderer;
+    TextBuffer buffer{ til::size{ 8, 6 }, TextAttribute{}, 0, false, &renderer };
+    RowWriteState firstRow{ .text = L"ABCDEFGH" };
+    buffer.Replace(0, TextAttribute{}, firstRow);
+    buffer.SetWrapForced(0, true);
+    RowWriteState secondRow{ .text = L"IJ" };
+    buffer.Replace(1, TextAttribute{}, secondRow);
+    buffer.GetCursor().SetPosition({ 1, 1 });
+
+    auto wrappedPlacement = MakePlacement({ 1, 1 }, { 2, 0, 6, 2 });
+    const auto wrappedSurface = wrappedPlacement.SurfacePointer();
+    AddPlacement(buffer, std::move(wrappedPlacement));
+    auto imageOnlyPlacement = MakePlacement({ 2, 2 }, { 0, 4, 1, 5 });
+    const auto imageOnlySurface = imageOnlyPlacement.SurfacePointer();
+    AddPlacement(buffer, std::move(imageOnlyPlacement));
+
+    TextBuffer reflowed{ til::size{ 4, 8 }, TextAttribute{}, 0, false, &renderer };
+    TextBuffer::Reflow(buffer, reflowed);
+
+    VERIFY_ARE_EQUAL(size_t{ 5 }, reflowed.GetImages().Size());
+    auto foundFirstSegment = false;
+    auto foundFirstWrappedSegment = false;
+    auto foundSecondSegment = false;
+    auto foundSecondWrappedSegment = false;
+    auto foundImageOnlyRow = false;
+    for (const auto& fragment : reflowed.GetImages().All())
+    {
+        if (fragment.Identity() == ImagePlacement::Key{ 1, 1 })
+        {
+            VERIFY_ARE_EQUAL(wrappedSurface.get(), fragment.SurfacePointer().get());
+            foundFirstSegment |= fragment.CellBounds() == til::rect{ 2, 0, 4, 1 };
+            foundFirstWrappedSegment |= fragment.CellBounds() == til::rect{ 0, 1, 2, 2 };
+            foundSecondSegment |= fragment.CellBounds() == til::rect{ 2, 2, 4, 3 };
+            foundSecondWrappedSegment |= fragment.CellBounds() == til::rect{ 0, 3, 2, 4 };
+        }
+        else if (fragment.Identity() == ImagePlacement::Key{ 2, 2 })
+        {
+            VERIFY_ARE_EQUAL(imageOnlySurface.get(), fragment.SurfacePointer().get());
+            foundImageOnlyRow |= fragment.CellBounds() == til::rect{ 0, 6, 1, 7 };
+        }
+    }
+
+    VERIFY_IS_TRUE(foundFirstSegment, L"the first source segment follows its exact destination cells");
+    VERIFY_IS_TRUE(foundFirstWrappedSegment, L"the wrapped part of the first source row becomes a distinct fragment");
+    VERIFY_IS_TRUE(foundSecondSegment, L"the joined source row follows its first destination segment");
+    VERIFY_IS_TRUE(foundSecondWrappedSegment, L"the joined source row also fragments when it wraps");
+    VERIFY_IS_TRUE(foundImageOnlyRow, L"an image-only source row participates in reflow");
+    VERIFY_ARE_EQUAL(1u, reflowed.GetRowByOffset(0).GetImageSlice()->ColumnOwner(2));
+    VERIFY_ARE_EQUAL(1u, reflowed.GetRowByOffset(1).GetImageSlice()->ColumnOwner(0));
+    VERIFY_ARE_EQUAL(1u, reflowed.GetRowByOffset(2).GetImageSlice()->ColumnOwner(2));
+    VERIFY_ARE_EQUAL(1u, reflowed.GetRowByOffset(3).GetImageSlice()->ColumnOwner(0));
+    VERIFY_ARE_EQUAL(2u, reflowed.GetRowByOffset(6).GetImageSlice()->ColumnOwner(0));
 }

--- a/src/terminal/adapter/KittyParser.cpp
+++ b/src/terminal/adapter/KittyParser.cpp
@@ -3827,12 +3827,11 @@ bool KittyParser::_placeImageCellRef(const Image& image, const uint32_t imageId,
         LOG_HR(E_OUTOFMEMORY);
         return false;
     }
-    auto& dstRow = buffer.GetMutableRowByOffset(row);
-    auto dstSlice = dstRow.GetMutableImageSlice();
-    if (!dstSlice || dstSlice->CellSize() != clampedCellSize)
-    {
-        dstSlice = dstRow.SetImageSlice(std::make_unique<ImageSlice>(clampedCellSize));
-    }
+
+    auto stagedSlice = existingSlice && existingSlice->CellSize() == clampedCellSize ?
+                           std::make_unique<ImageSlice>(*existingSlice) :
+                           std::make_unique<ImageSlice>(clampedCellSize);
+    auto dstSlice = stagedSlice.get();
     auto dstIterator = dstSlice->MutablePixels(column, column + 1, { imageId, place.layerId }, place.zIndex);
     auto sourceIterator = dstSlice->MutableSourceIndices(column, column + 1, { imageId, place.layerId }, place.zIndex);
     for (auto pixelRow = 0; pixelRow < cellHeight; ++pixelRow)
@@ -3863,6 +3862,43 @@ bool KittyParser::_placeImageCellRef(const Image& image, const uint32_t imageId,
             std::advance(sourceIterator, dstSlice->PixelWidth());
         }
     }
+
+    auto surface = image.surface;
+    const auto newSurface = !surface;
+    if (newSurface)
+    {
+        surface = std::make_shared<::Image>(
+            til::size{ gsl::narrow_cast<til::CoordType>(image.width), gsl::narrow_cast<til::CoordType>(image.height) },
+            *framePixels);
+    }
+
+    const auto originalLeft = gsl::narrow<til::CoordType>(static_cast<int64_t>(column) - cellCol);
+    const auto originalTop = gsl::narrow<til::CoordType>(static_cast<int64_t>(row) - cellRow);
+    const til::rect originalBounds{
+        originalLeft,
+        originalTop,
+        gsl::narrow<til::CoordType>(static_cast<int64_t>(originalLeft) + gridCols),
+        gsl::narrow<til::CoordType>(static_cast<int64_t>(originalTop) + gridRows),
+    };
+    auto fragment = ImagePlacement::FromFragment(
+        { imageId, place.layerId },
+        surface,
+        { column, row, column + 1, row + 1 },
+        originalBounds,
+        place.zIndex,
+        { cropX, cropY, cropX + cropW, cropY + cropH },
+        {
+            .cellSize = clampedCellSize,
+            .targetWidth = gsl::narrow_cast<uint64_t>(targetW),
+            .targetHeight = gsl::narrow_cast<uint64_t>(targetH),
+        }
+    );
+    buffer.GetMutableImages().AddOrReplaceArea(std::move(fragment));
+    if (newSurface)
+    {
+        image.surface = std::move(surface);
+    }
+    buffer.GetMutableRowByOffset(row).SetImageSlice(std::move(stagedSlice));
     return true;
 }
 

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -886,21 +886,26 @@ void AdaptDispatch::_SelectiveEraseRect(const Page& page, const til::rect& erase
 {
     if (eraseRect)
     {
+        std::vector<til::rect> areas;
         for (auto row = eraseRect.top; row < eraseRect.bottom; row++)
         {
-            auto& rowBuffer = page.Buffer().GetMutableRowByOffset(row);
+            const auto& rowBuffer = page.Buffer().GetRowByOffset(row);
             for (auto col = eraseRect.left; col < eraseRect.right; col++)
             {
-                // Only unprotected cells are affected.
                 if (!rowBuffer.GetAttrByColumn(col).IsProtected())
                 {
-                    // The text is cleared but the attributes are left as is.
-                    rowBuffer.ClearCell(col);
-                    // Any image content also needs to be erased.
-                    ImageSlice::EraseCells(rowBuffer, col, col + 1);
-                    page.Buffer().TriggerRedraw(Viewport::FromDimensions({ col, row }, { 1, 1 }));
+                    areas.emplace_back(col, row, col + 1, row + 1);
                 }
             }
+        }
+
+        page.Buffer().GetMutableImages().EraseAreas(areas);
+        for (const auto area : areas)
+        {
+            auto& rowBuffer = page.Buffer().GetMutableRowByOffset(area.top);
+            rowBuffer.ClearCell(area.left);
+            ImageSlice::EraseCells(rowBuffer, area.left, area.right);
+            page.Buffer().TriggerRedraw(Viewport::FromDimensions(area.origin(), { 1, 1 }));
         }
     }
 }

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -7175,6 +7175,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,U=1,i=1,f=24,s=2,v=2,c=2,r=2;/wAAAP8AAAD/////\x1b\\");
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m");
         _stateMachine->ProcessString(Placeholder() + L"\x030D" + L"\x0305"); // (1,0) blue
+        const auto surface = buffer.GetImages().All()[0].SurfacePointer();
 
         buffer.ScrollRows(origin.y, 1, 1);
         buffer.GetCursor().SetPosition({ 10, origin.y + 2 });
@@ -7185,6 +7186,22 @@ public:
         const auto* slice = buffer.GetRowByOffset(origin.y + 1).GetImageSlice();
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 0, 0, 255), L"the explicit blue cell moved with the row");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 255, 255, 255), L"the moved metadata resolves the adjacent omission as (1,1) white");
+        const auto* metadata = buffer.GetRowByOffset(origin.y + 1).GetImageCellRef(origin.x);
+        VERIFY_IS_NOT_NULL(metadata);
+        const til::rect expectedOriginal{ origin.x, origin.y, origin.x + 2, origin.y + 2 };
+        auto movedFragments = size_t{ 0 };
+        for (const auto& fragment : buffer.GetImages().All())
+        {
+            const auto bounds = fragment.CellBounds();
+            if (fragment.Identity() == ImagePlacement::Key{ 1, metadata->layerId } &&
+                bounds.top == origin.y + 1 && bounds.left >= origin.x && bounds.right <= origin.x + 2)
+            {
+                ++movedFragments;
+                VERIFY_ARE_EQUAL(expectedOriginal, fragment.OriginalCellBounds());
+                VERIFY_ARE_EQUAL(surface.get(), fragment.SurfacePointer().get());
+            }
+        }
+        VERIFY_ARE_EQUAL(size_t{ 2 }, movedFragments, L"the collection follows both moved placeholder cells");
     }
 
     // ICH moves cells horizontally through AdaptDispatch's cell-walking scroll path. The image
@@ -7239,6 +7256,21 @@ public:
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 0, 0, 255), L"the explicit blue cell moved down with the partial-width scroll");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 255, 255, 255), L"the adjacent omission inherits (1,1) white after the move");
+        const auto* metadata = buffer.GetRowByOffset(origin.y + 1).GetImageCellRef(origin.x);
+        VERIFY_IS_NOT_NULL(metadata);
+        const til::rect expectedOriginal{ origin.x, origin.y, origin.x + 2, origin.y + 2 };
+        auto movedFragments = size_t{ 0 };
+        for (const auto& fragment : buffer.GetImages().All())
+        {
+            const auto bounds = fragment.CellBounds();
+            if (fragment.Identity() == ImagePlacement::Key{ 1, metadata->layerId } &&
+                bounds.top == origin.y + 1 && bounds.left >= origin.x && bounds.right <= origin.x + 2)
+            {
+                ++movedFragments;
+                VERIFY_ARE_EQUAL(expectedOriginal, fragment.OriginalCellBounds());
+            }
+        }
+        VERIFY_ARE_EQUAL(size_t{ 2 }, movedFragments);
     }
 
     // DECCRA copies cells through the same WriteLine-plus-CopyBlock pattern. Copying explicit
@@ -7256,14 +7288,42 @@ public:
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m");
         _stateMachine->ProcessString(Placeholder() + L"\x0305" + L"\x030D"); // explicit (0,1) green
 
+        const auto* sourceSlice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        const auto* sourceMetadata = buffer.GetRowByOffset(origin.y).GetImageCellRef(origin.x);
+        VERIFY_IS_NOT_NULL(sourceMetadata);
+        VERIFY_ARE_NOT_EQUAL(0u, sourceMetadata->layerId);
+        VERIFY_ARE_EQUAL(size_t{ 1 }, buffer.GetImages().Size());
+        VERIFY_IS_NOT_NULL(sourceSlice);
+        const auto sourcePixel = SlicePixelAt(sourceSlice, 0, 0);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), sourcePixel.rgbRed);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), sourcePixel.rgbGreen);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), sourcePixel.rgbBlue);
         _pDispatch->CopyRectangularArea(vtRow, 1, vtRow, 1, 1, vtRow, 6, 1); // copy x=0 to x=5
         buffer.GetCursor().SetPosition({ 6, origin.y });
         _stateMachine->ProcessString(Placeholder()); // inherit (0,2) from copied x=5
 
         const auto* slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
         VERIFY_IS_NOT_NULL(slice);
-        VERIFY_IS_TRUE(SlicePixelIs(slice, 5, 0, 0, 255, 0), L"DECCRA copied the explicit grid-col-1 cell (green)");
+        const auto copiedPixel = SlicePixelAt(slice, 5, 0);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), copiedPixel.rgbRed);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), copiedPixel.rgbGreen, L"DECCRA copied the explicit grid-col-1 cell (green)");
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), copiedPixel.rgbBlue);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 6, 0, 0, 0, 255), L"the adjacent omission inherits grid col 2 (blue)");
+        const auto* metadata = buffer.GetRowByOffset(origin.y).GetImageCellRef(5);
+        VERIFY_IS_NOT_NULL(metadata);
+        const til::rect expectedOriginal{ 4, origin.y, 7, origin.y + 1 };
+        auto copiedFragments = size_t{ 0 };
+        for (const auto& fragment : buffer.GetImages().All())
+        {
+            const auto bounds = fragment.CellBounds();
+            if (fragment.Identity() == ImagePlacement::Key{ 1, metadata->layerId } &&
+                bounds.top == origin.y && bounds.left >= 5 && bounds.right <= 7)
+            {
+                ++copiedFragments;
+                VERIFY_ARE_EQUAL(expectedOriginal, fragment.OriginalCellBounds());
+            }
+        }
+        VERIFY_ARE_EQUAL(size_t{ 2 }, copiedFragments);
     }
 
     // Reflow copies text in cell ranges rather than moving whole ROW objects. The resolved
@@ -7278,6 +7338,8 @@ public:
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m");
         buffer.GetCursor().SetPosition({ 10, origin.y });
         _stateMachine->ProcessString(Placeholder() + L"\x030D" + L"\x030D"); // explicit (1,1)
+        const auto sourceSurface = buffer.GetImages().All()[0].SurfacePointer();
+        const auto sourceMetadata = *buffer.GetRowByOffset(origin.y).GetImageCellRef(10);
 
         auto reflowed = std::make_unique<TextBuffer>(til::size{ 5, 600 }, TextAttribute{}, 0, false, &_testGetSet->_renderer);
         TextBuffer::Reflow(buffer, *reflowed);
@@ -7303,6 +7365,19 @@ public:
         VERIFY_IS_TRUE(found, L"reflowed placeholder retains its resolved metadata");
         const til::point oldPosition{ 10, origin.y };
         VERIFY_IS_TRUE(movedTo != oldPosition, L"metadata moved with the text rather than staying at its old absolute position");
+        const til::rect expectedOriginal{ movedTo.x - 1, movedTo.y - 1, movedTo.x + 1, movedTo.y + 1 };
+        auto foundPlacement = false;
+        for (const auto& fragment : reflowed->GetImages().All())
+        {
+            if (fragment.Identity() == ImagePlacement::Key{ 1, sourceMetadata.layerId } &&
+                fragment.CellBounds() == til::rect{ movedTo.x, movedTo.y, movedTo.x + 1, movedTo.y + 1 })
+            {
+                foundPlacement = true;
+                VERIFY_ARE_EQUAL(expectedOriginal, fragment.OriginalCellBounds());
+                VERIFY_ARE_EQUAL(sourceSurface.get(), fragment.SurfacePointer().get());
+            }
+        }
+        VERIFY_IS_TRUE(foundPlacement, L"the collection fragment follows the exact placeholder cell");
     }
 
     // Two placeholder cells of a multi-COLUMN grid sent in SEPARATE writes on the same
@@ -8464,7 +8539,7 @@ public:
         _testGetSet->_cellSize = { 1, 1 };
         auto& buffer = *_testGetSet->_textBuffer;
         const auto origin = buffer.GetCursor().GetPosition();
-        buffer.GetCursor().SetPosition({ 10, origin.y });
+        buffer.GetCursor().SetPosition({ 3, origin.y });
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
         const auto layerId = _kitty()._placements.at({ 1u, 1u }).layerId;
 
@@ -8477,6 +8552,10 @@ public:
             found |= slice && slice->ContainsPlacement(layerId);
         }
         VERIFY_IS_TRUE(found, L"reflow preserves the retained placement identity");
+        VERIFY_ARE_EQUAL(size_t{ 1 }, reflowed->GetImages().Size());
+        const auto& placement = reflowed->GetImages().All()[0];
+        VERIFY_ARE_EQUAL(ImagePlacement::Key({ 1, layerId }), placement.Identity());
+        VERIFY_ARE_EQUAL(3, placement.CellBounds().left, L"an unwrapped direct placement follows its source cells");
     }
 
     // Bug #28: an anonymous relative placement (no p=) must be cascade-deleted with its parent and
@@ -9232,9 +9311,9 @@ public:
         _testGetSet->_cellSize = { 1, 1 };
         auto& buffer = *_testGetSet->_textBuffer;
         const auto origin = buffer.GetCursor().GetPosition();
-        buffer.GetCursor().SetPosition({ 10, origin.y });
+        buffer.GetCursor().SetPosition({ 3, origin.y });
         _stateMachine->ProcessString(L"X");
-        buffer.GetCursor().SetPosition({ 10, origin.y });
+        buffer.GetCursor().SetPosition({ 3, origin.y });
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,z=-1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
 
         auto reflowed = std::make_unique<TextBuffer>(til::size{ 5, 600 }, TextAttribute{}, 0, false, &_testGetSet->_renderer);
@@ -9251,9 +9330,10 @@ public:
             }
         }
         VERIFY_IS_TRUE(found, L"reflow must preserve negative-z layer pixels");
+        VERIFY_ARE_EQUAL(3, reflowed->GetImages().All()[0].CellBounds().left);
     }
 
-    TEST_METHOD(KittyGraphicsPlaceholderReflowLeavesOverlappingLayerInPlace)
+    TEST_METHOD(KittyGraphicsPlaceholderReflowPreservesOverlappingDirectMapping)
     {
         _testGetSet->PrepData();
         _testGetSet->_cellSize = { 1, 1 };
@@ -9309,16 +9389,17 @@ public:
                 VERIFY_IS_NOT_NULL(slice);
                 VERIFY_IS_TRUE(slice->Contains(1), L"the placeholder's image follows its reflowed text cell");
                 VERIFY_IS_TRUE(slice->ContainsPlacement(virtualLayer), L"the placeholder's exact placement follows its reflowed text cell");
-                VERIFY_IS_FALSE(slice->ContainsPlacement(physicalLayer), L"another placement of the same image must not follow the placeholder");
-                VERIFY_IS_FALSE(slice->Contains(2), L"an unrelated overlapping layer must not follow the placeholder");
+                VERIFY_IS_TRUE(slice->ContainsPlacement(physicalLayer), L"another direct placement follows its own mapped source cell");
+                VERIFY_IS_TRUE(slice->Contains(2), L"an unrelated direct layer follows its own mapped source cell");
                 const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::BehindText, x - slice->ColumnOffset(), 0);
                 VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbRed);
             }
         }
 
         VERIFY_IS_TRUE(foundPlaceholder);
-        VERIFY_IS_TRUE(foundOverlappingPlacement, L"the same image's unrelated placement remains attached to the cloned source row");
-        VERIFY_IS_TRUE(foundOverlappingImage, L"the unrelated layer remains attached to the cloned source row");
+        VERIFY_IS_TRUE(foundOverlappingPlacement, L"the overlapping direct placement follows the same exact source-cell mapping");
+        VERIFY_IS_TRUE(foundOverlappingImage, L"the unrelated direct layer follows its own source cells");
+        VERIFY_ARE_EQUAL(size_t{ 3 }, reflowed->GetImages().Size());
     }
 
     TEST_METHOD(KittyGraphicsUnresolvedPlaceholderDoesNotMoveOverlappingLayer)
@@ -9338,7 +9419,7 @@ public:
         VERIFY_IS_NOT_NULL(metadata);
         VERIFY_ARE_EQUAL(0u, metadata->layerId, L"an unresolved placement has no retained-layer identity");
 
-        buffer.GetCursor().SetPosition(placeholderPosition);
+        buffer.GetCursor().SetPosition({ 3, placeholderPosition.y });
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=1,z=1,C=1;\x1b\\");
         const auto physicalLayer = _kitty()._placements.at({ 1u, 1u }).layerId;
 
@@ -10124,7 +10205,7 @@ public:
         _testGetSet->_cellSize = { 1, 1 };
         auto& buffer = *_testGetSet->_textBuffer;
         const auto origin = buffer.GetCursor().GetPosition();
-        buffer.GetCursor().SetPosition({ 10, origin.y });
+        buffer.GetCursor().SetPosition({ 3, origin.y });
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
 
         auto reflowed = std::make_unique<TextBuffer>(til::size{ 5, 600 }, TextAttribute{}, 0, false, &_testGetSet->_renderer);


### PR DESCRIPTION
## Summary of the Pull Request

Moves rectangular-image lifecycle ownership into `ImageCollection` and `TextBuffer` while preserving the row-local `ImageSlice` renderer compatibility bridge.

- Uses a monotonic row epoch plus a 64-bit absolute interval index for O(1) normal full-buffer circular scrolling.
- Makes regional scroll, copy, erase, traditional resize, and reflow update collection-owned placements transactionally.
- Preserves exact original bounds, crop geometry, sampling, placement identity, and shared image surfaces across clipping and fragmentation.
- Reflows placeholder-backed placements from authoritative `ImageCellRef` metadata and direct placements through exact source-to-destination cell segments.

## References and Relevant Issues

- Depends on #62 (`crutkas-kgp-image-model-experiment`).
- Parent branch tip used by this PR: `e19d35943f34a3bd1e62e147485a3dbc7cf7b7b1`.

## Detailed Description of the Pull Request / Additional comments

`ImageCollection` now owns rectangle mutation semantics and exposes frame-local logical query views over epoch-stamped storage. Full-buffer scrolling advances the collection epoch without translating every placement or rebuilding the absolute row index; expired entries are filtered immediately and purged in batches. Regional operations snapshot source fragments before destination erasure for overlapping-copy correctness, preserve original sampling transforms, and stage replacement vectors before committing.

`TextBuffer` routes row/cell mutations, circular and regional scrolling, clear/reset paths, traditional resize, and reflow through the collection. Resize and reflow build destination collection state separately and stage the `ImageSlice` bridge before committing. Direct placements split along the exact reflow mapping, including wrapped and image-only rows. Kitty Unicode placeholders register one-cell fragments carrying their complete virtual-grid original bounds and continue rendering through the compatibility bridge.

Direct GPU placement-quad rendering, compatibility-bridge removal, and Sixel migration remain out of scope.

## Validation Steps Performed

- Built `TextBuffer.Unit.Tests.vcxproj` (Debug x64).
- Built `Adapter.UnitTests.vcxproj` (Debug x64).
- All TextBuffer tests: 45/45 passed.
- KittyGraphics selection: 176/176 passed.
- KittyAnimation selection: 35/35 passed.
- KittyPlaceholder selection: 54/54 passed.
- Scroll selection: 31/31 passed.
- Reflow selection: 8/8 passed.
- Rectangular-copy selection: 2/2 passed.
- Unresolved-placeholder selection: 1/1 passed.

## PR Checklist
- [ ] Closes #xxx (N/A)
- [x] Tests added/passed
- [ ] Documentation updated (N/A: no user-facing behavior or documentation surface changed)
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (N/A)