### PR TITLE
Render Kitty images as shared surfaces

### DIFF
--- a/src/buffer/out/Image.cpp
+++ b/src/buffer/out/Image.cpp
@@ -23,6 +23,7 @@ namespace
     size_t checkedPixelCount(const til::size size)
     {
         THROW_HR_IF(E_INVALIDARG, size.width <= 0 || size.height <= 0);
+        THROW_HR_IF(E_INVALIDARG, size.width > Image::MaximumDimension || size.height > Image::MaximumDimension);
         const auto width = static_cast<size_t>(size.width);
         const auto height = static_cast<size_t>(size.height);
         THROW_HR_IF(E_INVALIDARG, width > SIZE_MAX / height);
@@ -56,7 +57,7 @@ namespace
 }
 
 Image::Image(const til::size pixelSize, std::vector<RGBQUAD> pixels) :
-    Image{ pixelSize, std::make_shared<std::vector<RGBQUAD>>(std::move(pixels)) }
+    Image{ pixelSize, std::make_shared<const std::vector<RGBQUAD>>(std::move(pixels)) }
 {
 }
 
@@ -91,8 +92,7 @@ const Image::PixelStorage& Image::Storage() const noexcept
 void Image::UpdatePixels(const std::span<const RGBQUAD> pixels)
 {
     THROW_HR_IF(E_INVALIDARG, pixels.size() != _pixels->size());
-    std::copy(pixels.begin(), pixels.end(), _pixels->begin());
-    _revision = nextRevision();
+    UpdatePixels(std::make_shared<const std::vector<RGBQUAD>>(pixels.begin(), pixels.end()));
 }
 
 void Image::UpdatePixels(PixelStorage pixels)

--- a/src/buffer/out/Image.hpp
+++ b/src/buffer/out/Image.hpp
@@ -18,7 +18,9 @@ class Image final
 {
 public:
     using Pointer = std::shared_ptr<Image>;
-    using PixelStorage = std::shared_ptr<std::vector<RGBQUAD>>;
+    using PixelStorage = std::shared_ptr<const std::vector<RGBQUAD>>;
+    // D2D and the minimum D3D feature level supported by Atlas both guarantee 8192px textures.
+    static constexpr til::CoordType MaximumDimension = 8192;
 
     Image(til::size pixelSize, std::vector<RGBQUAD> pixels);
     Image(til::size pixelSize, PixelStorage pixels);

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -58,73 +58,6 @@ static uint64_t imageCellRefLayerId(const ROW& row, const til::CoordType column)
     return metadata ? metadata->layerId : 0;
 }
 
-struct StagedImageRow
-{
-    til::CoordType row = 0;
-    ImageSlice::Pointer slice;
-};
-
-static std::vector<StagedImageRow> stageImageSlices(TextBuffer& buffer,
-                                                   const ImageCollection& images,
-                                                   const std::span<const ImagePlacement> previousImages)
-{
-    std::vector<ImagePlacement::Key> keys;
-    keys.reserve(previousImages.size());
-    for (const auto& image : previousImages)
-    {
-        keys.emplace_back(image.Identity());
-    }
-    std::sort(keys.begin(), keys.end(), [](const auto lhs, const auto rhs) {
-        return std::tie(lhs.imageId, lhs.layerId) < std::tie(rhs.imageId, rhs.layerId);
-    });
-    keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
-
-    std::vector<StagedImageRow> stagedRows;
-    images.PrepareRowIndex();
-    const auto height = buffer.GetSize().Height();
-    for (auto rowIndex = 0; rowIndex < height; ++rowIndex)
-    {
-        const auto placements = images.IntersectingRows(rowIndex, rowIndex + 1);
-        const auto existing = buffer.GetRowByOffset(rowIndex).GetImageSlice();
-        const auto removesPlacement = existing && std::any_of(keys.begin(), keys.end(), [&](const auto key) {
-            return existing->Contains({ key.imageId, key.layerId });
-        });
-        if (!removesPlacement && placements.empty())
-        {
-            continue;
-        }
-
-        auto staged = existing ? std::make_unique<ImageSlice>(*existing) : nullptr;
-        for (const auto key : keys)
-        {
-            if (staged && staged->Contains({ key.imageId, key.layerId }) && staged->EraseLayer({ key.imageId, key.layerId }))
-            {
-                staged.reset();
-            }
-        }
-        for (const auto placement : placements)
-        {
-            if (!staged || staged->CellSize() != placement->Geometry().cellSize)
-            {
-                auto replacement = std::make_unique<ImageSlice>(placement->Geometry().cellSize);
-                staged = std::move(replacement);
-            }
-            const auto bounds = placement->CellBounds();
-            THROW_HR_IF(E_UNEXPECTED, !placement->RasterizeRow(rowIndex, bounds.left, bounds.right, *staged));
-        }
-        stagedRows.push_back({ rowIndex, std::move(staged) });
-    }
-    return stagedRows;
-}
-
-static void commitImageSlices(TextBuffer& buffer, std::vector<StagedImageRow> stagedRows) noexcept
-{
-    for (auto& staged : stagedRows)
-    {
-        buffer.GetMutableRowByOffset(staged.row).SetImageSlice(std::move(staged.slice));
-    }
-}
-
 static std::atomic<uint64_t> s_lastMutationIdInitialValue;
 
 // Routine Description:
@@ -1017,11 +950,6 @@ void TextBuffer::_copyRowData(const til::CoordType srcRowIndex, const til::Coord
     ImageSlice::CopyRow(srcRow, dstRow);
 }
 
-void TextBuffer::_rebuildImageSlices(const std::span<const ImagePlacement> previousImages)
-{
-    commitImageSlices(*this, stageImageSlices(*this, _images, previousImages));
-}
-
 Cursor& TextBuffer::GetCursor() noexcept
 {
     return _cursor;
@@ -1192,7 +1120,6 @@ void TextBuffer::ResizeTraditional(til::size newSize)
     newSize.height = std::max(newSize.height, 1);
 
     TextBuffer newBuffer{ newSize, _currentAttributes, 0, false, _renderer };
-    const auto oldImages = _images.All();
     const auto cursorRow = GetCursor().GetPosition().y;
     const auto copyableRows = std::min<til::CoordType>(_height, newSize.height);
     til::CoordType srcRow = 0;
@@ -1208,7 +1135,6 @@ void TextBuffer::ResizeTraditional(til::size newSize)
         CopyRow(srcRow, dstRow, newBuffer);
     }
     newBuffer._images.ClipArea({ 0, 0, newSize.width, newSize.height });
-    newBuffer._rebuildImageSlices(oldImages);
 
     // NOTE: Keep this in sync with _reserve().
     _images = std::move(newBuffer._images);
@@ -3310,9 +3236,7 @@ void TextBuffer::Reflow(TextBuffer& oldBuffer, TextBuffer& newBuffer, const View
         }
     }
 
-    auto stagedImageRows = stageImageSlices(newBuffer, reflowedImages, oldImages);
     newBuffer._images = std::move(reflowedImages);
-    commitImageSlices(newBuffer, std::move(stagedImageRows));
     newBuffer.CopyProperties(oldBuffer);
     newBuffer.CopyHyperlinkMaps(oldBuffer);
 

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -328,8 +328,6 @@ private:
     bool _isRowCommitted(til::CoordType y) const noexcept;
     void _copyRowData(til::CoordType srcRow, til::CoordType dstRow, TextBuffer& dstBuffer) const;
     void _scrollRows(til::CoordType firstRow, til::CoordType size, til::CoordType delta, bool copyImages);
-    void _rebuildImageSlices(std::span<const ImagePlacement> previousImages);
-
     void _SetFirstRowIndex(const til::CoordType FirstRowIndex) noexcept;
     void _ExpandTextRow(til::inclusive_rect& selectionRow) const;
     DelimiterClass _GetDelimiterClassAt(const til::point pos, const std::wstring_view wordDelimiters) const;

--- a/src/buffer/out/ut_textbuffer/ImageTests.cpp
+++ b/src/buffer/out/ut_textbuffer/ImageTests.cpp
@@ -30,7 +30,7 @@ class ImageTests
     TEST_METHOD(RectangularCopyAndErasePreserveSampling);
     TEST_METHOD(CrossBufferBlankCopyErasesPlacement);
     TEST_METHOD(TraditionalResizeClipsAndRetainsImages);
-    TEST_METHOD(ResizeRebuildHandlesMixedCellSizes);
+    TEST_METHOD(ResizeRetainsMixedCellSizesWithoutRowSlices);
     TEST_METHOD(ReflowAppliesDirectPlacementPolicy);
 
     static constexpr til::size CellSize{ 2, 3 };
@@ -63,18 +63,19 @@ class ImageTests
 
     static void AddPlacement(TextBuffer& buffer, ImagePlacement placement)
     {
-        const auto bounds = placement.CellBounds() & buffer.GetSize().ToExclusive();
-        for (auto rowIndex = bounds.top; rowIndex < bounds.bottom; ++rowIndex)
-        {
-            auto& row = buffer.GetMutableRowByOffset(rowIndex);
-            auto slice = row.GetMutableImageSlice();
-            if (!slice)
-            {
-                slice = row.SetImageSlice(std::make_unique<ImageSlice>(placement.Geometry().cellSize));
-            }
-            THROW_HR_IF(E_UNEXPECTED, !placement.RasterizeRow(rowIndex, bounds.left, bounds.right, *slice));
-        }
         buffer.GetMutableImages().Add(std::move(placement));
+    }
+
+    static bool PlacementCoversCell(const TextBuffer& buffer, const uint32_t imageId, const til::point cell)
+    {
+        for (const auto& placement : buffer.GetImages().IntersectingRows(cell.y, cell.y + 1))
+        {
+            if (placement->Identity().imageId == imageId && placement->CellBounds().contains(cell))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 };
 
@@ -188,12 +189,15 @@ void ImageTests::SurfaceUpdateReachesEveryFragment()
     images.Add(MakePlacement({ 1, 1 }, { 0, 0, 6, 6 }));
     const auto surface = images.All()[0].SurfacePointer();
     const auto oldRevision = surface->Revision();
+    const auto oldStorage = surface->Storage();
     images.EraseArea({ 2, 2, 4, 4 });
 
     auto pixels = std::vector<RGBQUAD>(surface->Pixels().size(), RGBQUAD{ 1, 2, 3, 4 });
     surface->UpdatePixels(pixels);
 
     VERIFY_ARE_NOT_EQUAL(oldRevision, surface->Revision());
+    VERIFY_ARE_NOT_EQUAL(oldStorage.get(), surface->Storage().get());
+    VERIFY_ARE_EQUAL(0, static_cast<int>(oldStorage->front().rgbBlue), L"a frame snapshot must retain immutable pixels across revision updates");
     for (const auto& fragment : images.All())
     {
         VERIFY_ARE_EQUAL(surface->Revision(), fragment.Surface().Revision());
@@ -293,9 +297,8 @@ void ImageTests::CircularAndRegionalScrollUseLogicalRows()
     {
         VERIFY_ARE_EQUAL(surface.get(), fragment.SurfacePointer().get());
     }
-    const auto* copiedRow = buffer.GetRowByOffset(1).GetImageSlice();
-    VERIFY_IS_NOT_NULL(copiedRow);
-    VERIFY_ARE_EQUAL(1u, copiedRow->ColumnOwner(2));
+    VERIFY_IS_TRUE(PlacementCoversCell(buffer, 1, { 2, 1 }));
+    VERIFY_IS_NULL(buffer.GetRowByOffset(1).GetImageSlice());
 
     buffer.IncrementCircularBuffer(TextAttribute{});
 
@@ -335,8 +338,8 @@ void ImageTests::RectangularCopyAndErasePreserveSampling()
         }
     }
     VERIFY_IS_TRUE(foundCopy);
-    VERIFY_ARE_EQUAL(1u, buffer.GetRowByOffset(0).GetImageSlice()->ColumnOwner(7));
-    VERIFY_ARE_EQUAL(1u, buffer.GetRowByOffset(1).GetImageSlice()->ColumnOwner(7));
+    VERIFY_IS_TRUE(PlacementCoversCell(buffer, 1, { 7, 0 }));
+    VERIFY_IS_TRUE(PlacementCoversCell(buffer, 1, { 7, 1 }));
 
     ImageSlice::EraseBlock(buffer, { 7, 0, 8, 2 });
 
@@ -352,11 +355,10 @@ void ImageTests::RectangularCopyAndErasePreserveSampling()
     }
     for (auto rowIndex = 0; rowIndex < 2; ++rowIndex)
     {
-        const auto* slice = buffer.GetRowByOffset(rowIndex).GetImageSlice();
-        VERIFY_IS_NOT_NULL(slice);
-        VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(6));
-        VERIFY_ARE_EQUAL(0u, slice->ColumnOwner(7));
-        VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(8));
+        VERIFY_IS_NULL(buffer.GetRowByOffset(rowIndex).GetImageSlice());
+        VERIFY_IS_TRUE(PlacementCoversCell(buffer, 1, { 6, rowIndex }));
+        VERIFY_IS_FALSE(PlacementCoversCell(buffer, 1, { 7, rowIndex }));
+        VERIFY_IS_TRUE(PlacementCoversCell(buffer, 1, { 8, rowIndex }));
     }
 }
 
@@ -396,15 +398,14 @@ void ImageTests::TraditionalResizeClipsAndRetainsImages()
     VERIFY_IS_NULL(buffer.GetRowByOffset(0).GetImageSlice());
     for (auto rowIndex = 1; rowIndex < 3; ++rowIndex)
     {
-        const auto* slice = buffer.GetRowByOffset(rowIndex).GetImageSlice();
-        VERIFY_IS_NOT_NULL(slice);
-        VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(4));
-        VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(5));
-        VERIFY_ARE_EQUAL(0u, slice->ColumnOwner(6));
+        VERIFY_IS_NULL(buffer.GetRowByOffset(rowIndex).GetImageSlice());
+        VERIFY_IS_TRUE(PlacementCoversCell(buffer, 1, { 4, rowIndex }));
+        VERIFY_IS_TRUE(PlacementCoversCell(buffer, 1, { 5, rowIndex }));
+        VERIFY_IS_FALSE(PlacementCoversCell(buffer, 1, { 6, rowIndex }));
     }
 }
 
-void ImageTests::ResizeRebuildHandlesMixedCellSizes()
+void ImageTests::ResizeRetainsMixedCellSizesWithoutRowSlices()
 {
     DummyRenderer renderer;
     TextBuffer buffer{ til::size{ 8, 2 }, TextAttribute{}, 0, false, &renderer };
@@ -428,11 +429,9 @@ void ImageTests::ResizeRebuildHandlesMixedCellSizes()
     buffer.ResizeTraditional({ 6, 2 });
 
     VERIFY_ARE_EQUAL(size_t{ 2 }, buffer.GetImages().Size());
-    const auto* slice = buffer.GetRowByOffset(0).GetImageSlice();
-    VERIFY_IS_NOT_NULL(slice);
-    VERIFY_ARE_EQUAL(smallCell, slice->CellSize());
-    VERIFY_IS_FALSE(slice->Contains({ 1, 1 }));
-    VERIFY_IS_TRUE(slice->Contains({ 2, 2 }));
+    VERIFY_IS_NULL(buffer.GetRowByOffset(0).GetImageSlice());
+    VERIFY_IS_TRUE(PlacementCoversCell(buffer, 1, { 0, 0 }));
+    VERIFY_IS_TRUE(PlacementCoversCell(buffer, 2, { 0, 0 }));
 }
 
 void ImageTests::ReflowAppliesDirectPlacementPolicy()
@@ -484,9 +483,13 @@ void ImageTests::ReflowAppliesDirectPlacementPolicy()
     VERIFY_IS_TRUE(foundSecondSegment, L"the joined source row follows its first destination segment");
     VERIFY_IS_TRUE(foundSecondWrappedSegment, L"the joined source row also fragments when it wraps");
     VERIFY_IS_TRUE(foundImageOnlyRow, L"an image-only source row participates in reflow");
-    VERIFY_ARE_EQUAL(1u, reflowed.GetRowByOffset(0).GetImageSlice()->ColumnOwner(2));
-    VERIFY_ARE_EQUAL(1u, reflowed.GetRowByOffset(1).GetImageSlice()->ColumnOwner(0));
-    VERIFY_ARE_EQUAL(1u, reflowed.GetRowByOffset(2).GetImageSlice()->ColumnOwner(2));
-    VERIFY_ARE_EQUAL(1u, reflowed.GetRowByOffset(3).GetImageSlice()->ColumnOwner(0));
-    VERIFY_ARE_EQUAL(2u, reflowed.GetRowByOffset(6).GetImageSlice()->ColumnOwner(0));
+    VERIFY_IS_TRUE(PlacementCoversCell(reflowed, 1, { 2, 0 }));
+    VERIFY_IS_TRUE(PlacementCoversCell(reflowed, 1, { 0, 1 }));
+    VERIFY_IS_TRUE(PlacementCoversCell(reflowed, 1, { 2, 2 }));
+    VERIFY_IS_TRUE(PlacementCoversCell(reflowed, 1, { 0, 3 }));
+    VERIFY_IS_TRUE(PlacementCoversCell(reflowed, 2, { 0, 6 }));
+    for (til::CoordType row = 0; row < reflowed.GetSize().Height(); ++row)
+    {
+        VERIFY_IS_NULL(reflowed.GetRowByOffset(row).GetImageSlice());
+    }
 }

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -33,6 +33,17 @@ namespace
     {
         til::CoordType targetRow;
         til::CoordType columnOffset;
+        ImagePlacement::Key key;
+        const Image* surface = nullptr;
+        uint64_t revision = 0;
+        til::rect bounds;
+        til::rect originalBounds;
+        til::rect source;
+        ImagePlacement::PixelGeometry geometry;
+        int32_t zIndex = 0;
+        ImagePlacement::RenderPosition position = ImagePlacement::RenderPosition::AboveText;
+        bool containsRed = false;
+        bool containsGreen = false;
         std::vector<uint32_t> columnOwners;
         std::vector<bool> columnsContainRed;
         std::vector<bool> columnsContainGreen;
@@ -44,6 +55,10 @@ namespace
     {
         std::vector<PaintedCluster> clusters;
         std::vector<PaintedImage> images;
+        size_t imageFramePreparations = 0;
+        size_t surfaceUploads = 0;
+        size_t surfaceRefreshes = 0;
+        size_t surfaceEvictions = 0;
     };
 
     class KittyRecordingRenderEngine final : public RenderEngineBase
@@ -54,6 +69,10 @@ namespace
             const auto guard = _lock.lock_exclusive();
             _clusters.clear();
             _images.clear();
+            _imageFramePreparations = 0;
+            _surfaceUploads = 0;
+            _surfaceRefreshes = 0;
+            _surfaceEvictions = 0;
             return S_OK;
         }
 
@@ -68,6 +87,10 @@ namespace
             const auto guard = _lock.lock_exclusive();
             _presentedClusters = _clusters;
             _presentedImages = _images;
+            _presentedImageFramePreparations = _imageFramePreparations;
+            _presentedSurfaceUploads = _surfaceUploads;
+            _presentedSurfaceRefreshes = _surfaceRefreshes;
+            _presentedSurfaceEvictions = _surfaceEvictions;
             return S_OK;
         }
         CATCH_RETURN()
@@ -125,19 +148,98 @@ namespace
             return S_OK;
         }
 
-        HRESULT BeginRowImages(const ImageSlice& imageSlice,
+        HRESULT PrepareImageFrame(const ImageFrameInfo info) noexcept override
+        try
+        {
+            const auto guard = _lock.lock_exclusive();
+            _framePlacements.assign(info.placements.begin(), info.placements.end());
+            _frameSurfaces.assign(info.surfaces.begin(), info.surfaces.end());
+            _imageViewportOrigin = info.viewportOrigin;
+            ++_imageFramePreparations;
+
+            std::vector<const Image*> seen;
+            for (const auto& surface : _frameSurfaces)
+            {
+                const auto key = surface.image.get();
+                seen.push_back(key);
+                const auto cached = _surfaceRevisions.find(key);
+                if (cached == _surfaceRevisions.end())
+                {
+                    _surfaceRevisions.emplace(key, surface.revision);
+                    ++_surfaceUploads;
+                }
+                else if (cached->second != surface.revision)
+                {
+                    cached->second = surface.revision;
+                    ++_surfaceRefreshes;
+                }
+            }
+            for (auto cached = _surfaceRevisions.begin(); cached != _surfaceRevisions.end();)
+            {
+                if (std::find(seen.begin(), seen.end(), cached->first) == seen.end())
+                {
+                    cached = _surfaceRevisions.erase(cached);
+                    ++_surfaceEvictions;
+                }
+                else
+                {
+                    ++cached;
+                }
+            }
+            return S_OK;
+        }
+        CATCH_RETURN()
+
+        HRESULT BeginRowImages(const ImageSlice* imageSlice,
                                const til::CoordType targetRow,
                                const til::CoordType viewportLeft,
                                const std::span<const uint8_t> defaultBackgroundMask,
                                const std::span<const COLORREF> cellBackgrounds) noexcept override
         try
         {
-            // The real engines decide when each plane lands relative to the
-            // text; this mock only cares what pixels each plane holds, so it
-            // records one entry per plane and lets the assertions search.
-            for (size_t plane = 0; plane < ImageSlice::RenderPositionCount; ++plane)
+            if (imageSlice)
             {
-                _recordPlane(imageSlice, static_cast<ImageSlice::RenderPosition>(plane), targetRow, viewportLeft, defaultBackgroundMask, cellBackgrounds);
+                for (size_t plane = 0; plane < ImageSlice::RenderPositionCount; ++plane)
+                {
+                    _recordPlane(*imageSlice, static_cast<ImageSlice::RenderPosition>(plane), targetRow, viewportLeft, defaultBackgroundMask, cellBackgrounds);
+                }
+            }
+
+            const auto bufferRow = targetRow + _imageViewportOrigin.y;
+            for (const auto& placement : _framePlacements)
+            {
+                const auto bounds = placement.CellBounds();
+                if (bufferRow < bounds.top || bufferRow >= bounds.bottom)
+                {
+                    continue;
+                }
+                const auto surface = std::ranges::find(_frameSurfaces, placement.SurfacePointer().get(), [](const auto& candidate) {
+                    return candidate.image.get();
+                });
+                THROW_HR_IF(E_UNEXPECTED, surface == _frameSurfaces.end() || !surface->pixels);
+
+                PaintedImage image{
+                    .targetRow = targetRow,
+                    .columnOffset = bounds.left - _imageViewportOrigin.x,
+                    .key = placement.Identity(),
+                    .surface = &placement.Surface(),
+                    .revision = surface->revision,
+                    .bounds = bounds,
+                    .originalBounds = placement.OriginalCellBounds(),
+                    .source = placement.SourceInPixels(),
+                    .geometry = placement.Geometry(),
+                    .zIndex = placement.ZIndex(),
+                    .position = placement.Position(),
+                };
+                image.defaultBackgroundMask.assign(defaultBackgroundMask.begin(), defaultBackgroundMask.end());
+                image.cellBackgrounds.assign(cellBackgrounds.begin(), cellBackgrounds.end());
+                for (const auto& pixel : *surface->pixels)
+                {
+                    image.containsRed |= pixel.rgbRed == 255 && pixel.rgbGreen == 0 && pixel.rgbBlue == 0;
+                    image.containsGreen |= pixel.rgbRed == 0 && pixel.rgbGreen == 255 && pixel.rgbBlue == 0;
+                }
+                const auto guard = _lock.lock_exclusive();
+                _images.emplace_back(std::move(image));
             }
             return S_OK;
         }
@@ -265,7 +367,14 @@ namespace
         PaintedFrame Snapshot() const
         {
             const auto guard = _lock.lock_shared();
-            return { _presentedClusters, _presentedImages };
+            return {
+                _presentedClusters,
+                _presentedImages,
+                _presentedImageFramePreparations,
+                _presentedSurfaceUploads,
+                _presentedSurfaceRefreshes,
+                _presentedSurfaceEvictions,
+            };
         }
 
     protected:
@@ -280,8 +389,20 @@ namespace
         TextAttribute _currentAttribute;
         std::vector<PaintedCluster> _clusters;
         std::vector<PaintedImage> _images;
+        std::vector<ImagePlacement> _framePlacements;
+        std::vector<ImageFrameInfo::Surface> _frameSurfaces;
+        til::point _imageViewportOrigin;
+        std::unordered_map<const Image*, uint64_t> _surfaceRevisions;
+        size_t _imageFramePreparations = 0;
+        size_t _surfaceUploads = 0;
+        size_t _surfaceRefreshes = 0;
+        size_t _surfaceEvictions = 0;
         std::vector<PaintedCluster> _presentedClusters;
         std::vector<PaintedImage> _presentedImages;
+        size_t _presentedImageFramePreparations = 0;
+        size_t _presentedSurfaceUploads = 0;
+        size_t _presentedSurfaceRefreshes = 0;
+        size_t _presentedSurfaceEvictions = 0;
     };
 
     class KittyRenderFixture
@@ -370,12 +491,11 @@ namespace
         auto imageAtPlaceholder = false;
         for (const auto& image : frame.images)
         {
-            const auto relativeColumn = screenPosition.x - image.columnOffset;
             if (image.targetRow == screenPosition.y &&
-                relativeColumn >= 0 &&
-                relativeColumn < gsl::narrow_cast<til::CoordType>(image.columnOwners.size()) &&
-                til::at(image.columnOwners, relativeColumn) == imageId &&
-                til::at(image.columnsContainRed, relativeColumn))
+                image.key.imageId == imageId &&
+                screenPosition.x >= image.columnOffset &&
+                screenPosition.x < image.columnOffset + image.bounds.width() &&
+                image.containsRed)
             {
                 imageAtPlaceholder = true;
                 break;
@@ -387,15 +507,8 @@ namespace
     bool FrameContainsKittyColor(const PaintedFrame& frame, const uint32_t imageId, const bool green)
     {
         return std::ranges::any_of(frame.images, [&](const auto& image) {
-            for (size_t column = 0; column < image.columnOwners.size(); ++column)
-            {
-                if (til::at(image.columnOwners, column) == imageId &&
-                    til::at(green ? image.columnsContainGreen : image.columnsContainRed, column))
-                {
-                    return true;
-                }
-            }
-            return false;
+            return image.key.imageId == imageId &&
+                   (green ? image.containsGreen : image.containsRed);
         });
     }
 }
@@ -427,6 +540,7 @@ namespace TerminalCoreUnitTests
 
         TEST_METHOD(GetCellSizeFallsBackWhenFontUnset);
 
+        TEST_METHOD(DirectImageRendererPreservesSharedSurfaceGeometryAndLifetime);
         TEST_METHOD(KittyAnimationSurvivesFontAndRendererRefresh);
         TEST_METHOD(KittyPlaceholderRendersInRealTerminal);
         TEST_METHOD(KittyImageRowCarriesEachCellsBackgroundColor);
@@ -823,6 +937,151 @@ void TerminalApiTest::GetCellSizeFallsBackWhenFontUnset()
     VERIFY_IS_GREATER_THAN(cellSize.height, 1, L"cell height must not be a degenerate 1px");
 }
 
+void TerminalApiTest::DirectImageRendererPreservesSharedSurfaceGeometryAndLifetime()
+{
+    KittyRenderFixture fixture{ { 6, 3 }, 0 };
+    auto& buffer = *fixture.terminal._mainBuffer;
+
+    auto pixels = std::make_shared<std::vector<RGBQUAD>>(8, RGBQUAD{ 0, 0, 128, 128 });
+    pixels->at(1) = RGBQUAD{ 0, 0, 255, 255 };
+    const auto surface = std::make_shared<Image>(til::size{ 4, 2 }, pixels);
+    const ImagePlacement::PixelGeometry croppedGeometry{
+        .cellSize = { 10, 20 },
+        .targetWidth = 40,
+        .targetHeight = 40,
+        .offset = { 2, 3 },
+    };
+    const ImagePlacement::PixelGeometry fullGeometry{
+        .cellSize = { 10, 20 },
+        .targetWidth = 20,
+        .targetHeight = 40,
+    };
+
+    fixture.terminal.LockConsole();
+    auto unlock = wil::scope_exit([&fixture]() {
+        fixture.terminal.UnlockConsole();
+    });
+    auto& images = buffer.GetMutableImages();
+    images.AddOrReplace(ImagePlacement{
+        { 9, 100 },
+        surface,
+        { 0, 1, 2, 3 },
+        ImagePlacement::BackgroundZThreshold - 1,
+        { 1, 0, 3, 2 },
+        croppedGeometry,
+    });
+    images.AddOrReplace(ImagePlacement{
+        { 9, 101 },
+        surface,
+        { 2, 0, 4, 2 },
+        -2,
+        { 0, 0, 4, 2 },
+        fullGeometry,
+    });
+    images.AddOrReplaceArea(ImagePlacement::FromFragment(
+        { 9, 102 },
+        surface,
+        { 4, 0, 5, 1 },
+        { 4, 0, 6, 2 },
+        5,
+        { 0, 0, 4, 2 },
+        fullGeometry));
+    images.AddOrReplaceArea(ImagePlacement::FromFragment(
+        { 9, 102 },
+        surface,
+        { 5, 1, 6, 2 },
+        { 4, 0, 6, 2 },
+        5,
+        { 0, 0, 4, 2 },
+        fullGeometry));
+    unlock.reset();
+
+    fixture.StartPainting();
+    auto frame = fixture.engine.Snapshot();
+    VERIFY_ARE_EQUAL(size_t{ 1 }, frame.imageFramePreparations, L"placements must be queried once per engine frame");
+    VERIFY_ARE_EQUAL(size_t{ 1 }, frame.surfaceUploads, L"all placements and fragments must share one complete upload");
+    VERIFY_ARE_EQUAL(size_t{ 0 }, frame.surfaceRefreshes);
+    VERIFY_ARE_EQUAL(static_cast<BYTE>(128), surface->Pixels().front().rgbReserved, L"surface alpha must remain intact");
+    VERIFY_IS_TRUE(std::ranges::all_of(frame.images, [&](const auto& image) {
+        return image.surface == surface.get();
+    }));
+
+    const auto cropped = std::ranges::find_if(frame.images, [](const auto& image) {
+        return image.key.layerId == 100;
+    });
+    VERIFY_IS_TRUE(cropped != frame.images.end());
+    if (cropped != frame.images.end())
+    {
+        VERIFY_ARE_EQUAL((til::rect{ 1, 0, 3, 2 }), cropped->source);
+        VERIFY_ARE_EQUAL(uint64_t{ 40 }, cropped->geometry.targetWidth);
+        VERIFY_ARE_EQUAL(uint64_t{ 40 }, cropped->geometry.targetHeight);
+        VERIFY_ARE_EQUAL((til::point{ 2, 3 }), cropped->geometry.offset);
+        VERIFY_ARE_EQUAL(static_cast<int>(ImagePlacement::RenderPosition::BehindBackground), static_cast<int>(cropped->position));
+    }
+
+    const auto fragmentCount = std::ranges::count_if(frame.images, [](const auto& image) {
+        return image.key.layerId == 102;
+    });
+    VERIFY_ARE_EQUAL(ptrdiff_t{ 2 }, fragmentCount, L"disjoint fragments must reuse one placement surface");
+    std::vector<int32_t> rowOneZ;
+    for (const auto& image : frame.images)
+    {
+        if (image.targetRow == 1)
+        {
+            rowOneZ.push_back(image.zIndex);
+        }
+    }
+    VERIFY_IS_TRUE(std::ranges::is_sorted(rowOneZ), L"the renderer must preserve stable z composition across all three phases");
+
+    for (til::CoordType row = 0; row < buffer.GetSize().Height(); ++row)
+    {
+        VERIFY_IS_NULL(buffer.GetRowByOffset(row).GetImageSlice(), L"direct images must not create row-local pixels");
+    }
+
+    fixture.terminal.LockConsole();
+    auto unlockAfterScroll = wil::scope_exit([&fixture]() {
+        fixture.terminal.UnlockConsole();
+    });
+    buffer.GetMutableImages().AdvanceRows(1, buffer.GetSize().Height());
+    unlockAfterScroll.reset();
+    fixture.Repaint();
+    frame = fixture.engine.Snapshot();
+    VERIFY_ARE_EQUAL(size_t{ 0 }, frame.surfaceUploads, L"epoch scrolling must reuse the cached surface");
+    const auto scrolledFragment = std::ranges::find_if(frame.images, [](const auto& image) {
+        return image.key.layerId == 102;
+    });
+    VERIFY_IS_TRUE(scrolledFragment != frame.images.end());
+    if (scrolledFragment != frame.images.end())
+    {
+        VERIFY_ARE_EQUAL(0, scrolledFragment->bounds.top);
+        VERIFY_ARE_EQUAL(-1, scrolledFragment->originalBounds.top, L"logical bounds must follow the monotonic row epoch");
+    }
+
+    auto changedPixels = std::make_shared<std::vector<RGBQUAD>>(*pixels);
+    changedPixels->front() = RGBQUAD{ 0, 255, 0, 192 };
+    fixture.terminal.LockConsole();
+    auto unlockAfterRevision = wil::scope_exit([&fixture]() {
+        fixture.terminal.UnlockConsole();
+    });
+    surface->UpdatePixels(std::move(changedPixels));
+    unlockAfterRevision.reset();
+    fixture.Repaint();
+    frame = fixture.engine.Snapshot();
+    VERIFY_ARE_EQUAL(size_t{ 0 }, frame.surfaceUploads);
+    VERIFY_ARE_EQUAL(size_t{ 1 }, frame.surfaceRefreshes, L"a new revision must refresh the existing cached surface");
+
+    fixture.terminal.LockConsole();
+    auto unlockAfterDelete = wil::scope_exit([&fixture]() {
+        fixture.terminal.UnlockConsole();
+    });
+    buffer.GetMutableImages().Clear();
+    unlockAfterDelete.reset();
+    fixture.Repaint();
+    frame = fixture.engine.Snapshot();
+    VERIFY_IS_TRUE(frame.images.empty());
+    VERIFY_ARE_EQUAL(size_t{ 1 }, frame.surfaceEvictions, L"deletion must release the backend cache entry");
+}
+
 void TerminalApiTest::KittyAnimationSurvivesFontAndRendererRefresh()
 {
     KittyRenderFixture fixture{ { 6, 3 }, 0 };
@@ -833,22 +1092,31 @@ void TerminalApiTest::KittyAnimationSurvivesFontAndRendererRefresh()
     stateMachine.ProcessString(L"\x1b_Ga=f,i=7,f=24,s=1,v=1,z=1000,q=2;AP8A\x1b\\");
     stateMachine.ProcessString(L"\x1b_Ga=a,i=7,c=1,r=1,z=5000,s=3,v=1,q=2;\x1b\\");
     fixture.StartPainting();
-    VERIFY_IS_TRUE(FrameContainsKittyColor(fixture.engine.Snapshot(), 7, false), L"frame 1 must be visible before the lifecycle transition");
+    auto frame = fixture.engine.Snapshot();
+    VERIFY_IS_TRUE(FrameContainsKittyColor(frame, 7, false), L"frame 1 must be visible before the lifecycle transition");
+    VERIFY_ARE_EQUAL(size_t{ 1 }, frame.imageFramePreparations);
+    VERIFY_ARE_EQUAL(size_t{ 1 }, frame.surfaceUploads, L"the complete image must upload once per shared surface");
 
-    // Reproduce the stale retained-layer state observed after renderer recreation:
-    // the animation source of truth is frame 1 (red), while the retained pixels
-    // contain the wrong frame (green).
-    const std::array stalePixels{ RGBQUAD{ 0, 255, 0, 0 } };
+    const auto placements = buffer.GetImages().All();
+    VERIFY_ARE_EQUAL(size_t{ 1 }, placements.size());
+    const auto surface = placements.front().SurfacePointer();
+    VERIFY_IS_NOT_NULL(surface.get());
+    VERIFY_IS_NULL(buffer.GetRowByOffset(0).GetImageSlice(), L"Kitty must not create a row-local ImageSlice");
+
+    // Simulate an out-of-date backend-facing surface while the animation source of
+    // truth remains frame 1 (red). A font refresh must update the same shared object.
+    auto stalePixels = std::make_shared<std::vector<RGBQUAD>>(1, RGBQUAD{ 0, 255, 0, 0 });
     fixture.terminal.LockConsole();
-    auto unlockAfterStaleLayer = wil::scope_exit([&fixture]() {
+    auto unlockAfterStaleSurface = wil::scope_exit([&fixture]() {
         fixture.terminal.UnlockConsole();
     });
-    auto* slice = buffer.GetMutableRowByOffset(0).GetMutableImageSlice();
-    VERIFY_IS_NOT_NULL(slice);
-    VERIFY_IS_TRUE(slice && slice->UpdateImage(7, stalePixels));
-    unlockAfterStaleLayer.reset();
+    surface->UpdatePixels(std::move(stalePixels));
+    unlockAfterStaleSurface.reset();
     fixture.Repaint();
-    VERIFY_IS_TRUE(FrameContainsKittyColor(fixture.engine.Snapshot(), 7, true), L"the test must reproduce a stale retained animation layer");
+    frame = fixture.engine.Snapshot();
+    VERIFY_IS_TRUE(FrameContainsKittyColor(frame, 7, true), L"the test must reproduce a stale shared animation surface");
+    VERIFY_ARE_EQUAL(size_t{ 0 }, frame.surfaceUploads);
+    VERIFY_ARE_EQUAL(size_t{ 1 }, frame.surfaceRefreshes, L"a revision change must refresh rather than allocate another surface");
 
     fixture.terminal.LockConsole();
     auto unlockAfterFontChange = wil::scope_exit([&fixture]() {
@@ -857,7 +1125,13 @@ void TerminalApiTest::KittyAnimationSurvivesFontAndRendererRefresh()
     fixture.terminal.SetFontInfo(FontInfo{ DEFAULT_FONT_FACE, TMPF_TRUETYPE, 10, { 12, 24 }, CP_UTF8, false });
     unlockAfterFontChange.reset();
     fixture.Repaint();
-    VERIFY_IS_TRUE(FrameContainsKittyColor(fixture.engine.Snapshot(), 7, false), L"font/DPI recreation must restore the current animation frame");
+    frame = fixture.engine.Snapshot();
+    VERIFY_IS_TRUE(FrameContainsKittyColor(frame, 7, false), L"font/DPI recreation must restore the current animation frame");
+    if (!frame.images.empty())
+    {
+        VERIFY_ARE_EQUAL(surface.get(), frame.images.front().surface, L"refresh must retain the complete shared surface");
+    }
+    VERIFY_ARE_EQUAL(size_t{ 1 }, frame.surfaceRefreshes);
 
     fixture.terminal.LockConsole();
     stateMachine.ProcessString(L"\x1b_Ga=a,i=7,r=1,z=20,q=2;\x1b\\");
@@ -1535,24 +1809,20 @@ void TerminalApiTest::KittyPlaceholderRendersInRealTerminal()
     sm.ProcessString(L"\x1b[38;2;0;0;1m");
     sm.ProcessString(std::wstring{ L'\xDBFB', L'\xDEEE' });
 
-    // The placeholder must render the stored image's actual color (red), not merely produce
-    // an empty slice. Scan every slice's pixels for RGB(255,0,0).
-    auto renderedRed = false;
-    for (til::CoordType y = 0; y < 100 && !renderedRed; ++y)
+    const auto placements = tbi.GetImages().All();
+    VERIFY_ARE_EQUAL(size_t{ 1 }, placements.size(), L"the placeholder must register one direct-renderer fragment");
+    if (!placements.empty())
     {
-        if (const auto slice = tbi.GetRowByOffset(y).GetImageSlice())
-        {
-            for (const auto& px : slice->Pixels(ImageSlice::RenderPosition::AboveText))
-            {
-                if (px.rgbRed == 255 && px.rgbGreen == 0 && px.rgbBlue == 0)
-                {
-                    renderedRed = true;
-                    break;
-                }
-            }
-        }
+        const auto& pixel = placements.front().Surface().Pixels().front();
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbRed);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), pixel.rgbGreen);
+        VERIFY_ARE_EQUAL(static_cast<BYTE>(0), pixel.rgbBlue);
+        VERIFY_ARE_EQUAL((til::rect{ 0, 0, 1, 1 }), placements.front().CellBounds());
     }
-    VERIFY_IS_TRUE(renderedRed, L"a placeholder cell must render the stored image's red pixels in the real Terminal");
+    for (til::CoordType y = 0; y < 100; ++y)
+    {
+        VERIFY_IS_NULL(tbi.GetRowByOffset(y).GetImageSlice(), L"Kitty placeholders must not allocate row-local image pixels");
+    }
 }
 
 // An engine that withholds the text pass's background fill from the cells an image
@@ -1575,10 +1845,10 @@ void TerminalApiTest::KittyImageRowCarriesEachCellsBackgroundColor()
     const auto painted = std::ranges::find(frame.images, til::CoordType{ 0 }, &PaintedImage::targetRow);
     VERIFY_IS_TRUE(painted != frame.images.end(), L"the image row was never handed to the engine");
 
-    const std::vector<uint8_t> expectedMask{ 0, 0, 1, 1 };
+    const std::vector<uint8_t> expectedMask{ 0, 0, 1, 1, 1, 1, 1, 1 };
     VERIFY_ARE_EQUAL(expectedMask, painted->defaultBackgroundMask, L"only the two cells with an explicit background are non-default");
 
-    VERIFY_ARE_EQUAL(size_t{ 4 }, painted->cellBackgrounds.size(), L"the engine needs one color per column of the slice");
+    VERIFY_ARE_EQUAL(size_t{ 8 }, painted->cellBackgrounds.size(), L"the engine needs one color per visible column");
     VERIFY_ARE_EQUAL(RGB(4, 5, 6), painted->cellBackgrounds.at(0), L"a cell's own background color must survive to the engine");
     VERIFY_ARE_EQUAL(RGB(4, 5, 6), painted->cellBackgrounds.at(1), L"a cell's own background color must survive to the engine");
     VERIFY_ARE_EQUAL(painted->cellBackgrounds.at(2), painted->cellBackgrounds.at(3), L"the default-background cells must agree");
@@ -1651,20 +1921,10 @@ void TerminalApiTest::KittyPlaceholderSuppressesGlyphAfterResize()
 
     const til::point oldPosition{ 10, 0 };
     VERIFY_IS_NOT_NULL(initialBuffer.GetRowByOffset(oldPosition.y).GetImageCellRef(oldPosition.x));
-    auto initialSlice = initialBuffer.GetMutableRowByOffset(0).GetMutableImageSlice();
-    VERIFY_IS_NOT_NULL(initialSlice);
-    if (initialSlice)
-    {
-        auto sixelPixels = initialSlice->MutablePixels(0, 1);
-        for (auto y = 0; y < initialSlice->CellSize().height; ++y)
-        {
-            for (auto x = 0; x < initialSlice->CellSize().width; ++x)
-            {
-                *sixelPixels++ = RGBQUAD{ 255, 0, 0, 0 };
-            }
-            std::advance(sixelPixels, initialSlice->PixelWidth() - initialSlice->CellSize().width);
-        }
-    }
+    VERIFY_IS_NULL(initialBuffer.GetRowByOffset(0).GetImageSlice(), L"Kitty must not create row-local image pixels");
+    auto sixelSlice = std::make_unique<ImageSlice>(til::size{ 1, 1 });
+    *sixelSlice->MutablePixels(0, 1) = RGBQUAD{ 255, 0, 0, 0 };
+    initialBuffer.GetMutableRowByOffset(0).SetImageSlice(std::move(sixelSlice));
     fixture.StartPainting();
 
     fixture.terminal.LockConsole();

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -548,97 +548,117 @@ try
 }
 CATCH_RETURN()
 
+[[nodiscard]] HRESULT AtlasEngine::PrepareImageFrame(const ImageFrameInfo info) noexcept
+try
+{
+    _api.imagePlacements.assign(info.placements.begin(), info.placements.end());
+    _p.imageSurfaces.assign(info.surfaces.begin(), info.surfaces.end());
+    _api.imageViewportOrigin = info.viewportOrigin;
+    return S_OK;
+}
+CATCH_RETURN()
+
 // cellBackgrounds is unused here: this engine draws the whole row's backgrounds in
 // its own pass before any of the image quads it appends below, so content between
 // the background and the text already composites over the right color.
-[[nodiscard]] HRESULT AtlasEngine::BeginRowImages(const ImageSlice& imageSlice, const til::CoordType targetRow, const til::CoordType viewportLeft, const std::span<const uint8_t> defaultBackgroundMask, const std::span<const COLORREF> /*cellBackgrounds*/) noexcept
+[[nodiscard]] HRESULT AtlasEngine::BeginRowImages(const ImageSlice* const imageSlice, const til::CoordType targetRow, const til::CoordType viewportLeft, const std::span<const uint8_t> defaultBackgroundMask, const std::span<const COLORREF> /*cellBackgrounds*/) noexcept
 try
 {
     const auto y = clamp<til::CoordType>(targetRow, 0, _p.s->viewportCellCount.y - 1);
     const auto row = _p.rows[y];
-    const auto srcWidth = std::max(0, imageSlice.PixelWidth());
-    const auto srcCellSize = imageSlice.CellSize();
-    if (srcCellSize.width <= 0)
+    row->images.clear();
+    row->imageDefaultBackground.assign(defaultBackgroundMask.begin(), defaultBackgroundMask.end());
+    const auto bufferRow = targetRow + _api.imageViewportOrigin.y;
+    for (const auto& placement : _api.imagePlacements)
     {
-        return S_OK;
-    }
-    const auto columnCount = srcWidth / srcCellSize.width;
-
-    for (size_t i = 0; i < ImageSlice::RenderPositionCount; i++)
-    {
-        const auto position = static_cast<ImageSlice::RenderPosition>(i);
-        if (!imageSlice.HasPixels(position))
+        const auto bounds = placement.CellBounds();
+        if (bufferRow >= bounds.top && bufferRow < bounds.bottom)
         {
-            continue;
-        }
-
-        // Snapshots are cached by revision. A masked snapshot is no longer the
-        // slice's own pixels, so it needs a key of its own. Keeping those in the
-        // top half of the space puts them permanently out of reach of the
-        // revision counter, which starts at zero and only ever climbs.
-        auto revision = imageSlice.Revision(position);
-        const auto masked = position == ImageSlice::RenderPosition::BehindBackground &&
-                            defaultBackgroundMask.size() == gsl::narrow_cast<size_t>(columnCount);
-        if (masked)
-        {
-            for (const auto value : defaultBackgroundMask)
+            if (auto fragment = placement.Crop({ bounds.left, bufferRow, bounds.right, bufferRow + 1 }))
             {
-                revision = (revision ^ value) * 0x100000001b3ull;
+                row->images.emplace_back(std::move(*fragment));
             }
-            revision |= 0x8000000000000000ull;
         }
+    }
 
-        auto& b = til::at(row->bitmaps, i);
-
-        // If this row's ImageSlice has changed we need to update our snapshot.
-        // Theoretically another _p.rows[y]->bitmaps may have this particular revision already,
-        // but that can only happen if we're scrolling _and_ the entire viewport was invalidated.
-        if (b.revision != revision)
+    if (imageSlice)
+    {
+        const auto srcWidth = std::max(0, imageSlice->PixelWidth());
+        const auto srcCellSize = imageSlice->CellSize();
+        if (srcCellSize.width <= 0)
         {
-            const auto srcHeight = std::max(0, srcCellSize.height);
-            const auto pixels = imageSlice.Pixels(position);
-            const auto expectedSize = gsl::narrow_cast<size_t>(srcWidth) * gsl::narrow_cast<size_t>(srcHeight);
+            return S_OK;
+        }
+        const auto columnCount = srcWidth / srcCellSize.width;
 
-            // Sanity check.
-            if (pixels.size() != expectedSize)
+        for (size_t i = 0; i < ImageSlice::RenderPositionCount; i++)
+        {
+            const auto position = static_cast<ImageSlice::RenderPosition>(i);
+            if (!imageSlice->HasPixels(position))
             {
-                assert(false);
                 continue;
             }
 
-            if (b.source.size() != pixels.size())
-            {
-                b.source = Buffer<u32, 32>{ pixels.size() };
-            }
-
-            memcpy(b.source.data(), pixels.data(), pixels.size_bytes());
-
+            auto revision = imageSlice->Revision(position);
+            const auto maskOffset = imageSlice->ColumnOffset() - viewportLeft;
+            const auto masked = position == ImageSlice::RenderPosition::BehindBackground &&
+                                maskOffset >= 0 &&
+                                maskOffset + columnCount <= gsl::narrow_cast<til::CoordType>(defaultBackgroundMask.size());
             if (masked)
             {
-                // Content below the background is only visible through cells
-                // whose background is the default one.
-                for (auto column = 0; column < columnCount; column++)
+                for (auto column = 0; column < columnCount; ++column)
                 {
-                    if (til::at(defaultBackgroundMask, gsl::narrow_cast<size_t>(column)) != 0)
-                    {
-                        continue;
-                    }
-                    for (auto pixelRow = 0; pixelRow < srcHeight; pixelRow++)
-                    {
-                        const auto first = b.source.data() + gsl::narrow_cast<size_t>(pixelRow) * srcWidth + gsl::narrow_cast<size_t>(column) * srcCellSize.width;
-                        std::fill_n(first, srcCellSize.width, 0u);
-                    }
+                    revision = (revision ^ til::at(defaultBackgroundMask, gsl::narrow_cast<size_t>(maskOffset + column))) * 0x100000001b3ull;
                 }
+                revision |= 0x8000000000000000ull;
             }
 
-            b.revision = revision;
-            b.sourceSize.x = srcWidth;
-            b.sourceSize.y = srcHeight;
-        }
+            auto& b = til::at(row->bitmaps, i);
 
-        b.targetOffset = (imageSlice.ColumnOffset() - viewportLeft);
-        b.targetWidth = columnCount;
-        b.active = true;
+            if (b.revision != revision)
+            {
+                const auto srcHeight = std::max(0, srcCellSize.height);
+                const auto pixels = imageSlice->Pixels(position);
+                const auto expectedSize = gsl::narrow_cast<size_t>(srcWidth) * gsl::narrow_cast<size_t>(srcHeight);
+
+                if (pixels.size() != expectedSize)
+                {
+                    assert(false);
+                    continue;
+                }
+
+                if (b.source.size() != pixels.size())
+                {
+                    b.source = Buffer<u32, 32>{ pixels.size() };
+                }
+
+                memcpy(b.source.data(), pixels.data(), pixels.size_bytes());
+
+                if (masked)
+                {
+                    for (auto column = 0; column < columnCount; column++)
+                    {
+                        if (til::at(defaultBackgroundMask, gsl::narrow_cast<size_t>(maskOffset + column)) != 0)
+                        {
+                            continue;
+                        }
+                        for (auto pixelRow = 0; pixelRow < srcHeight; pixelRow++)
+                        {
+                            const auto first = b.source.data() + gsl::narrow_cast<size_t>(pixelRow) * srcWidth + gsl::narrow_cast<size_t>(column) * srcCellSize.width;
+                            std::fill_n(first, srcCellSize.width, 0u);
+                        }
+                    }
+                }
+
+                b.revision = revision;
+                b.sourceSize.x = srcWidth;
+                b.sourceSize.y = srcHeight;
+            }
+
+            b.targetOffset = (imageSlice->ColumnOffset() - viewportLeft);
+            b.targetWidth = columnCount;
+            b.active = true;
+        }
     }
     return S_OK;
 }

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -38,12 +38,13 @@ namespace Microsoft::Console::Render::Atlas
         [[nodiscard]] HRESULT InvalidateTitle(std::wstring_view proposedTitle) noexcept override;
         [[nodiscard]] HRESULT NotifyNewText(const std::wstring_view newText) noexcept override;
         [[nodiscard]] HRESULT PrepareRenderInfo(RenderFrameInfo info) noexcept override;
+        [[nodiscard]] HRESULT PrepareImageFrame(ImageFrameInfo info) noexcept override;
         [[nodiscard]] HRESULT ResetLineTransform() noexcept override;
         [[nodiscard]] HRESULT PrepareLineTransform(LineRendition lineRendition, til::CoordType targetRow, til::CoordType viewportLeft) noexcept override;
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
         [[nodiscard]] HRESULT PaintBufferLine(std::span<const Cluster> clusters, til::point coord, bool fTrimLeft) noexcept override;
         [[nodiscard]] HRESULT PaintBufferGridLines(const GridLineSet lines, const COLORREF gridlineColor, const COLORREF underlineColor, const size_t cchLine, const til::point coordTarget) noexcept override;
-        [[nodiscard]] HRESULT BeginRowImages(const ImageSlice& imageSlice, til::CoordType targetRow, til::CoordType viewportLeft, std::span<const uint8_t> defaultBackgroundMask, std::span<const COLORREF> cellBackgrounds) noexcept override;
+        [[nodiscard]] HRESULT BeginRowImages(const ImageSlice* imageSlice, til::CoordType targetRow, til::CoordType viewportLeft, std::span<const uint8_t> defaultBackgroundMask, std::span<const COLORREF> cellBackgrounds) noexcept override;
         [[nodiscard]] HRESULT EndRowImages() noexcept override;
         [[nodiscard]] HRESULT PaintSelection(const til::rect& rect) noexcept override;
         [[nodiscard]] HRESULT PaintCursor(const CursorOptions& options) noexcept override;
@@ -168,6 +169,8 @@ namespace Microsoft::Console::Render::Atlas
             u16x2 lastPaintBufferLineCoord{};
             // UpdateHyperlinkHoveredId()
             u16 hyperlinkHoveredId = 0;
+            std::vector<ImagePlacement> imagePlacements;
+            til::point imageViewportOrigin{};
 
             // These tracks the highlighted regions on the screen that are yet to be painted.
             std::span<const til::point_span> searchHighlights;

--- a/src/renderer/atlas/BackendD2D.cpp
+++ b/src/renderer/atlas/BackendD2D.cpp
@@ -30,6 +30,7 @@ void BackendD2D::ReleaseResources() noexcept
 {
     _renderTarget.reset();
     _renderTarget4.reset();
+    _imageCache.clear();
     // Ensure _handleSettingsUpdate() is called so that _renderTarget gets recreated.
     _generation = {};
 }
@@ -40,6 +41,7 @@ void BackendD2D::Render(RenderingPayload& p)
     {
         _handleSettingsUpdate(p);
     }
+    _pruneImageCache(p);
 
     _renderTarget->BeginDraw();
     try
@@ -85,6 +87,7 @@ void BackendD2D::_handleSettingsUpdate(const RenderingPayload& p)
 
     if (renderTargetChanged)
     {
+        _imageCache.clear();
         {
             wil::com_ptr<ID3D11Texture2D> buffer;
             THROW_IF_FAILED(p.swapChain.swapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), reinterpret_cast<void**>(buffer.addressof())));
@@ -232,6 +235,7 @@ void BackendD2D::_drawText(RenderingPayload& p)
             {
                 _drawBitmap(p, underlay, y);
             }
+            _drawImages(p, *row, y, static_cast<ImagePlacement::RenderPosition>(i));
         }
 
         if (row->lineRendition != LineRendition::SingleWidth)
@@ -336,6 +340,7 @@ void BackendD2D::_drawText(RenderingPayload& p)
         {
             _drawBitmap(p, overlay, y);
         }
+        _drawImages(p, *row, y, ImagePlacement::RenderPosition::AboveText);
 
         if (p.invalidatedRows.contains(y))
         {
@@ -848,6 +853,150 @@ void BackendD2D::_drawBitmap(const RenderingPayload& p, const Bitmap& b, u16 y) 
         static_cast<f32>(bottom),
     };
     _renderTarget->DrawBitmap(bitmap.get(), &rectF, 1, D2D1_BITMAP_INTERPOLATION_MODE_LINEAR);
+}
+
+void BackendD2D::_pruneImageCache(const RenderingPayload& p)
+{
+    for (auto it = _imageCache.begin(); it != _imageCache.end();)
+    {
+        auto active = false;
+        for (const auto row : p.rows)
+        {
+            active = std::any_of(row->images.begin(), row->images.end(), [&](const auto& placement) {
+                return placement.SurfacePointer().get() == it->first;
+            });
+            if (active)
+            {
+                break;
+            }
+        }
+        it = active ? std::next(it) : _imageCache.erase(it);
+    }
+}
+
+void BackendD2D::_drawImages(const RenderingPayload& p, const ShapedRow& row, const u16 y, const ImagePlacement::RenderPosition position)
+{
+    const auto cellWidth = p.s->font->cellSize.x;
+    const auto cellHeight = p.s->font->cellSize.y;
+    const auto rowTop = static_cast<f32>(y * cellHeight);
+    const auto rowBottom = rowTop + cellHeight;
+
+    for (const auto& placement : row.images)
+    {
+        if (placement.Position() != position)
+        {
+            continue;
+        }
+        const auto bounds = placement.CellBounds();
+        auto left = bounds.left;
+        const auto right = bounds.right;
+        if (position == ImagePlacement::RenderPosition::BehindBackground)
+        {
+            while (left < right)
+            {
+                while (left < right)
+                {
+                    const auto index = left - p.scrollOffsetX;
+                    if (index >= 0 && gsl::narrow_cast<size_t>(index) < row.imageDefaultBackground.size() && row.imageDefaultBackground[index] != 0)
+                    {
+                        break;
+                    }
+                    ++left;
+                }
+                const auto runBegin = left;
+                while (left < right)
+                {
+                    const auto index = left - p.scrollOffsetX;
+                    if (index < 0 || gsl::narrow_cast<size_t>(index) >= row.imageDefaultBackground.size() || row.imageDefaultBackground[index] == 0)
+                    {
+                        break;
+                    }
+                    ++left;
+                }
+                if (runBegin < left)
+                {
+                    const D2D1_RECT_F clip{
+                        static_cast<f32>((runBegin - p.scrollOffsetX) * cellWidth),
+                        rowTop,
+                        static_cast<f32>((left - p.scrollOffsetX) * cellWidth),
+                        rowBottom,
+                    };
+                    _drawImage(p, placement, clip);
+                }
+            }
+        }
+        else
+        {
+            const D2D1_RECT_F clip{
+                static_cast<f32>((left - p.scrollOffsetX) * cellWidth),
+                rowTop,
+                static_cast<f32>((right - p.scrollOffsetX) * cellWidth),
+                rowBottom,
+            };
+            _drawImage(p, placement, clip);
+        }
+    }
+}
+
+void BackendD2D::_drawImage(const RenderingPayload& p, const ImagePlacement& placement, const D2D1_RECT_F& clip)
+{
+    const auto& image = placement.SurfacePointer();
+    const auto snapshot = std::ranges::find(p.imageSurfaces, image.get(), [](const auto& surface) {
+        return surface.image.get();
+    });
+    THROW_HR_IF(E_UNEXPECTED, snapshot == p.imageSurfaces.end() || !snapshot->pixels);
+    auto& cached = _imageCache[image.get()];
+    cached.image = image;
+    if (!cached.bitmap)
+    {
+        const auto size = image->PixelSize();
+        const D2D1_SIZE_U bitmapSize{
+            gsl::narrow_cast<UINT32>(size.width),
+            gsl::narrow_cast<UINT32>(size.height),
+        };
+        const D2D1_BITMAP_PROPERTIES properties{
+            .pixelFormat = { DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED },
+            .dpiX = static_cast<f32>(p.s->font->dpi),
+            .dpiY = static_cast<f32>(p.s->font->dpi),
+        };
+        THROW_IF_FAILED(_renderTarget->CreateBitmap(bitmapSize, nullptr, 0, &properties, cached.bitmap.put()));
+    }
+    if (cached.revision != snapshot->revision)
+    {
+        const auto size = image->PixelSize();
+        const auto pixels = std::span{ *snapshot->pixels };
+        THROW_HR_IF(E_UNEXPECTED, pixels.size() != static_cast<size_t>(size.width) * size.height);
+        THROW_IF_FAILED(cached.bitmap->CopyFromMemory(nullptr, pixels.data(), gsl::narrow_cast<UINT32>(size.width * sizeof(RGBQUAD))));
+        cached.revision = snapshot->revision;
+    }
+
+    const auto cellWidth = static_cast<f32>(p.s->font->cellSize.x);
+    const auto cellHeight = static_cast<f32>(p.s->font->cellSize.y);
+    const auto original = placement.OriginalCellBounds();
+    const auto fragment = placement.CellBounds();
+    const auto& geometry = placement.Geometry();
+    const auto left = static_cast<f32>(original.left - p.scrollOffsetX) * cellWidth +
+                      static_cast<f32>(geometry.offset.x) * cellWidth / geometry.cellSize.width;
+    const auto top = clip.top -
+                     static_cast<f32>(fragment.top - original.top) * cellHeight +
+                     static_cast<f32>(geometry.offset.y) * cellHeight / geometry.cellSize.height;
+    const D2D1_RECT_F target{
+        left,
+        top,
+        left + static_cast<f32>(geometry.targetWidth) * cellWidth / geometry.cellSize.width,
+        top + static_cast<f32>(geometry.targetHeight) * cellHeight / geometry.cellSize.height,
+    };
+    const auto source = placement.SourceInPixels();
+    const D2D1_RECT_F sourceRect{
+        static_cast<f32>(source.left),
+        static_cast<f32>(source.top),
+        static_cast<f32>(source.right),
+        static_cast<f32>(source.bottom),
+    };
+
+    _renderTarget->PushAxisAlignedClip(&clip, D2D1_ANTIALIAS_MODE_ALIASED);
+    _renderTarget->DrawBitmap(cached.bitmap.get(), &target, 1, D2D1_BITMAP_INTERPOLATION_MODE_NEAREST_NEIGHBOR, &sourceRect);
+    _renderTarget->PopAxisAlignedClip();
 }
 
 void BackendD2D::_drawCursorPart1(const RenderingPayload& p)

--- a/src/renderer/atlas/BackendD2D.h
+++ b/src/renderer/atlas/BackendD2D.h
@@ -7,6 +7,7 @@
 
 #include "Backend.h"
 #include "BuiltinGlyphs.h"
+#include <unordered_map>
 
 namespace Microsoft::Console::Render::Atlas
 {
@@ -29,6 +30,9 @@ namespace Microsoft::Console::Render::Atlas
         ATLAS_ATTR_COLD f32r _getGlyphRunDesignBounds(const DWRITE_GLYPH_RUN& glyphRun, f32 baselineX, f32 baselineY);
         ATLAS_ATTR_COLD void _drawGridlineRow(const RenderingPayload& p, const ShapedRow* row, u16 y);
         ATLAS_ATTR_COLD void _drawBitmap(const RenderingPayload& p, const Bitmap& bitmap, u16 y) const;
+        void _drawImages(const RenderingPayload& p, const ShapedRow& row, u16 y, ImagePlacement::RenderPosition position);
+        void _drawImage(const RenderingPayload& p, const ImagePlacement& placement, const D2D1_RECT_F& clip);
+        void _pruneImageCache(const RenderingPayload& p);
         void _drawCursorPart1(const RenderingPayload& p);
         void _drawCursorPart2(const RenderingPayload& p);
         static void _drawCursor(const RenderingPayload& p, ID2D1RenderTarget* renderTarget, D2D1_RECT_F rect, ID2D1Brush* brush) noexcept;
@@ -63,6 +67,14 @@ namespace Microsoft::Console::Render::Atlas
         u32 _brushColor = 0;
 
         Buffer<DWRITE_GLYPH_METRICS> _glyphMetrics;
+
+        struct CachedImage
+        {
+            Image::Pointer image;
+            uint64_t revision = 0;
+            wil::com_ptr<ID2D1Bitmap> bitmap;
+        };
+        std::unordered_map<const Image*, CachedImage> _imageCache;
 
         til::generation_t _generation;
         til::generation_t _fontGeneration;

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -78,7 +78,8 @@ BackendD3D::BackendD3D(const RenderingPayload& p)
             { "renditionScale", 0, DXGI_FORMAT_R8G8_UINT, 1, offsetof(QuadInstance, renditionScale), D3D11_INPUT_PER_INSTANCE_DATA, 1 },
             { "position", 0, DXGI_FORMAT_R16G16_SINT, 1, offsetof(QuadInstance, position), D3D11_INPUT_PER_INSTANCE_DATA, 1 },
             { "size", 0, DXGI_FORMAT_R16G16_UINT, 1, offsetof(QuadInstance, size), D3D11_INPUT_PER_INSTANCE_DATA, 1 },
-            { "texcoord", 0, DXGI_FORMAT_R16G16_UINT, 1, offsetof(QuadInstance, texcoord), D3D11_INPUT_PER_INSTANCE_DATA, 1 },
+            { "texcoord", 0, DXGI_FORMAT_R32G32_FLOAT, 1, offsetof(QuadInstance, texcoord), D3D11_INPUT_PER_INSTANCE_DATA, 1 },
+            { "textureSize", 0, DXGI_FORMAT_R32G32_FLOAT, 1, offsetof(QuadInstance, textureSize), D3D11_INPUT_PER_INSTANCE_DATA, 1 },
             { "color", 0, DXGI_FORMAT_R8G8B8A8_UNORM, 1, offsetof(QuadInstance, color), D3D11_INPUT_PER_INSTANCE_DATA, 1 },
         };
         THROW_IF_FAILED(p.device->CreateInputLayout(&layout[0], std::size(layout), &shader_vs[0], sizeof(shader_vs), _inputLayout.addressof()));
@@ -205,6 +206,7 @@ void BackendD3D::ReleaseResources() noexcept
 {
     _renderTargetView.reset();
     _customRenderTargetView.reset();
+    _imageCache.clear();
     // Ensure _handleSettingsUpdate() is called so that _renderTarget gets recreated.
     _generation = {};
 }
@@ -817,6 +819,7 @@ void BackendD3D::_resetGlyphAtlas(const RenderingPayload& p, u32 minWidth, u32 m
         glyphs.clear();
     }
     _glyphAtlasBitmaps.clear();
+    _imageCache.clear();
 
     _d2dBeginDrawing();
     _d2dRenderTarget->Clear();
@@ -1111,6 +1114,7 @@ void BackendD3D::_drawText(RenderingPayload& p)
     {
         _resetGlyphAtlas(p, 0, 0);
     }
+    _pruneImageCache(p);
 
     til::CoordType dirtyTop = til::CoordTypeMax;
     til::CoordType dirtyBottom = til::CoordTypeMin;
@@ -1146,6 +1150,7 @@ void BackendD3D::_drawText(RenderingPayload& p)
             {
                 _drawBitmap(p, underlay, y);
             }
+            _drawImages(p, *row, y, static_cast<ImagePlacement::RenderPosition>(i));
         }
 
         for (const auto& m : row->mappings)
@@ -1199,7 +1204,10 @@ void BackendD3D::_drawText(RenderingPayload& p)
                         .renditionScale = renditionScale,
                         .position = { static_cast<i16>(l), static_cast<i16>(t) },
                         .size = glyphEntry->size,
-                        .texcoord = glyphEntry->texcoord,
+                        .texcoord = {
+                            static_cast<f32>(glyphEntry->texcoord.x),
+                            static_cast<f32>(glyphEntry->texcoord.y),
+                        },
                         .color = row->colors[x],
                     };
 
@@ -1224,6 +1232,7 @@ void BackendD3D::_drawText(RenderingPayload& p)
         {
             _drawBitmap(p, overlay, y);
         }
+        _drawImages(p, *row, y, ImagePlacement::RenderPosition::AboveText);
 
         if (p.invalidatedRows.contains(y))
         {
@@ -1902,6 +1911,226 @@ void BackendD3D::_drawGridlines(const RenderingPayload& p, u16 y)
     }
 }
 
+void BackendD3D::_pruneImageCache(const RenderingPayload& p)
+{
+    const auto hasStaleEntry = std::any_of(_imageCache.begin(), _imageCache.end(), [&](const auto& entry) {
+        for (const auto row : p.rows)
+        {
+            if (std::any_of(row->images.begin(), row->images.end(), [&](const auto& placement) {
+                    return placement.SurfacePointer().get() == entry.first;
+                }))
+            {
+                return false;
+            }
+        }
+        return true;
+    });
+    if (hasStaleEntry)
+    {
+        _resetGlyphAtlas(p, 0, 0);
+    }
+}
+
+void BackendD3D::_uploadImage(const RenderingPayload& p, const ImageFrameInfo::Surface& surface)
+{
+    const auto& image = surface.image;
+    THROW_HR_IF(E_UNEXPECTED, !image || !surface.pixels);
+    auto found = _imageCache.find(image.get());
+    if (found == _imageCache.end())
+    {
+        const auto size = image->PixelSize();
+        THROW_HR_IF(E_UNEXPECTED, size.width > Image::MaximumDimension || size.height > Image::MaximumDimension);
+        stbrp_rect rect{
+            .w = gsl::narrow_cast<stbrp_coord>(size.width),
+            .h = gsl::narrow_cast<stbrp_coord>(size.height),
+        };
+        _drawGlyphAtlasAllocate(p, rect);
+        auto& cached = _imageCache[image.get()];
+        cached.image = image;
+        cached.size = {
+            gsl::narrow_cast<u16>(size.width),
+            gsl::narrow_cast<u16>(size.height),
+        };
+        cached.texcoord = {
+            gsl::narrow_cast<u16>(rect.x),
+            gsl::narrow_cast<u16>(rect.y),
+        };
+        found = _imageCache.find(image.get());
+    }
+
+    auto& cached = found->second;
+    if (cached.revision == surface.revision)
+    {
+        return;
+    }
+
+    _d2dBeginDrawing();
+    const auto size = image->PixelSize();
+    const auto pixels = std::span{ *surface.pixels };
+    THROW_HR_IF(E_UNEXPECTED, pixels.size() != static_cast<size_t>(size.width) * size.height);
+    const D2D1_SIZE_U bitmapSize{
+        gsl::narrow_cast<UINT32>(size.width),
+        gsl::narrow_cast<UINT32>(size.height),
+    };
+    const D2D1_BITMAP_PROPERTIES properties{
+        .pixelFormat = { DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED },
+        .dpiX = static_cast<f32>(p.s->font->dpi),
+        .dpiY = static_cast<f32>(p.s->font->dpi),
+    };
+    wil::com_ptr<ID2D1Bitmap> bitmap;
+    THROW_IF_FAILED(_d2dRenderTarget->CreateBitmap(bitmapSize,
+                                                   pixels.data(),
+                                                   gsl::narrow_cast<UINT32>(size.width * sizeof(RGBQUAD)),
+                                                   &properties,
+                                                   bitmap.put()));
+    const D2D1_RECT_F destination{
+        static_cast<f32>(cached.texcoord.x),
+        static_cast<f32>(cached.texcoord.y),
+        static_cast<f32>(cached.texcoord.x + cached.size.x),
+        static_cast<f32>(cached.texcoord.y + cached.size.y),
+    };
+    _d2dRenderTarget->SetPrimitiveBlend(D2D1_PRIMITIVE_BLEND_COPY);
+    _d2dRenderTarget->DrawBitmap(bitmap.get(), &destination, 1, D2D1_BITMAP_INTERPOLATION_MODE_NEAREST_NEIGHBOR);
+    _d2dRenderTarget->SetPrimitiveBlend(D2D1_PRIMITIVE_BLEND_SOURCE_OVER);
+    cached.revision = surface.revision;
+}
+
+void BackendD3D::_drawImage(const RenderingPayload& p, const ImagePlacement& placement, const i32r& clip)
+{
+    const auto& image = placement.SurfacePointer();
+    const auto snapshot = std::ranges::find(p.imageSurfaces, image.get(), [](const auto& surface) {
+        return surface.image.get();
+    });
+    THROW_HR_IF(E_UNEXPECTED, snapshot == p.imageSurfaces.end());
+    _uploadImage(p, *snapshot);
+    const auto& cached = _imageCache.at(image.get());
+
+    const auto cellWidth = static_cast<int64_t>(p.s->font->cellSize.x);
+    const auto cellHeight = static_cast<int64_t>(p.s->font->cellSize.y);
+    const auto original = placement.OriginalCellBounds();
+    const auto fragment = placement.CellBounds();
+    const auto& geometry = placement.Geometry();
+    const auto targetLeft = (static_cast<int64_t>(original.left) - p.scrollOffsetX) * cellWidth +
+                            static_cast<int64_t>(geometry.offset.x) * cellWidth / geometry.cellSize.width;
+    const auto targetTop = static_cast<int64_t>(clip.top) -
+                           static_cast<int64_t>(fragment.top - original.top) * cellHeight +
+                           static_cast<int64_t>(geometry.offset.y) * cellHeight / geometry.cellSize.height;
+    const auto widthLimit = static_cast<uint64_t>(INT64_MAX / cellWidth);
+    const auto heightLimit = static_cast<uint64_t>(INT64_MAX / cellHeight);
+    const auto targetWidth = geometry.targetWidth > widthLimit ? INT64_MAX : static_cast<int64_t>(geometry.targetWidth * cellWidth / geometry.cellSize.width);
+    const auto targetHeight = geometry.targetHeight > heightLimit ? INT64_MAX : static_cast<int64_t>(geometry.targetHeight * cellHeight / geometry.cellSize.height);
+    if (targetWidth <= 0 || targetHeight <= 0)
+    {
+        return;
+    }
+    const auto targetRight = targetLeft > INT64_MAX - targetWidth ? INT64_MAX : targetLeft + targetWidth;
+    const auto targetBottom = targetTop > INT64_MAX - targetHeight ? INT64_MAX : targetTop + targetHeight;
+    const auto left = std::max<int64_t>(clip.left, targetLeft);
+    const auto top = std::max<int64_t>(clip.top, targetTop);
+    const auto right = std::min<int64_t>(clip.right, targetRight);
+    const auto bottom = std::min<int64_t>(clip.bottom, targetBottom);
+    if (left >= right || top >= bottom)
+    {
+        return;
+    }
+
+    const auto source = placement.SourceInPixels();
+    const auto sourceLeft = static_cast<double>(source.left) + static_cast<double>(left - targetLeft) * source.width() / targetWidth;
+    const auto sourceTop = static_cast<double>(source.top) + static_cast<double>(top - targetTop) * source.height() / targetHeight;
+    const auto sourceRight = static_cast<double>(source.left) + static_cast<double>(right - targetLeft) * source.width() / targetWidth;
+    const auto sourceBottom = static_cast<double>(source.top) + static_cast<double>(bottom - targetTop) * source.height() / targetHeight;
+    if (sourceLeft >= sourceRight || sourceTop >= sourceBottom)
+    {
+        return;
+    }
+
+    _appendQuad() = {
+        .shadingType = static_cast<u16>(ShadingType::TextPassthrough),
+        .renditionScale = { 1, 1 },
+        .position = {
+            gsl::narrow_cast<i16>(left),
+            gsl::narrow_cast<i16>(top),
+        },
+        .size = {
+            gsl::narrow_cast<u16>(right - left),
+            gsl::narrow_cast<u16>(bottom - top),
+        },
+        .texcoord = {
+            static_cast<f32>(cached.texcoord.x + sourceLeft),
+            static_cast<f32>(cached.texcoord.y + sourceTop),
+        },
+        .textureSize = {
+            static_cast<f32>(sourceRight - sourceLeft),
+            static_cast<f32>(sourceBottom - sourceTop),
+        },
+    };
+}
+
+void BackendD3D::_drawImages(const RenderingPayload& p, const ShapedRow& row, const u16 y, const ImagePlacement::RenderPosition position)
+{
+    const auto cellWidth = p.s->font->cellSize.x;
+    const auto cellHeight = p.s->font->cellSize.y;
+    const auto rowTop = y * cellHeight;
+    const auto rowBottom = rowTop + cellHeight;
+    for (const auto& placement : row.images)
+    {
+        if (placement.Position() != position)
+        {
+            continue;
+        }
+        const auto bounds = placement.CellBounds();
+        auto left = bounds.left;
+        const auto right = bounds.right;
+        if (position == ImagePlacement::RenderPosition::BehindBackground)
+        {
+            while (left < right)
+            {
+                while (left < right)
+                {
+                    const auto index = left - p.scrollOffsetX;
+                    if (index >= 0 && gsl::narrow_cast<size_t>(index) < row.imageDefaultBackground.size() && row.imageDefaultBackground[index] != 0)
+                    {
+                        break;
+                    }
+                    ++left;
+                }
+                const auto runBegin = left;
+                while (left < right)
+                {
+                    const auto index = left - p.scrollOffsetX;
+                    if (index < 0 || gsl::narrow_cast<size_t>(index) >= row.imageDefaultBackground.size() || row.imageDefaultBackground[index] == 0)
+                    {
+                        break;
+                    }
+                    ++left;
+                }
+                if (runBegin < left)
+                {
+                    _drawImage(p,
+                               placement,
+                               {
+                                   (runBegin - p.scrollOffsetX) * cellWidth,
+                                   rowTop,
+                                   (left - p.scrollOffsetX) * cellWidth,
+                                   rowBottom,
+                               });
+                }
+            }
+        }
+        else
+        {
+            _drawImage(p,
+                       placement,
+                       {
+                           (left - p.scrollOffsetX) * cellWidth,
+                           rowTop,
+                           (right - p.scrollOffsetX) * cellWidth,
+                           rowBottom,
+                       });
+        }
+    }
+}
+
 void BackendD3D::_drawBitmap(const RenderingPayload& p, const Bitmap& b, u16 y)
 {
     auto ab = _glyphAtlasBitmaps.lookup(b.revision);
@@ -1949,7 +2178,10 @@ void BackendD3D::_drawBitmap(const RenderingPayload& p, const Bitmap& b, u16 y)
         .renditionScale = { 1, 1 },
         .position = { static_cast<i16>(left), static_cast<i16>(top) },
         .size = ab->size,
-        .texcoord = ab->texcoord,
+        .texcoord = {
+            static_cast<f32>(ab->texcoord.x),
+            static_cast<f32>(ab->texcoord.y),
+        },
     };
 }
 
@@ -2248,6 +2480,7 @@ size_t BackendD3D::_drawCursorForegroundSlowPath(const CursorRect& c, size_t off
         const auto& cutout = cutouts[i];
         auto& target = _instances[offset + i];
 
+        target = it;
         target.shadingType = it.shadingType;
         target.renditionScale.x = it.renditionScale.x;
         target.renditionScale.y = it.renditionScale.y;
@@ -2255,8 +2488,8 @@ size_t BackendD3D::_drawCursorForegroundSlowPath(const CursorRect& c, size_t off
         target.position.y = static_cast<i16>(cutout.top);
         target.size.x = static_cast<u16>(cutout.right - cutout.left);
         target.size.y = static_cast<u16>(cutout.bottom - cutout.top);
-        target.texcoord.x = static_cast<u16>(it.texcoord.x + cutout.left - instanceL);
-        target.texcoord.y = static_cast<u16>(it.texcoord.y + cutout.top - instanceT);
+        target.texcoord.x = it.texcoord.x + cutout.left - instanceL;
+        target.texcoord.y = it.texcoord.y + cutout.top - instanceT;
         target.color = it.color;
     }
 
@@ -2267,6 +2500,7 @@ size_t BackendD3D::_drawCursorForegroundSlowPath(const CursorRect& c, size_t off
     // we don't append a new quad, but rather reuse the one that already exists (cutoutCount == 0).
     auto& target = cutoutCount ? _appendQuad() : _instances[offset];
 
+    target = it;
     target.shadingType = it.shadingType;
     target.renditionScale.x = it.renditionScale.x;
     target.renditionScale.y = it.renditionScale.y;
@@ -2274,8 +2508,8 @@ size_t BackendD3D::_drawCursorForegroundSlowPath(const CursorRect& c, size_t off
     target.position.y = static_cast<i16>(intersectionT);
     target.size.x = static_cast<u16>(intersectionR - intersectionL);
     target.size.y = static_cast<u16>(intersectionB - intersectionT);
-    target.texcoord.x = static_cast<u16>(it.texcoord.x + intersectionL - instanceL);
-    target.texcoord.y = static_cast<u16>(it.texcoord.y + intersectionT - instanceT);
+    target.texcoord.x = it.texcoord.x + intersectionL - instanceL;
+    target.texcoord.y = it.texcoord.y + intersectionT - instanceT;
     target.color = color;
 
     return addedInstances;

--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -7,6 +7,7 @@
 #include <til/flat_set.h>
 
 #include "Backend.h"
+#include <unordered_map>
 
 namespace Microsoft::Console::Render::Atlas
 {
@@ -95,7 +96,8 @@ namespace Microsoft::Console::Render::Atlas
             alignas(u16) u8x2 renditionScale;
             alignas(u32) i16x2 position;
             alignas(u32) u16x2 size;
-            alignas(u32) u16x2 texcoord;
+            alignas(u32) f32x2 texcoord;
+            alignas(u32) f32x2 textureSize;
             alignas(u32) u32 color;
         };
 
@@ -257,6 +259,10 @@ namespace Microsoft::Console::Render::Atlas
         static void _splitDoubleHeightGlyph(const RenderingPayload& p, const ShapedRow& row, AtlasFontFaceEntry& fontFaceEntry, AtlasGlyphEntry* glyphEntry);
         ATLAS_ATTR_COLD void _drawGridlines(const RenderingPayload& p, u16 y);
         ATLAS_ATTR_COLD void _drawBitmap(const RenderingPayload& p, const Bitmap& bitmap, u16 y);
+        void _drawImages(const RenderingPayload& p, const ShapedRow& row, u16 y, ImagePlacement::RenderPosition position);
+        void _drawImage(const RenderingPayload& p, const ImagePlacement& placement, const i32r& clip);
+        void _uploadImage(const RenderingPayload& p, const ImageFrameInfo::Surface& surface);
+        void _pruneImageCache(const RenderingPayload& p);
         void _drawCursorBackground(const RenderingPayload& p);
         ATLAS_ATTR_COLD void _drawCursorForeground();
         ATLAS_ATTR_COLD size_t _drawCursorForegroundSlowPath(const CursorRect& c, size_t offset);
@@ -297,6 +303,14 @@ namespace Microsoft::Console::Render::Atlas
         wil::com_ptr<ID3D11ShaderResourceView> _glyphAtlasView;
         til::linear_flat_set<AtlasFontFaceEntry, AtlasFontFaceEntryHashTrait> _glyphAtlasMap;
         til::linear_flat_set<AtlasBitmap, AtlasBitmapHashTrait> _glyphAtlasBitmaps;
+        struct CachedImage
+        {
+            Image::Pointer image;
+            uint64_t revision = 0;
+            u16x2 size{};
+            u16x2 texcoord{};
+        };
+        std::unordered_map<const Image*, CachedImage> _imageCache;
         AtlasFontFaceEntry _builtinGlyphs;
         Buffer<stbrp_node> _rectPackerData;
         stbrp_context _rectPacker{};

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -476,6 +476,8 @@ namespace Microsoft::Console::Render::Atlas
             {
                 bitmap.active = false;
             }
+            images.clear();
+            imageDefaultBackground.clear();
             gridLineRanges.clear();
             lineRendition = LineRendition::SingleWidth;
             dirtyTop = y * cellHeight;
@@ -495,6 +497,8 @@ namespace Microsoft::Console::Render::Atlas
         std::vector<u32> colors;
 
         std::array<Bitmap, ImageSlice::RenderPositionCount> bitmaps;
+        std::vector<ImagePlacement> images;
+        std::vector<uint8_t> imageDefaultBackground;
         std::vector<GridLineRange> gridLineRanges;
         LineRendition lineRendition = LineRendition::SingleWidth;
         til::CoordType dirtyTop = 0;
@@ -574,6 +578,7 @@ namespace Microsoft::Console::Render::Atlas
         // A generation of 1 ensures that the backends redraw the background on the first Present().
         // The 1st entry in this array corresponds to the background and the 2nd to the foreground bitmap.
         std::array<til::generation_t, 3> colorBitmapGenerations{ 1, 1, 1 };
+        std::vector<ImageFrameInfo::Surface> imageSurfaces;
         // In columns/rows.
         til::rect cursorRect;
         // The viewport/SwapChain area to be presented. In pixel.

--- a/src/renderer/atlas/shader_common.hlsl
+++ b/src/renderer/atlas/shader_common.hlsl
@@ -25,7 +25,8 @@ struct VSData
     uint2 renditionScale : renditionScale;
     int2 position : position;
     uint2 size : size;
-    uint2 texcoord : texcoord;
+    float2 texcoord : texcoord;
+    float2 textureSize : textureSize;
     float4 color : color;
 };
 

--- a/src/renderer/atlas/shader_vs.hlsl
+++ b/src/renderer/atlas/shader_vs.hlsl
@@ -20,6 +20,7 @@ PSData main(VSData data)
     // addition below this will transform our "position" from pixel into normalized device coordinate (NDC) space.
     output.position.xy = (data.position + data.vertex.xy * data.size) * positionScale + float2(-1.0f, 1.0f);
     output.position.zw = float2(0, 1);
-    output.texcoord = data.texcoord + data.vertex.xy * data.size;
+    float2 textureSize = any(data.textureSize) ? data.textureSize : data.size;
+    output.texcoord = data.texcoord + data.vertex.xy * textureSize;
     return output;
 }

--- a/src/renderer/base/RenderEngineBase.cpp
+++ b/src/renderer/base/RenderEngineBase.cpp
@@ -57,6 +57,11 @@ HRESULT RenderEngineBase::PrepareRenderInfo(RenderFrameInfo /*info*/) noexcept
     return S_FALSE;
 }
 
+HRESULT RenderEngineBase::PrepareImageFrame(ImageFrameInfo /*info*/) noexcept
+{
+    return S_FALSE;
+}
+
 HRESULT RenderEngineBase::ResetLineTransform() noexcept
 {
     return S_FALSE;
@@ -69,7 +74,7 @@ HRESULT RenderEngineBase::PrepareLineTransform(const LineRendition /*lineRenditi
     return S_FALSE;
 }
 
-HRESULT RenderEngineBase::BeginRowImages(const ImageSlice& /*imageSlice*/,
+HRESULT RenderEngineBase::BeginRowImages(const ImageSlice* /*imageSlice*/,
                                          const til::CoordType /*targetRow*/,
                                          const til::CoordType /*viewportLeft*/,
                                          const std::span<const uint8_t> /*defaultBackgroundMask*/,

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -501,6 +501,7 @@ DWORD Renderer::_timerToMillis(TimerRepr t) noexcept
         _updateCursorInfo();
         _invalidateCurrentCursor(); // NOTE: This now refers to the updated cursor position.
         _prepareNewComposition();
+        _prepareImageFrame();
 
         for (const auto pEngine : _engines)
         {
@@ -553,12 +554,18 @@ try
 
     // C. Prepare the engine with additional information before we start drawing.
     RETURN_IF_FAILED(_PrepareRenderInfo(pEngine));
+    const auto imageFrameResult = pEngine->PrepareImageFrame({
+        .placements = _imagePlacements,
+        .surfaces = _imageSurfaces,
+        .viewportOrigin = _viewport.Origin(),
+    });
+    RETURN_IF_FAILED(imageFrameResult);
 
     // 1. Paint Background
     RETURN_IF_FAILED(_PaintBackground(pEngine));
 
     // 2. Paint Rows of Text
-    _PaintBufferOutput(pEngine);
+    _PaintBufferOutput(pEngine, imageFrameResult == S_OK);
 
     // 4. Paint Selection
     _PaintSelection(pEngine);
@@ -1105,7 +1112,7 @@ bool Renderer::IsGlyphWideByFont(const std::wstring_view glyph)
 // - <none>
 // Return Value:
 // - <none>
-void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
+void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine, const bool directImagesSupported)
 {
     // This is the subsection of the entire screen buffer that is currently being presented.
     // It can move left/right or top/bottom depending on how the viewport is scrolled
@@ -1119,24 +1126,6 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
     LOG_IF_FAILED(pEngine->GetDirtyArea(dirtyAreas));
 
     auto& buffer = _pData->GetTextBuffer();
-    const auto visibleImages = buffer.GetImages().IntersectingRows(_viewport.Top(), _viewport.BottomExclusive());
-    til::small_vector<ImageSlice::ImageUpdate, 16> visibleImageUpdates;
-    visibleImageUpdates.reserve(visibleImages.size());
-    for (const auto placement : visibleImages)
-    {
-        const auto& surface = placement->Surface();
-        visibleImageUpdates.emplace_back(placement->Identity().imageId, surface.Pixels(), surface.Revision());
-    }
-    std::sort(visibleImageUpdates.begin(), visibleImageUpdates.end(), [](const auto& lhs, const auto& rhs) {
-        return lhs.imageId != rhs.imageId ? lhs.imageId < rhs.imageId : lhs.sourceRevision > rhs.sourceRevision;
-    });
-    const auto uniqueEnd = std::unique(visibleImageUpdates.begin(), visibleImageUpdates.end(), [](const auto& lhs, const auto& rhs) {
-        return lhs.imageId == rhs.imageId;
-    });
-    const auto imageUpdates = std::span<const ImageSlice::ImageUpdate>{
-        visibleImageUpdates.data(),
-        static_cast<size_t>(std::distance(visibleImageUpdates.begin(), uniqueEnd)),
-    };
 
     // This is to make sure any transforms are reset when this paint is finished.
     auto resetLineTransform = wil::scope_exit([&]() {
@@ -1204,15 +1193,27 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
 
             // Image content is painted around the text so that it can sit below
             // it. The engine decides how; all we do is bracket the text.
-            _syncImageSurfaces(r, imageUpdates);
             const auto imageSlice = r.GetImageSlice();
-            const auto hasImages = imageSlice && (imageSlice->HasPixels(ImageSlice::RenderPosition::BehindBackground) ||
-                                                  imageSlice->HasPixels(ImageSlice::RenderPosition::BehindText) ||
-                                                  imageSlice->HasPixels(ImageSlice::RenderPosition::AboveText));
+            const auto hasSliceImages = imageSlice && (imageSlice->HasPixels(ImageSlice::RenderPosition::BehindBackground) ||
+                                                       imageSlice->HasPixels(ImageSlice::RenderPosition::BehindText) ||
+                                                       imageSlice->HasPixels(ImageSlice::RenderPosition::AboveText));
+            ImagePlacement::RenderPosition directUnderlay{};
+            const auto hasDirectImages = directImagesSupported && _rowHasDirectImages(row, &directUnderlay);
+            const auto hasImages = hasSliceImages || hasDirectImages;
             if (hasImages) [[unlikely]]
             {
-                _buildImageRowBackgrounds(r, *imageSlice);
-                LOG_IF_FAILED(pEngine->BeginRowImages(*imageSlice, screenPosition.y, _viewport.Left(), _backgroundMask, _backgroundColors));
+                const auto hasSliceUnderlay = imageSlice && (imageSlice->HasPixels(ImageSlice::RenderPosition::BehindBackground) ||
+                                                             imageSlice->HasPixels(ImageSlice::RenderPosition::BehindText));
+                if (hasSliceUnderlay || (hasDirectImages && directUnderlay != ImagePlacement::RenderPosition::AboveText))
+                {
+                    _buildImageRowBackgrounds(r);
+                }
+                else
+                {
+                    _backgroundMask.clear();
+                    _backgroundColors.clear();
+                }
+                LOG_IF_FAILED(pEngine->BeginRowImages(hasSliceImages ? imageSlice : nullptr, screenPosition.y, _viewport.Left(), _backgroundMask, _backgroundColors));
             }
 
             // Painting text can throw, and an engine left mid-row would keep
@@ -1230,40 +1231,73 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
     }
 }
 
-void Renderer::_syncImageSurfaces(const ROW& row, const std::span<const ImageSlice::ImageUpdate> updates)
+void Renderer::_prepareImageFrame()
 {
-    const auto source = row.GetImageSlice();
-    if (!source)
+    _imagePlacements.clear();
+    _imageSurfaces.clear();
+    const auto bounds = _viewport.ToExclusive();
+    const auto placements = _pData->GetTextBuffer().GetImages().IntersectingRows(bounds.top, bounds.bottom);
+    _imagePlacements.reserve(placements.size());
+    for (const auto placement : placements)
     {
-        return;
+        if (auto cropped = placement->Crop(bounds))
+        {
+            _imagePlacements.emplace_back(std::move(*cropped));
+        }
     }
-
-    const_cast<ImageSlice*>(source)->UpdateImages(updates);
+    std::stable_sort(_imagePlacements.begin(), _imagePlacements.end(), [](const auto& lhs, const auto& rhs) {
+        return std::tuple{ lhs.ZIndex(), lhs.Identity().imageId } <
+               std::tuple{ rhs.ZIndex(), rhs.Identity().imageId };
+    });
+    _imageSurfaces.reserve(_imagePlacements.size());
+    for (const auto& placement : _imagePlacements)
+    {
+        const auto& image = placement.SurfacePointer();
+        const auto found = std::ranges::find(_imageSurfaces, image.get(), [](const auto& surface) {
+            return surface.image.get();
+        });
+        if (found == _imageSurfaces.end())
+        {
+            _imageSurfaces.emplace_back(ImageFrameInfo::Surface{
+                .image = image,
+                .pixels = image->Storage(),
+                .revision = image->Revision(),
+            });
+        }
+    }
 }
 
-// Resolves, for each column of `imageSlice`, whether the cell's background is the
+bool Renderer::_rowHasDirectImages(const til::CoordType row, ImagePlacement::RenderPosition* const underlay) const noexcept
+{
+    auto found = false;
+    auto firstPosition = ImagePlacement::RenderPosition::AboveText;
+    for (const auto& placement : _imagePlacements)
+    {
+        const auto bounds = placement.CellBounds();
+        if (row >= bounds.top && row < bounds.bottom)
+        {
+            found = true;
+            firstPosition = std::min(firstPosition, placement.Position());
+        }
+    }
+    if (underlay)
+    {
+        *underlay = firstPosition;
+    }
+    return found;
+}
+
+// Resolves, for each visible screen column, whether the cell's background is the
 // default one - content below the background only shows through where it is - and
 // what that background's color is, which content above the background has to be
 // composited over. Both are left empty when the slice has nothing to draw beneath
 // the text, which is the case for every image that predates layering.
-void Renderer::_buildImageRowBackgrounds(const ROW& r, const ImageSlice& imageSlice)
+void Renderer::_buildImageRowBackgrounds(const ROW& r)
 {
     _backgroundMask.clear();
     _backgroundColors.clear();
 
-    if (!imageSlice.HasPixels(ImageSlice::RenderPosition::BehindBackground) &&
-        !imageSlice.HasPixels(ImageSlice::RenderPosition::BehindText))
-    {
-        return;
-    }
-
-    const auto cellWidth = imageSlice.CellSize().width;
-    if (cellWidth <= 0)
-    {
-        return;
-    }
-
-    const auto columnCount = gsl::narrow_cast<size_t>(imageSlice.PixelWidth() / cellWidth);
+    const auto columnCount = gsl::narrow_cast<size_t>(_viewport.Width());
     // Reused across rows and frames; painting is hot and this would otherwise
     // be a heap allocation per row per frame. Columns we can't resolve keep the
     // default background, which hides content below it rather than letting it
@@ -1278,8 +1312,8 @@ void Renderer::_buildImageRowBackgrounds(const ROW& r, const ImageSlice& imageSl
     const auto readableColumns = r.GetReadableColumnCount();
     for (size_t column = 0; column < columnCount; column++)
     {
-        const auto sliceColumn = imageSlice.ColumnOffset() + gsl::narrow_cast<til::CoordType>(column);
-        const auto bufferColumn = sliceColumn >> scale;
+        const auto screenColumn = _viewport.Left() + gsl::narrow_cast<til::CoordType>(column);
+        const auto bufferColumn = screenColumn >> scale;
         if (bufferColumn >= 0 && bufferColumn < readableColumns)
         {
             const auto attributes = r.GetAttrByColumn(bufferColumn);

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -135,11 +135,12 @@ namespace Microsoft::Console::Render
         bool _CheckViewportAndScroll();
         void _scheduleRenditionBlink();
         [[nodiscard]] HRESULT _PaintBackground(_In_ IRenderEngine* const pEngine);
-        void _PaintBufferOutput(_In_ IRenderEngine* const pEngine);
+        void _PaintBufferOutput(_In_ IRenderEngine* const pEngine, bool directImagesSupported);
         ROW* _PaintBufferOutputComposition(TextBuffer& buffer, const ROW& r, const Composition& activeComposition);
         void _PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine, TextBufferCellIterator it, const til::point target);
-        void _syncImageSurfaces(const ROW& row, std::span<const ImageSlice::ImageUpdate> updates);
-        void _buildImageRowBackgrounds(const ROW& r, const ImageSlice& imageSlice);
+        void _prepareImageFrame();
+        void _buildImageRowBackgrounds(const ROW& r);
+        bool _rowHasDirectImages(til::CoordType row, ImagePlacement::RenderPosition* underlay = nullptr) const noexcept;
         void _PaintBufferOutputGridLineHelper(_In_ IRenderEngine* const pEngine, const TextAttribute textAttribute, const size_t cchLine, const til::point coordTarget);
         bool _isHoveredHyperlink(const TextAttribute& textAttribute) const noexcept;
         void _PaintSelection(_In_ IRenderEngine* const pEngine);
@@ -193,6 +194,8 @@ namespace Microsoft::Console::Render
         std::vector<Cluster> _clusterBuffer;
         std::vector<uint8_t> _backgroundMask;
         std::vector<COLORREF> _backgroundColors;
+        std::vector<ImagePlacement> _imagePlacements;
+        std::vector<ImageFrameInfo::Surface> _imageSurfaces;
         std::function<void()> _pfnBackgroundColorChanged;
         std::function<void()> _pfnFrameColorChanged;
         std::function<void()> _pfnRendererEnteredErrorState;

--- a/src/renderer/gdi/gdirenderer.hpp
+++ b/src/renderer/gdi/gdirenderer.hpp
@@ -16,6 +16,7 @@ Author(s):
 
 #include "../inc/RenderEngineBase.hpp"
 #include "../inc/FontResource.hpp"
+#include <unordered_map>
 
 namespace Microsoft::Console::Render
 {
@@ -54,7 +55,8 @@ namespace Microsoft::Console::Render
                                                    const COLORREF underlineColor,
                                                    const size_t cchLine,
                                                    const til::point coordTarget) noexcept override;
-        [[nodiscard]] HRESULT BeginRowImages(const ImageSlice& imageSlice,
+        [[nodiscard]] HRESULT PrepareImageFrame(ImageFrameInfo info) noexcept override;
+        [[nodiscard]] HRESULT BeginRowImages(const ImageSlice* imageSlice,
                                              til::CoordType targetRow,
                                              til::CoordType viewportLeft,
                                              std::span<const uint8_t> defaultBackgroundMask,
@@ -180,6 +182,20 @@ namespace Microsoft::Console::Render
         std::pmr::vector<std::pmr::vector<int>> _polyWidths;
 
         std::vector<RGBQUAD> _imagePlane;
+        struct CachedImageSurface
+        {
+            Image::Pointer image;
+            uint64_t revision = 0;
+            til::size size{};
+            wil::unique_hbitmap bitmap;
+            wil::unique_hdc context;
+            RGBQUAD* bits = nullptr;
+            bool allOpaque = false;
+            bool allTransparent = true;
+        };
+        std::unordered_map<const Image*, CachedImageSurface> _imageSurfaces;
+        std::vector<ImagePlacement> _frameImagePlacements;
+        til::point _imageViewportOrigin{};
         // A DIB section to blend image content from. Declared before the device
         // context that selects it so that the context is destroyed first and the
         // bitmap is no longer selected anywhere by the time it goes.
@@ -201,6 +217,17 @@ namespace Microsoft::Console::Render
         // or 0 if we never changed it. See BeginRowImages.
         int _restoreBkMode = 0;
 
+        [[nodiscard]] HRESULT _PrepareImageSurface(const ImageFrameInfo::Surface& surface) noexcept;
+        [[nodiscard]] HRESULT _PaintDirectImages(ImagePlacement::RenderPosition position,
+                                                 til::CoordType targetRow,
+                                                 std::span<const uint8_t> defaultBackgroundMask,
+                                                 bool markUnderlay) noexcept;
+        [[nodiscard]] HRESULT _PaintDirectImage(const ImagePlacement& placement, const RECT& clip) noexcept;
+        void _MarkDirectImageUnderlay(const ImagePlacement& placement,
+                                      til::CoordType targetRow,
+                                      std::span<const uint8_t> defaultBackgroundMask) noexcept;
+        void _MarkSliceUnderlay(const ImageSlice& imageSlice,
+                                til::CoordType viewportLeft) noexcept;
         [[nodiscard]] HRESULT _PaintImagePlane(const ImageSlice& imageSlice,
                                                ImageSlice::RenderPosition position,
                                                til::CoordType targetRow,
@@ -211,9 +238,7 @@ namespace Microsoft::Console::Render
         bool _UnderlayCoversColumn(til::CoordType column) const noexcept;        bool _UnderlayCoversBufferCell(til::CoordType bufferColumn) const noexcept;
         bool _UnderlayCoversAnyOf(til::CoordType columnBegin, til::CoordType columnEnd) const noexcept;
         [[nodiscard]] HRESULT _FillUncoveredRunBackground(const RECT& runRect, til::CoordType fontWidth) noexcept;
-        [[nodiscard]] HRESULT _FillImageRowCellBackgrounds(const ImageSlice& imageSlice,
-                                                           til::CoordType targetRow,
-                                                           til::CoordType viewportLeft,
+        [[nodiscard]] HRESULT _FillImageRowCellBackgrounds(til::CoordType targetRow,
                                                            std::span<const uint8_t> defaultBackgroundMask,
                                                            std::span<const COLORREF> cellBackgrounds) noexcept;
 

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -688,6 +688,324 @@ try
 }
 CATCH_RETURN();
 
+namespace
+{
+    struct DirectImageTarget
+    {
+        int64_t left;
+        int64_t top;
+        int64_t right;
+        int64_t bottom;
+    };
+
+    int64_t scaleImagePixels(const uint64_t value, const int64_t numerator, const int64_t denominator) noexcept
+    {
+        if (denominator <= 0 || numerator <= 0)
+        {
+            return 0;
+        }
+        const auto limit = static_cast<uint64_t>(INT64_MAX / numerator);
+        if (value > limit)
+        {
+            return INT64_MAX;
+        }
+        return static_cast<int64_t>(value * numerator / denominator);
+    }
+
+    DirectImageTarget resolveImageTarget(const ImagePlacement& placement, const til::size cellSize, const til::point viewportOrigin) noexcept
+    {
+        const auto bounds = placement.OriginalCellBounds();
+        const auto& geometry = placement.Geometry();
+        const auto left = (static_cast<int64_t>(bounds.left) - viewportOrigin.x) * cellSize.width +
+                          static_cast<int64_t>(geometry.offset.x) * cellSize.width / geometry.cellSize.width;
+        const auto top = (static_cast<int64_t>(bounds.top) - viewportOrigin.y) * cellSize.height +
+                         static_cast<int64_t>(geometry.offset.y) * cellSize.height / geometry.cellSize.height;
+        return {
+            left,
+            top,
+            left + scaleImagePixels(geometry.targetWidth, cellSize.width, geometry.cellSize.width),
+            top + scaleImagePixels(geometry.targetHeight, cellSize.height, geometry.cellSize.height),
+        };
+    }
+
+    LONG clampToLong(const int64_t value) noexcept
+    {
+        return static_cast<LONG>(std::clamp<int64_t>(value, LONG_MIN, LONG_MAX));
+    }
+}
+
+[[nodiscard]] HRESULT GdiEngine::PrepareImageFrame(const ImageFrameInfo info) noexcept
+try
+{
+    _frameImagePlacements.assign(info.placements.begin(), info.placements.end());
+    _imageViewportOrigin = info.viewportOrigin;
+
+    for (const auto& surface : info.surfaces)
+    {
+        RETURN_IF_FAILED(_PrepareImageSurface(surface));
+    }
+
+    for (auto it = _imageSurfaces.begin(); it != _imageSurfaces.end();)
+    {
+        const auto active = std::any_of(_frameImagePlacements.begin(), _frameImagePlacements.end(), [&](const auto& placement) {
+            return placement.SurfacePointer().get() == it->first;
+        });
+        if (active)
+        {
+            ++it;
+        }
+        else
+        {
+            it = _imageSurfaces.erase(it);
+        }
+    }
+    return S_OK;
+}
+CATCH_RETURN();
+
+[[nodiscard]] HRESULT GdiEngine::_PrepareImageSurface(const ImageFrameInfo::Surface& surface) noexcept
+try
+{
+    const auto& image = surface.image;
+    RETURN_HR_IF(E_INVALIDARG, !image);
+    RETURN_HR_IF(E_INVALIDARG, !surface.pixels);
+    auto& cached = _imageSurfaces.try_emplace(image.get()).first->second;
+    cached.image = image;
+
+    const auto size = image->PixelSize();
+    if (!cached.context)
+    {
+        cached.context.reset(CreateCompatibleDC(nullptr));
+        RETURN_LAST_ERROR_IF_NULL(cached.context.get());
+    }
+    if (!cached.bitmap || cached.size != size)
+    {
+        const BITMAPINFO info{
+            .bmiHeader = {
+                .biSize = sizeof(BITMAPINFOHEADER),
+                .biWidth = size.width,
+                .biHeight = -size.height,
+                .biPlanes = 1,
+                .biBitCount = 32,
+                .biCompression = BI_RGB,
+            }
+        };
+        void* bits = nullptr;
+        wil::unique_hbitmap bitmap{ CreateDIBSection(cached.context.get(), &info, DIB_RGB_COLORS, &bits, nullptr, 0) };
+        RETURN_LAST_ERROR_IF_NULL(bitmap.get());
+        RETURN_LAST_ERROR_IF_NULL(SelectObject(cached.context.get(), bitmap.get()));
+        cached.bitmap = std::move(bitmap);
+        cached.bits = static_cast<RGBQUAD*>(bits);
+        cached.size = size;
+        cached.revision = 0;
+    }
+
+    if (cached.revision != surface.revision)
+    {
+        const auto pixels = std::span{ *surface.pixels };
+        RETURN_HR_IF(E_INVALIDARG, pixels.size() != static_cast<size_t>(size.width) * size.height);
+        memcpy(cached.bits, pixels.data(), pixels.size_bytes());
+        cached.allOpaque = true;
+        cached.allTransparent = true;
+        for (const auto& pixel : pixels)
+        {
+            cached.allOpaque &= pixel.rgbReserved == 0xff;
+            cached.allTransparent &= pixel.rgbReserved == 0;
+        }
+        cached.revision = surface.revision;
+    }
+    return S_OK;
+}
+CATCH_RETURN();
+
+[[nodiscard]] HRESULT GdiEngine::_PaintDirectImage(const ImagePlacement& placement, const RECT& clip) noexcept
+try
+{
+    const auto found = _imageSurfaces.find(placement.SurfacePointer().get());
+    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), found == _imageSurfaces.end());
+    const auto& cached = found->second;
+    RETURN_HR_IF(S_OK, cached.allTransparent);
+
+    const auto cellSize = _GetFontSize();
+    const auto target = resolveImageTarget(placement, cellSize, _imageViewportOrigin);
+    const auto targetWidth = target.right - target.left;
+    const auto targetHeight = target.bottom - target.top;
+    RETURN_HR_IF(S_OK, targetWidth <= 0 || targetHeight <= 0);
+
+    const auto saved = SaveDC(_hdcMemoryContext);
+    RETURN_LAST_ERROR_IF(saved == 0);
+    const auto restore = wil::scope_exit([&]() {
+        RestoreDC(_hdcMemoryContext, saved);
+    });
+    RETURN_HR_IF(S_OK, IntersectClipRect(_hdcMemoryContext, clip.left, clip.top, clip.right, clip.bottom) == NULLREGION);
+
+    const auto source = placement.SourceInPixels();
+    const auto x = clampToLong(target.left);
+    const auto y = clampToLong(target.top);
+    const auto width = clampToLong(targetWidth);
+    const auto height = clampToLong(targetHeight);
+    if (cached.allOpaque)
+    {
+        SetStretchBltMode(_hdcMemoryContext, COLORONCOLOR);
+        RETURN_HR_IF(E_FAIL, !StretchBlt(_hdcMemoryContext,
+                                        x,
+                                        y,
+                                        width,
+                                        height,
+                                        cached.context.get(),
+                                        source.left,
+                                        source.top,
+                                        source.width(),
+                                        source.height(),
+                                        SRCCOPY));
+    }
+    else
+    {
+        constexpr BLENDFUNCTION blend{ .BlendOp = AC_SRC_OVER, .BlendFlags = 0, .SourceConstantAlpha = 255, .AlphaFormat = AC_SRC_ALPHA };
+        RETURN_HR_IF(E_FAIL, !GdiAlphaBlend(_hdcMemoryContext,
+                                           x,
+                                           y,
+                                           width,
+                                           height,
+                                           cached.context.get(),
+                                           source.left,
+                                           source.top,
+                                           source.width(),
+                                           source.height(),
+                                           blend));
+    }
+    return S_OK;
+}
+CATCH_RETURN();
+
+void GdiEngine::_MarkDirectImageUnderlay(const ImagePlacement& placement,
+                                         const til::CoordType targetRow,
+                                         const std::span<const uint8_t> defaultBackgroundMask) noexcept
+{
+    const auto found = _imageSurfaces.find(placement.SurfacePointer().get());
+    if (found == _imageSurfaces.end() || found->second.allTransparent)
+    {
+        return;
+    }
+
+    const auto cellSize = _GetFontSize();
+    const auto target = resolveImageTarget(placement, cellSize, _imageViewportOrigin);
+    const auto rowTop = static_cast<int64_t>(targetRow) * cellSize.height;
+    const auto rowBottom = rowTop + cellSize.height;
+    if (target.bottom <= rowTop || target.top >= rowBottom)
+    {
+        return;
+    }
+
+    const auto bounds = placement.CellBounds();
+    const auto left = std::max(bounds.left, _imageViewportOrigin.x);
+    const auto right = std::min(bounds.right, _imageViewportOrigin.x + gsl::narrow_cast<til::CoordType>(_underlayColumns.size()));
+    for (auto column = left; column < right; ++column)
+    {
+        const auto index = gsl::narrow_cast<size_t>(column - _imageViewportOrigin.x);
+        const auto cellLeft = static_cast<int64_t>(column - _imageViewportOrigin.x) * cellSize.width;
+        const auto cellRight = cellLeft + cellSize.width;
+        if (target.right <= cellLeft || target.left >= cellRight)
+        {
+            continue;
+        }
+        if (placement.Position() == ImagePlacement::RenderPosition::BehindBackground &&
+            (index >= defaultBackgroundMask.size() || til::at(defaultBackgroundMask, index) == 0))
+        {
+            continue;
+        }
+        til::at(_underlayColumns, index) = 1;
+    }
+}
+
+void GdiEngine::_MarkSliceUnderlay(const ImageSlice& imageSlice, const til::CoordType viewportLeft) noexcept
+{
+    const auto cellWidth = imageSlice.CellSize().width;
+    if (cellWidth <= 0 || !imageSlice.HasPixels(ImageSlice::RenderPosition::BehindText))
+    {
+        return;
+    }
+    const auto columns = imageSlice.PixelWidth() / cellWidth;
+    for (auto column = 0; column < columns; ++column)
+    {
+        const auto index = imageSlice.ColumnOffset() - viewportLeft + column;
+        if (index >= 0 && gsl::narrow_cast<size_t>(index) < _underlayColumns.size())
+        {
+            til::at(_underlayColumns, gsl::narrow_cast<size_t>(index)) = 1;
+        }
+    }
+}
+
+[[nodiscard]] HRESULT GdiEngine::_PaintDirectImages(const ImagePlacement::RenderPosition position,
+                                                    const til::CoordType targetRow,
+                                                    const std::span<const uint8_t> defaultBackgroundMask,
+                                                    const bool markUnderlay) noexcept
+try
+{
+    const auto cellSize = _GetFontSize();
+    const auto bufferRow = targetRow + _imageViewportOrigin.y;
+    for (const auto& placement : _frameImagePlacements)
+    {
+        const auto bounds = placement.CellBounds();
+        if (placement.Position() != position || bufferRow < bounds.top || bufferRow >= bounds.bottom)
+        {
+            continue;
+        }
+        if (markUnderlay)
+        {
+            _MarkDirectImageUnderlay(placement, targetRow, defaultBackgroundMask);
+        }
+
+        const auto left = std::max(bounds.left, _imageViewportOrigin.x);
+        const auto right = bounds.right;
+        if (left >= right)
+        {
+            continue;
+        }
+        const auto topPx = targetRow * cellSize.height;
+        const auto bottomPx = topPx + cellSize.height;
+        if (position == ImagePlacement::RenderPosition::BehindBackground)
+        {
+            RETURN_HR_IF(S_OK, defaultBackgroundMask.empty());
+            auto run = left;
+            while (run < right)
+            {
+                while (run < right && til::at(defaultBackgroundMask, gsl::narrow_cast<size_t>(run - _imageViewportOrigin.x)) == 0)
+                {
+                    ++run;
+                }
+                const auto runBegin = run;
+                while (run < right && til::at(defaultBackgroundMask, gsl::narrow_cast<size_t>(run - _imageViewportOrigin.x)) != 0)
+                {
+                    ++run;
+                }
+                if (runBegin < run)
+                {
+                    const RECT clip{
+                        (runBegin - _imageViewportOrigin.x) * cellSize.width,
+                        topPx,
+                        (run - _imageViewportOrigin.x) * cellSize.width,
+                        bottomPx,
+                    };
+                    RETURN_IF_FAILED(_PaintDirectImage(placement, clip));
+                }
+            }
+        }
+        else
+        {
+            const RECT clip{
+                (left - _imageViewportOrigin.x) * cellSize.width,
+                topPx,
+                (right - _imageViewportOrigin.x) * cellSize.width,
+                bottomPx,
+            };
+            RETURN_IF_FAILED(_PaintDirectImage(placement, clip));
+        }
+    }
+    return S_OK;
+}
+CATCH_RETURN();
+
 [[nodiscard]] HRESULT GdiEngine::_PaintImagePlane(const ImageSlice& imageSlice,
                                                  const ImageSlice::RenderPosition position,
                                                  const til::CoordType targetRow,
@@ -714,7 +1032,7 @@ try
     const auto columnCount = srcWidth / srcCellSize.width;
 
     auto plane = imageSlice.Pixels(position);
-    if (defaultBackgroundMask.size() == gsl::narrow_cast<size_t>(columnCount))
+    if (!defaultBackgroundMask.empty())
     {
         // Content below the background is only visible through cells whose
         // background is the default one. Blanking the rest makes it transparent
@@ -722,7 +1040,12 @@ try
         _imagePlane.assign(plane.begin(), plane.end());
         for (auto column = 0; column < columnCount; column++)
         {
-            if (til::at(defaultBackgroundMask, gsl::narrow_cast<size_t>(column)) != 0)
+            const auto maskIndex = defaultBackgroundMask.size() == gsl::narrow_cast<size_t>(columnCount) ?
+                                       column :
+                                       imageSlice.ColumnOffset() - viewportLeft + column;
+            if (maskIndex >= 0 &&
+                gsl::narrow_cast<size_t>(maskIndex) < defaultBackgroundMask.size() &&
+                til::at(defaultBackgroundMask, gsl::narrow_cast<size_t>(maskIndex)) != 0)
             {
                 continue;
             }
@@ -742,8 +1065,13 @@ try
     {
         for (auto column = 0; column < columnCount; column++)
         {
-            const auto slot = gsl::narrow_cast<size_t>(column);
-            if (slot >= _underlayColumns.size() || til::at(_underlayColumns, slot) != 0)
+            const auto screenColumn = imageSlice.ColumnOffset() - viewportLeft + column;
+            if (screenColumn < 0 || gsl::narrow_cast<size_t>(screenColumn) >= _underlayColumns.size())
+            {
+                continue;
+            }
+            const auto slot = gsl::narrow_cast<size_t>(screenColumn);
+            if (til::at(_underlayColumns, slot) != 0)
             {
                 continue;
             }
@@ -855,7 +1183,7 @@ CATCH_RETURN();
     return S_OK;
 }
 
-[[nodiscard]] HRESULT GdiEngine::BeginRowImages(const ImageSlice& imageSlice,
+[[nodiscard]] HRESULT GdiEngine::BeginRowImages(const ImageSlice* const imageSlice,
                                                 const til::CoordType targetRow,
                                                 const til::CoordType viewportLeft,
                                                 const std::span<const uint8_t> defaultBackgroundMask,
@@ -866,29 +1194,44 @@ try
     // only this row's text can end up above what we're about to paint.
     LOG_IF_FAILED(_FlushBufferLines());
 
-    const auto srcCellSize = imageSlice.CellSize();
-    _underlayColumns.clear();
-    _underlayColumnOffset = imageSlice.ColumnOffset();
+    _underlayColumns.assign(defaultBackgroundMask.size(), uint8_t{ 0 });
+    _underlayColumnOffset = viewportLeft;
     // The rendition is already baked into the slice's own geometry, but the
     // text's coordinates are not, so runs get scaled up to match.
     _underlayScale = _currentLineRendition != LineRendition::SingleWidth ? 1 : 0;
-    if (srcCellSize.width > 0)
-    {
-        _underlayColumns.assign(gsl::narrow_cast<size_t>(imageSlice.PixelWidth() / srcCellSize.width), uint8_t{ 0 });
-    }
-
     // The slice already accounts for line rendition in its own geometry, so it
     // is painted untransformed. The row's text still needs the transform.
     const auto rendition = _currentLineRendition;
     LOG_IF_FAILED(ResetLineTransform());
 
-    LOG_IF_FAILED(_PaintImagePlane(imageSlice, ImageSlice::RenderPosition::BehindBackground, targetRow, viewportLeft, defaultBackgroundMask, true));
+    if (imageSlice)
+    {
+        LOG_IF_FAILED(_PaintImagePlane(*imageSlice, ImageSlice::RenderPosition::BehindBackground, targetRow, viewportLeft, defaultBackgroundMask, true));
+        _MarkSliceUnderlay(*imageSlice, viewportLeft);
+    }
+    LOG_IF_FAILED(_PaintDirectImages(ImagePlacement::RenderPosition::BehindBackground, targetRow, defaultBackgroundMask, true));
+    for (const auto& placement : _frameImagePlacements)
+    {
+        if (placement.Position() == ImagePlacement::RenderPosition::BehindText)
+        {
+            const auto bounds = placement.CellBounds();
+            const auto bufferRow = targetRow + _imageViewportOrigin.y;
+            if (bufferRow >= bounds.top && bufferRow < bounds.bottom)
+            {
+                _MarkDirectImageUnderlay(placement, targetRow, {});
+            }
+        }
+    }
     // Content between the background and the text has to be composited over the
     // cell's own background, and the text pass will not paint one for any cell
     // this row's images cover. Lay it down now, in the one window where the plane
     // below the background is already painted and the plane above it is not.
-    LOG_IF_FAILED(_FillImageRowCellBackgrounds(imageSlice, targetRow, viewportLeft, defaultBackgroundMask, cellBackgrounds));
-    LOG_IF_FAILED(_PaintImagePlane(imageSlice, ImageSlice::RenderPosition::BehindText, targetRow, viewportLeft, {}, true));
+    LOG_IF_FAILED(_FillImageRowCellBackgrounds(targetRow, defaultBackgroundMask, cellBackgrounds));
+    if (imageSlice)
+    {
+        LOG_IF_FAILED(_PaintImagePlane(*imageSlice, ImageSlice::RenderPosition::BehindText, targetRow, viewportLeft, {}, true));
+    }
+    LOG_IF_FAILED(_PaintDirectImages(ImagePlacement::RenderPosition::BehindText, targetRow, {}, false));
 
     // Withholding ETO_OPAQUE stops the text filling its background *rectangle*,
     // but a device context also fills the box behind every individual glyph
@@ -905,7 +1248,7 @@ try
 
     LOG_IF_FAILED(PrepareLineTransform(rendition, targetRow, viewportLeft));
 
-    _rowImageSlice = &imageSlice;
+    _rowImageSlice = imageSlice;
     _rowImageTargetRow = targetRow;
     _rowImageViewportLeft = viewportLeft;
 
@@ -1006,43 +1349,33 @@ bool GdiEngine::_UnderlayCoversAnyOf(const til::CoordType columnBegin, const til
 // - cellBackgrounds - one color per slice column
 // Return Value:
 // - S_OK, or E_FAIL if GDI failed.
-[[nodiscard]] HRESULT GdiEngine::_FillImageRowCellBackgrounds(const ImageSlice& imageSlice,
-                                                              const til::CoordType targetRow,
-                                                              const til::CoordType viewportLeft,
+[[nodiscard]] HRESULT GdiEngine::_FillImageRowCellBackgrounds(const til::CoordType targetRow,
                                                               const std::span<const uint8_t> defaultBackgroundMask,
                                                               const std::span<const COLORREF> cellBackgrounds) noexcept
 try
 {
-    // Only content between the background and the text composites over the cell's
-    // background. The plane below the background is masked to the cells that have
-    // none, and the plane above the text is painted after the text pass has filled
-    // whatever it was going to fill.
-    if (!imageSlice.HasPixels(ImageSlice::RenderPosition::BehindText))
-    {
-        return S_OK;
-    }
-
-    const auto srcCellSize = imageSlice.CellSize();
-    RETURN_HR_IF(S_OK, srcCellSize.width <= 0);
-    const auto columnCount = gsl::narrow_cast<size_t>(imageSlice.PixelWidth() / srcCellSize.width);
+    const auto columnCount = _underlayColumns.size();
     RETURN_HR_IF(S_OK, cellBackgrounds.size() != columnCount || defaultBackgroundMask.size() != columnCount);
 
     const auto dstCellSize = _GetFontSize();
     RETURN_HR_IF(S_OK, dstCellSize.width <= 0 || dstCellSize.height <= 0);
     const auto top = targetRow * dstCellSize.height;
-    const auto left = (imageSlice.ColumnOffset() - viewportLeft) * dstCellSize.width;
+    const auto left = 0;
 
     // Adjacent cells usually share a colour, so they are filled as one rectangle.
     for (size_t column = 0; column < columnCount;)
     {
-        if (til::at(defaultBackgroundMask, column) != 0)
+        if (til::at(defaultBackgroundMask, column) != 0 || til::at(_underlayColumns, column) == 0)
         {
             column++;
             continue;
         }
         const auto color = til::at(cellBackgrounds, column);
         auto end = column + 1;
-        while (end < columnCount && til::at(defaultBackgroundMask, end) == 0 && til::at(cellBackgrounds, end) == color)
+        while (end < columnCount &&
+               til::at(defaultBackgroundMask, end) == 0 &&
+               til::at(_underlayColumns, end) != 0 &&
+               til::at(cellBackgrounds, end) == color)
         {
             end++;
         }
@@ -1065,6 +1398,7 @@ CATCH_RETURN();
 [[nodiscard]] HRESULT GdiEngine::EndRowImages() noexcept
 try
 {
+    const auto rendition = _currentLineRendition;
     // Push the row's text out over whatever was painted below it...
     _underlayColumns.clear();
     LOG_IF_FAILED(_FlushBufferLines());
@@ -1077,12 +1411,16 @@ try
     // ...and only then put the above-text content on top of all of it.
     if (_rowImageSlice)
     {
-        const auto rendition = _currentLineRendition;
         LOG_IF_FAILED(ResetLineTransform());
         LOG_IF_FAILED(_PaintImagePlane(*_rowImageSlice, ImageSlice::RenderPosition::AboveText, _rowImageTargetRow, _rowImageViewportLeft, {}, false));
-        LOG_IF_FAILED(PrepareLineTransform(rendition, _rowImageTargetRow, _rowImageViewportLeft));
-        _rowImageSlice = nullptr;
     }
+    else
+    {
+        LOG_IF_FAILED(ResetLineTransform());
+    }
+    LOG_IF_FAILED(_PaintDirectImages(ImagePlacement::RenderPosition::AboveText, _rowImageTargetRow, {}, false));
+    LOG_IF_FAILED(PrepareLineTransform(rendition, _rowImageTargetRow, _rowImageViewportLeft));
+    _rowImageSlice = nullptr;
 
     return S_OK;
 }

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -22,6 +22,7 @@ Author(s):
 #include "IRenderData.hpp"
 #include "RenderSettings.hpp"
 #include "../../buffer/out/LineRendition.hpp"
+#include "../../buffer/out/Image.hpp"
 #include "../../buffer/out/ImageSlice.hpp"
 
 #pragma warning(push)
@@ -34,6 +35,23 @@ namespace Microsoft::Console::Render
         const til::point_span* searchHighlightFocused;
         std::span<const til::point_span> selectionSpans;
         til::color selectionBackground;
+    };
+
+    // The placements are an owning snapshot of ImageCollection's frame-local
+    // views. Engines may retain copies until EndPaint without depending on the
+    // collection's next-mutation invalidation rules.
+    struct ImageFrameInfo
+    {
+        struct Surface
+        {
+            Image::Pointer image;
+            Image::PixelStorage pixels;
+            uint64_t revision = 0;
+        };
+
+        std::span<const ImagePlacement> placements;
+        std::span<const Surface> surfaces;
+        til::point viewportOrigin;
     };
 
     enum class GridLines
@@ -75,12 +93,16 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT InvalidateTitle(std::wstring_view proposedTitle) noexcept = 0;
         [[nodiscard]] virtual HRESULT NotifyNewText(const std::wstring_view newText) noexcept = 0;
         [[nodiscard]] virtual HRESULT PrepareRenderInfo(RenderFrameInfo info) noexcept = 0;
+        // S_OK means complete Image surfaces are supported. S_FALSE is the
+        // explicit fallback for nonvisual engines and engines that have never
+        // supported terminal graphics.
+        [[nodiscard]] virtual HRESULT PrepareImageFrame(ImageFrameInfo info) noexcept = 0;
         [[nodiscard]] virtual HRESULT ResetLineTransform() noexcept = 0;
         [[nodiscard]] virtual HRESULT PrepareLineTransform(LineRendition lineRendition, til::CoordType targetRow, til::CoordType viewportLeft) noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintBackground() noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintBufferLine(std::span<const Cluster> clusters, til::point coord, bool fTrimLeft) noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintBufferGridLines(GridLineSet lines, COLORREF gridlineColor, COLORREF underlineColor, size_t cchLine, til::point coordTarget) noexcept = 0;
-        [[nodiscard]] virtual HRESULT BeginRowImages(const ImageSlice& imageSlice, til::CoordType targetRow, til::CoordType viewportLeft, std::span<const uint8_t> defaultBackgroundMask, std::span<const COLORREF> cellBackgrounds) noexcept = 0;
+        [[nodiscard]] virtual HRESULT BeginRowImages(const ImageSlice* imageSlice, til::CoordType targetRow, til::CoordType viewportLeft, std::span<const uint8_t> defaultBackgroundMask, std::span<const COLORREF> cellBackgrounds) noexcept = 0;
         [[nodiscard]] virtual HRESULT EndRowImages() noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintSelection(const til::rect& rect) noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintCursor(const CursorOptions& options) noexcept = 0;

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -37,13 +37,14 @@ namespace Microsoft::Console::Render
                                              const size_t centeringHint) noexcept override;
 
         [[nodiscard]] HRESULT PrepareRenderInfo(RenderFrameInfo info) noexcept override;
+        [[nodiscard]] HRESULT PrepareImageFrame(ImageFrameInfo info) noexcept override;
 
         [[nodiscard]] HRESULT ResetLineTransform() noexcept override;
         [[nodiscard]] HRESULT PrepareLineTransform(const LineRendition lineRendition,
                                                    const til::CoordType targetRow,
                                                    const til::CoordType viewportLeft) noexcept override;
 
-        [[nodiscard]] HRESULT BeginRowImages(const ImageSlice& imageSlice,
+        [[nodiscard]] HRESULT BeginRowImages(const ImageSlice* imageSlice,
                                              til::CoordType targetRow,
                                              til::CoordType viewportLeft,
                                              std::span<const uint8_t> defaultBackgroundMask,

--- a/src/terminal/adapter/KittyParser.cpp
+++ b/src/terminal/adapter/KittyParser.cpp
@@ -5,7 +5,6 @@
 
 #include "KittyParser.hpp"
 #include "adaptDispatch.hpp"
-#include "../buffer/out/ImageSlice.hpp"
 #include "../../inc/unicode.hpp"
 #include <til/unicode.h>
 #include "../../types/inc/Viewport.hpp"
@@ -60,7 +59,7 @@ void KittyParser::RestoreMainBufferState() noexcept
         _mainBufferState.reset();
         _restoreBufferState(std::move(state));
     }
-    RefreshImageLayers();
+    RefreshImageSurfaces();
     _scheduleAnimationTimer();
 }
 
@@ -500,12 +499,6 @@ void KittyParser::_ProcessCommand(const Control& command, const std::string_view
                 success = false;
                 return;
             }
-            if (!_placementFitsMemory(image, targetImageId, layerId, command.cols, command.rows, command.srcX, command.srcY, command.srcW, command.srcH, command.zIndex, childAnchor))
-            {
-                success = false;
-                code = L"ENOMEM:image layer memory limit exceeded";
-                return;
-            }
             // Draw at the resolved anchor; the cursor must NOT move for a relative placement.
             til::size drawn;
             try
@@ -565,12 +558,6 @@ void KittyParser::_ProcessCommand(const Control& command, const std::string_view
             !_movePlacementChildren({ targetImageId, placementId }, cursorPos, false, code))
         {
             success = false;
-            return;
-        }
-        if (!_placementFitsMemory(image, targetImageId, layerId, command.cols, command.rows, command.srcX, command.srcY, command.srcW, command.srcH, command.zIndex))
-        {
-            success = false;
-            code = L"ENOMEM:image layer memory limit exceeded";
             return;
         }
         til::size drawn;
@@ -908,6 +895,13 @@ void KittyParser::_ProcessCommand(const Control& command, const std::string_view
                     code = L"EINVAL:missing dimensions";
                     break;
                 }
+                if (width > static_cast<uint32_t>(::Image::MaximumDimension) ||
+                    height > static_cast<uint32_t>(::Image::MaximumDimension))
+                {
+                    success = false;
+                    code = L"EFBIG:image dimensions exceed renderer limit";
+                    break;
+                }
                 const auto area = static_cast<uint64_t>(width) * height;
                 if (area > bytes.size() / depth || area * depth != bytes.size())
                 {
@@ -934,10 +928,19 @@ void KittyParser::_ProcessCommand(const Control& command, const std::string_view
                     // or undecodable payload is an error, not a silently-empty image.
                     std::vector<RGBQUAD> decoded;
                     til::size decodedSize;
-                    if (!bytes.empty() &&
+                    const auto decodedSuccessfully =
+                        !bytes.empty() &&
                         _dispatcher._api.DecodeImageToBgra(bytes, decoded, decodedSize) &&
                         decodedSize.width > 0 && decodedSize.height > 0 &&
-                        decoded.size() == static_cast<size_t>(decodedSize.width) * decodedSize.height)
+                        decoded.size() == static_cast<size_t>(decodedSize.width) * decodedSize.height;
+                    if (decodedSuccessfully &&
+                        (decodedSize.width > ::Image::MaximumDimension || decodedSize.height > ::Image::MaximumDimension))
+                    {
+                        success = false;
+                        code = L"EFBIG:image dimensions exceed renderer limit";
+                        break;
+                    }
+                    if (decodedSuccessfully)
                     {
                         image.width = static_cast<uint32_t>(decodedSize.width);
                         image.height = static_cast<uint32_t>(decodedSize.height);
@@ -1117,7 +1120,7 @@ void KittyParser::_ProcessCommand(const Control& command, const std::string_view
                         {
                             _eraseImage(imageId);
                         }
-                        _eraseImageRows(imageId);
+                        _eraseImagePlacements(imageId);
                     }
                 }
                 else
@@ -1149,7 +1152,7 @@ void KittyParser::_ProcessCommand(const Control& command, const std::string_view
                             {
                                 _eraseImage(targetId);
                             }
-                            _eraseImageRows(targetId);
+                            _eraseImagePlacements(targetId);
                         }
                     }
                 }
@@ -1415,12 +1418,12 @@ bool KittyParser::_registerImage(const uint32_t id, Image&& image)
     for (const auto victimId : victims)
     {
         _erasePlacementsForImage(victimId);
-        _eraseImageRows(victimId);
+        _eraseImagePlacements(victimId);
         _eraseImage(victimId);
     }
 
     // Re-transmitting an id replaces its pixels and invalidates all prior placements.
-    _eraseImageRows(id);
+    _eraseImagePlacements(id);
     _erasePlacementsForImage(id);
     _eraseImage(id);
     _imageOrder.push_back(id);
@@ -1488,12 +1491,14 @@ void KittyParser::_eraseImage(const uint32_t id)
     }
 }
 
-// Clears the entire image registry and erases all drawn kitty placements, leaving any
-// co-resident Sixel pixels (image id 0) untouched. Slices that share a row with Sixel
-// keep that content; slices left fully empty are dropped.
+// Clears the entire image registry and its direct-renderer placements. Sixel row
+// slices are independent and remain untouched.
 void KittyParser::_clearImages() noexcept
 try
 {
+    auto page = _dispatcher._pages.ActivePage();
+    auto& buffer = page.Buffer();
+    const auto hadPlacements = !buffer.GetImages().Empty();
     _images.clear();
     _imageNumbers.clear();
     _imageOrder.clear();
@@ -1502,46 +1507,8 @@ try
     _anonymousPlacements.clear();
     _totalPixelBytes = 0;
     _scheduleAnimationTimer();
-    auto page = _dispatcher._pages.ActivePage();
-    auto& buffer = page.Buffer();
     buffer.GetMutableImages().Clear();
-    auto erased = false;
-    for (auto row = 0; row < page.Bottom(); ++row)
-    {
-        auto& dstRow = buffer.GetMutableRowByOffset(row);
-        const auto slice = dstRow.GetMutableImageSlice();
-        if (!slice)
-        {
-            continue;
-        }
-        // Erase every owned (non-Sixel) column; co-resident Sixel (id 0) survives.
-        const auto cellWidth = std::max(1, slice->CellSize().width);
-        const auto columnBegin = slice->ColumnOffset();
-        const auto columnEnd = columnBegin + slice->PixelWidth() / cellWidth;
-        std::vector<uint32_t> owners;
-        for (auto column = columnBegin; column < columnEnd; ++column)
-        {
-            for (const auto layerKey : slice->LayersAtColumn(column))
-            {
-                const auto owner = layerKey.imageId;
-                if (std::find(owners.begin(), owners.end(), owner) == owners.end())
-                {
-                    owners.push_back(owner);
-                }
-            }
-        }
-        auto sliceEmpty = false;
-        for (const auto owner : owners)
-        {
-            sliceEmpty = slice->EraseLayer(owner);
-            erased = true;
-        }
-        if (sliceEmpty)
-        {
-            dstRow.SetImageSlice(nullptr);
-        }
-    }
-    if (erased)
+    if (hadPlacements)
     {
         buffer.TriggerRedraw(Viewport::FromExclusive({ 0, 0, page.Width(), page.Bottom() }));
     }
@@ -1679,16 +1646,6 @@ size_t KittyParser::_frameCount(const Image& image) noexcept
     return !image.pixels || image.pixels->empty() ? 0 : image.animationFrames.size() + 1;
 }
 
-std::vector<RGBQUAD>* KittyParser::_framePixels(Image& image, const uint32_t frameNumber) noexcept
-{
-    if (frameNumber == 1)
-    {
-        return image.pixels.get();
-    }
-    const auto index = static_cast<size_t>(frameNumber) - 2;
-    return index < image.animationFrames.size() ? image.animationFrames[index].pixels.get() : nullptr;
-}
-
 const std::vector<RGBQUAD>* KittyParser::_framePixels(const Image& image, const uint32_t frameNumber) noexcept
 {
     if (frameNumber == 1)
@@ -1699,7 +1656,19 @@ const std::vector<RGBQUAD>* KittyParser::_framePixels(const Image& image, const 
     return index < image.animationFrames.size() ? image.animationFrames[index].pixels.get() : nullptr;
 }
 
-const ::Image::PixelStorage* KittyParser::_frameStorage(const Image& image, const uint32_t frameNumber) noexcept
+KittyParser::FramePixelStorage* KittyParser::_frameStorage(Image& image, const uint32_t frameNumber) noexcept
+{
+    if (frameNumber == 1)
+    {
+        return image.pixels ? &image.pixels : nullptr;
+    }
+    const auto index = static_cast<size_t>(frameNumber) - 2;
+    return index < image.animationFrames.size() && image.animationFrames[index].pixels ?
+               &image.animationFrames[index].pixels :
+               nullptr;
+}
+
+const KittyParser::FramePixelStorage* KittyParser::_frameStorage(const Image& image, const uint32_t frameNumber) noexcept
 {
     if (frameNumber == 1)
     {
@@ -1721,42 +1690,29 @@ int32_t* KittyParser::_frameGap(Image& image, const uint32_t frameNumber) noexce
     return index < image.animationFrames.size() ? &image.animationFrames[index].gapMilliseconds : nullptr;
 }
 
-void KittyParser::_updateImageLayers(const uint32_t imageId, const ::Image::PixelStorage& storage)
+void KittyParser::_updateImageSurface(const uint32_t imageId, const FramePixelStorage& storage)
 {
     const auto image = _images.find(imageId);
     if (image == _images.end() || !storage)
     {
         return;
     }
-    const std::span<const RGBQUAD> pixels{ *storage };
-    if (image->second.surface)
-    {
-        image->second.surface->UpdatePixels(storage);
-    }
-    if (!image->second.hasRenderedPlacements)
-    {
-        return;
-    }
-
     const auto visiblePageNumber = _dispatcher._pages.VisiblePage().Number();
-    auto foundLayer = false;
+    auto surface = image->second.surface;
+    auto foundPlacement = false;
     _dispatcher._pages.ForEachPage([&](const Page page) {
         auto& buffer = page.Buffer();
         auto firstRow = page.Bottom();
         auto lastRow = 0;
-        for (auto row = 0; row < page.Bottom(); ++row)
+        for (const auto& placement : buffer.GetImages().All())
         {
-            const auto* slice = buffer.GetRowByOffset(row).GetImageSlice();
-            if (slice && slice->Contains(imageId))
+            if (placement.Identity().imageId == imageId)
             {
-                foundLayer = true;
-                auto* mutableSlice = buffer.GetMutableRowByOffset(row).GetMutableImageSlice();
-                const auto surfaceRevision = image->second.surface ? image->second.surface->Revision() : 0;
-                if (mutableSlice->UpdateImage(imageId, pixels, surfaceRevision))
-                {
-                    firstRow = std::min(firstRow, row);
-                    lastRow = std::max(lastRow, row);
-                }
+                foundPlacement = true;
+                surface = surface ? surface : placement.SurfacePointer();
+                const auto bounds = placement.CellBounds();
+                firstRow = std::min(firstRow, bounds.top);
+                lastRow = std::max(lastRow, bounds.bottom - 1);
             }
         }
         if (page.Number() == visiblePageNumber && firstRow <= lastRow)
@@ -1764,17 +1720,19 @@ void KittyParser::_updateImageLayers(const uint32_t imageId, const ::Image::Pixe
             buffer.TriggerRedraw(Viewport::FromExclusive({ 0, firstRow, page.Width(), lastRow + 1 }));
         }
     });
-    if (!foundLayer)
+    image->second.hasRenderedPlacements = foundPlacement;
+    if (foundPlacement && surface)
     {
-        image->second.hasRenderedPlacements = false;
-        _dispatcher._pages.ForEachPage([&](const Page page) {
-            page.Buffer().GetMutableImages().EraseImage(imageId);
-        });
+        image->second.surface = surface;
+        surface->UpdatePixels(storage);
+    }
+    else
+    {
         _releaseImageSurface(image->second);
     }
 }
 
-void KittyParser::RefreshImageLayers()
+void KittyParser::RefreshImageSurfaces()
 {
     for (const auto& [imageId, image] : _images)
     {
@@ -1784,7 +1742,7 @@ void KittyParser::RefreshImageLayers()
         }
         if (const auto pixels = _frameStorage(image, image.presentedFrame))
         {
-            _updateImageLayers(imageId, *pixels);
+            _updateImageSurface(imageId, *pixels);
         }
     }
     _scheduleAnimationTimer();
@@ -1983,7 +1941,7 @@ try
                               command.upperX == 1);
     }
 
-    auto appendedFrame = ::Image::PixelStorage{};
+    auto appendedFrame = FramePixelStorage{};
     if (editFrame == 0)
     {
         // Allocate every fallible part of the append before eviction mutates unrelated
@@ -1997,7 +1955,7 @@ try
                 continue;
             }
             _erasePlacementsForImage(victimId);
-            _eraseImageRows(victimId);
+            _eraseImagePlacements(victimId);
             _eraseImage(victimId);
         }
         imageIt = _images.find(imageId);
@@ -2008,7 +1966,7 @@ try
     uint32_t changedFrame = 0;
     if (editFrame != 0)
     {
-        *_framePixels(storedImage, editFrame) = std::move(canvas);
+        *_frameStorage(storedImage, editFrame) = std::make_shared<std::vector<RGBQUAD>>(std::move(canvas));
         changedFrame = editFrame;
         if (command.haveZ && command.zIndex != 0)
         {
@@ -2027,7 +1985,7 @@ try
 
     if (storedImage.presentedFrame == changedFrame)
     {
-        _updateImageLayers(imageId, *_frameStorage(storedImage, changedFrame));
+        _updateImageSurface(imageId, *_frameStorage(storedImage, changedFrame));
     }
     const auto now = std::chrono::steady_clock::now();
     if (storedImage.animationState == 2 && storedImage.waitingForFrames)
@@ -2080,7 +2038,7 @@ bool KittyParser::_processAnimationControl(const Control& command, const uint32_
     {
         image.currentFrame = command.cols;
         image.presentedFrame = image.currentFrame;
-        _updateImageLayers(imageId, *_frameStorage(image, image.currentFrame));
+        _updateImageSurface(imageId, *_frameStorage(image, image.currentFrame));
         reschedule = true;
     }
     if (command.rows != 0 && command.haveZ && command.zIndex != 0)
@@ -2128,7 +2086,7 @@ try
     const auto sourceFrame = command.rows;
     const auto destinationFrame = command.cols;
     const auto* source = _framePixels(image, sourceFrame);
-    auto* destination = _framePixels(image, destinationFrame);
+    const auto* destination = _framePixels(image, destinationFrame);
     if (sourceFrame == 0 || destinationFrame == 0 || !source || !destination)
     {
         code = L"ENOENT:frame not found";
@@ -2175,16 +2133,18 @@ try
         const auto srcOffset = static_cast<size_t>(command.upperY + row) * image.width + command.upperX;
         std::copy_n(source->begin() + srcOffset, width, sourcePixels.begin() + static_cast<size_t>(row) * width);
     }
+    auto composed = *destination;
     for (uint32_t row = 0; row < height; ++row)
     {
         const auto dstOffset = static_cast<size_t>(command.srcY + row) * image.width + command.srcX;
-        _compositePixels(std::span{ *destination }.subspan(dstOffset, width),
+        _compositePixels(std::span{ composed }.subspan(dstOffset, width),
                               std::span{ sourcePixels }.subspan(static_cast<size_t>(row) * width, width),
                               command.noCursorMovement);
     }
+    *_frameStorage(image, destinationFrame) = std::make_shared<std::vector<RGBQUAD>>(std::move(composed));
     if (image.presentedFrame == destinationFrame)
     {
-        _updateImageLayers(imageId, *_frameStorage(image, destinationFrame));
+        _updateImageSurface(imageId, *_frameStorage(image, destinationFrame));
     }
     return true;
 }
@@ -2214,7 +2174,7 @@ void KittyParser::_scheduleAnimation(const uint32_t imageId, Image& image, const
         if (image.presentedFrame != image.currentFrame)
         {
             image.presentedFrame = image.currentFrame;
-            _updateImageLayers(imageId, *_frameStorage(image, image.presentedFrame));
+            _updateImageSurface(imageId, *_frameStorage(image, image.presentedFrame));
         }
         image.nextFrameTime = now + std::chrono::milliseconds(*gap);
     }
@@ -2275,7 +2235,7 @@ bool KittyParser::_advanceImage(const uint32_t imageId, Image& image, const std:
         {
             image.waitingForFrames = false;
             image.presentedFrame = image.currentFrame;
-            _updateImageLayers(imageId, *_frameStorage(image, image.currentFrame));
+            _updateImageSurface(imageId, *_frameStorage(image, image.currentFrame));
             image.nextFrameTime = now + std::chrono::milliseconds(*gap);
             return true;
         }
@@ -2340,7 +2300,7 @@ void KittyParser::_deleteAnimationFrames(const uint32_t imageId, const uint32_t 
         if (freeData)
         {
             _erasePlacementsForImage(imageId);
-            _eraseImageRows(imageId);
+            _eraseImagePlacements(imageId);
             _eraseImage(imageId);
         }
         _scheduleAnimationTimer();
@@ -2384,12 +2344,12 @@ void KittyParser::_deleteAnimationFrames(const uint32_t imageId, const uint32_t 
         image.waitingForFrames = false;
         image.nextFrameTime = {};
     }
-    _updateImageLayers(imageId, *_frameStorage(image, image.presentedFrame));
+    _updateImageSurface(imageId, *_frameStorage(image, image.presentedFrame));
 
     if (freeData && remaining == 1)
     {
         _erasePlacementsForImage(imageId);
-        _eraseImageRows(imageId);
+        _eraseImagePlacements(imageId);
         _eraseImage(imageId);
     }
     else if (image.animationState == 2 || image.animationState == 3)
@@ -2399,68 +2359,8 @@ void KittyParser::_deleteAnimationFrames(const uint32_t imageId, const uint32_t 
     _scheduleAnimationTimer();
 }
 
-bool KittyParser::_placementFitsMemory(const Image& image, const uint32_t imageId, const uint64_t layerId, const uint32_t cols, const uint32_t rows, const uint32_t srcX, const uint32_t srcY, const uint32_t srcW, const uint32_t srcH, const int32_t zIndex, const std::optional<til::point> anchor) const noexcept
-{
-    if (!image.pixels || image.pixels->empty() || image.width == 0 || image.height == 0)
-    {
-        return true;
-    }
-    const auto page = _dispatcher._pages.ActivePage();
-    const auto& buffer = page.Buffer();
-    const auto origin = anchor.has_value() ? *anchor : page.Cursor().GetPosition();
-    const auto cellSize = _dispatcher._api.GetCellSize();
-    const auto cellWidth = std::max(1, cellSize.width);
-    const auto cellHeight = std::max(1, cellSize.height);
-    const til::size clampedCellSize{ cellWidth, cellHeight };
-    const auto imageWidth = static_cast<til::CoordType>(image.width);
-    const auto imageHeight = static_cast<til::CoordType>(image.height);
-    const auto cropX = static_cast<til::CoordType>(std::min<uint32_t>(srcX, image.width));
-    const auto cropY = static_cast<til::CoordType>(std::min<uint32_t>(srcY, image.height));
-    const auto cropW = srcW == 0 ? imageWidth - cropX : std::min(static_cast<til::CoordType>(std::min<uint32_t>(srcW, image.width)), imageWidth - cropX);
-    const auto cropH = srcH == 0 ? imageHeight - cropY : std::min(static_cast<til::CoordType>(std::min<uint32_t>(srcH, image.height)), imageHeight - cropY);
-    if (cropW <= 0 || cropH <= 0)
-    {
-        return true;
-    }
-
-    const auto [targetW64, targetH64] = _targetPixels(cropW, cropH, cols, rows, cellWidth, cellHeight);
-    const auto targetW = std::max<int64_t>(targetW64, 1);
-    const auto targetH = std::max<int64_t>(targetH64, 1);
-    const auto columns = static_cast<til::CoordType>(std::min<int64_t>((targetW + cellWidth - 1) / cellWidth, page.Width()));
-    const auto columnBegin = origin.x;
-    const auto columnEnd = std::min(columnBegin + columns, page.Width());
-    const auto rowSpan = static_cast<til::CoordType>(std::min<int64_t>((targetH + cellHeight - 1) / cellHeight, page.Bottom()));
-    if (columnEnd <= columnBegin || rowSpan <= 0)
-    {
-        return true;
-    }
-    auto available = ImageSlice::LayerBytesAvailable();
-    ImageSlice emptySlice{ clampedCellSize };
-    for (auto row = 0; row < rowSpan; ++row)
-    {
-        const auto rowOffset = origin.y + row;
-        if (rowOffset < 0 || rowOffset >= page.Bottom())
-        {
-            break;
-        }
-        const auto slice = buffer.GetRowByOffset(rowOffset).GetImageSlice();
-        const auto required = slice && slice->CellSize() == clampedCellSize ?
-                                  slice->WriteMemoryUpperBound(columnBegin, columnEnd, { imageId, layerId }, zIndex) :
-                                  emptySlice.WriteMemoryUpperBound(columnBegin, columnEnd, { imageId, layerId }, zIndex);
-        if (required > available)
-        {
-            return false;
-        }
-        available -= required;
-    }
-    return true;
-}
-
-// Draws a stored image at the cursor as one ImageSlice per text row, tagging each
-// covered column with imageId for targeted delete. Geometry per the kitty spec: x/y/w/h
-// crop a source pixel rect (w/h=0=to-edge), c/r scale to a cell span (one axis preserves
-// aspect) via nearest-neighbour; oversize spans clip. Cursor advances by the span unless
-// moveCursor is false (C=1).
+// Registers a complete shared image surface and its placement geometry. The renderer
+// applies source cropping and target scaling directly, without row-local rasterization.
 // Protocol: https://sw.kovidgoyal.net/kitty/graphics-protocol/#controlling-displayed-image-layout
 til::size KittyParser::_placeImage(const Image& image, const bool moveCursor, const uint32_t imageId, const uint64_t layerId, const uint32_t cols, const uint32_t rows, const uint32_t srcX, const uint32_t srcY, const uint32_t srcW, const uint32_t srcH, const uint32_t cellOffsetX, const uint32_t cellOffsetY, const int32_t zIndex, const std::optional<til::point> anchor)
 {
@@ -2516,90 +2416,8 @@ til::size KittyParser::_placeImage(const Image& image, const bool moveCursor, co
     {
         return {};
     }
-    // Fill the whole owned footprint, so the X-offset gutter and any right-truncation are drawn.
-    const auto drawWidth = static_cast<til::CoordType>(static_cast<int64_t>(columnEnd - columnBegin) * cellWidth);
     const int64_t spanHeightPx = targetH;
     const auto rowSpan = static_cast<til::CoordType>(std::min<int64_t>((spanHeightPx + cellHeight - 1) / cellHeight, page.Bottom()));
-    // Precompute the source column for each drawn destination pixel (nearest-neighbour).
-    // Columns before the X offset OR past the shifted image's right edge have no source
-    // (sentinel -1 = transparent), so a right-shifted image is truncated, not stretched.
-    std::vector<til::CoordType> sampleXMap(static_cast<size_t>(drawWidth));
-    for (auto x = 0; x < drawWidth; ++x)
-    {
-        const auto imgX = x - offsetX;
-        sampleXMap[x] = (imgX < 0 || imgX >= targetW) ? -1 : cropX + std::min(cropW - 1, static_cast<til::CoordType>(static_cast<int64_t>(imgX) * cropW / targetW));
-    }
-
-    struct StagedImageRow
-    {
-        til::CoordType row = 0;
-        ImageSlice::Pointer slice;
-    };
-    std::vector<StagedImageRow> stagedRows;
-    stagedRows.reserve(static_cast<size_t>(rowSpan));
-    const auto stageRow = [&](const til::CoordType rowOffset) -> ImageSlice::Pointer& {
-        const auto found = std::find_if(stagedRows.begin(), stagedRows.end(), [&](const auto& staged) {
-            return staged.row == rowOffset;
-        });
-        if (found != stagedRows.end())
-        {
-            return found->slice;
-        }
-        const auto existing = buffer.GetRowByOffset(rowOffset).GetImageSlice();
-        auto copy = existing ? std::make_unique<ImageSlice>(*existing) : nullptr;
-        stagedRows.push_back({ rowOffset, std::move(copy) });
-        return stagedRows.back().slice;
-    };
-
-    for (auto row = 0; row < rowSpan; ++row)
-    {
-        const auto rowOffset = origin.y + row;
-        if (rowOffset < 0 || rowOffset >= page.Bottom())
-        {
-            break;
-        }
-        auto& staged = stageRow(rowOffset);
-        if (!staged || staged->CellSize() != clampedCellSize)
-        {
-            staged = std::make_unique<ImageSlice>(clampedCellSize);
-        }
-        staged->BumpRevision();
-        const auto dstSlice = staged.get();
-        auto dstIterator = dstSlice->MutablePixels(columnBegin, columnEnd, { imageId, layerId }, zIndex);
-        auto sourceIterator = dstSlice->MutableSourceIndices(columnBegin, columnEnd, { imageId, layerId }, zIndex);
-        for (auto pixelRow = 0; pixelRow < cellHeight; ++pixelRow)
-        {
-            const auto dstY = row * cellHeight + pixelRow;
-            // Destination rows before the Y offset (and past the image bottom) are blank.
-            const auto srcDstY = dstY - offsetY;
-            const auto rowInImage = srcDstY >= 0 && srcDstY < targetH;
-            const auto sampleY = rowInImage ? cropY + std::min(cropH - 1, static_cast<til::CoordType>(static_cast<int64_t>(srcDstY) * cropH / targetH)) : 0;
-            const auto srcRowStart = static_cast<size_t>(sampleY) * image.width;
-            // Always write every covered pixel (transparent for the X/Y gutters and past
-            // the image) so a reused slice never shows stale content under these columns.
-            for (auto pixelColumn = 0; pixelColumn < drawWidth; ++pixelColumn)
-            {
-                RGBQUAD px{};
-                auto sourceIndex = ImageSlice::NoSourceIndex;
-                if (rowInImage && sampleXMap[pixelColumn] >= 0)
-                {
-                    const auto srcIndex = srcRowStart + static_cast<size_t>(sampleXMap[pixelColumn]);
-                    if (srcIndex < framePixels->size())
-                    {
-                        px = til::at(*framePixels, srcIndex);
-                        sourceIndex = gsl::narrow_cast<uint32_t>(srcIndex);
-                    }
-                }
-                til::at(dstIterator, pixelColumn) = px;
-                til::at(sourceIterator, pixelColumn) = sourceIndex;
-            }
-            if (pixelRow + 1 < cellHeight)
-            {
-                std::advance(dstIterator, dstSlice->PixelWidth());
-                std::advance(sourceIterator, dstSlice->PixelWidth());
-            }
-        }
-    }
     auto redrawTop = std::max(0, origin.y);
     auto redrawBottom = std::min(origin.y + rowSpan, page.Bottom());
     const auto drawnColumns = columnEnd - columnBegin;
@@ -2631,10 +2449,6 @@ til::size KittyParser::_placeImage(const Image& image, const bool moveCursor, co
         {
             image.surface = std::move(surface);
         }
-    }
-    for (auto& staged : stagedRows)
-    {
-        buffer.GetMutableRowByOffset(staged.row).SetImageSlice(std::move(staged.slice));
     }
     buffer.TriggerRedraw(Viewport::FromExclusive({ 0, redrawTop, page.Width(), redrawBottom }));
 
@@ -2778,7 +2592,7 @@ void KittyParser::_registerPlacement(const Placement& placement)
 // A registered placement is the root of a bounded tree: every relative child has one parent,
 // anonymous children are leaves, and creation-time validation rejects cycles/depth overflow.
 // Build the tree index and complete movement plan once, then preflight it before the parent is
-// changed. The apply pass erases each old placement by its retained layer identity before
+// changed. The apply pass erases each old collection placement by its identity before
 // redrawing descendants parent-first, so the move never depends on stale creation rectangles.
 // Protocol: https://sw.kovidgoyal.net/kitty/graphics-protocol/#relative-placements
 bool KittyParser::_movePlacementChildren(const std::pair<uint32_t, uint32_t>& parent, const til::point parentAnchor, const bool apply, std::wstring_view& code)
@@ -2880,31 +2694,14 @@ bool KittyParser::_movePlacementChildren(const std::pair<uint32_t, uint32_t>& pa
 
     if (!apply)
     {
-        for (const auto& move : plan)
-        {
-            const auto image = _images.find(move.previous.imageId);
-            if (image == _images.end())
+        return std::ranges::all_of(plan, [&](const auto& move) {
+            if (_images.contains(move.previous.imageId))
             {
-                code = L"ENOENT:relative child image not found";
-                return false;
+                return true;
             }
-            if (!_placementFitsMemory(image->second,
-                                           move.previous.imageId,
-                                           move.previous.layerId,
-                                           move.previous.displayCols,
-                                           move.previous.displayRows,
-                                           move.previous.srcX,
-                                           move.previous.srcY,
-                                           move.previous.srcW,
-                                           move.previous.srcH,
-                                           move.previous.zIndex,
-                                           move.anchor))
-            {
-                code = L"ENOMEM:image layer memory limit exceeded";
-                return false;
-            }
-        }
-        return true;
+            code = L"ENOENT:relative child image not found";
+            return false;
+        });
     }
 
     for (const auto& move : plan)
@@ -3048,7 +2845,7 @@ void KittyParser::_erasePlacementsForImage(const uint32_t imageId)
     }
 
     // Drop this image's own anonymous placements (their cells are covered by the caller's broad
-    // _eraseImageRows(imageId), but the tracking entries must go too).
+    // _eraseImagePlacements(imageId), but the tracking entries must go too).
     for (auto it = _anonymousPlacements.begin(); it != _anonymousPlacements.end();)
     {
         if (it->imageId == imageId)
@@ -3090,7 +2887,7 @@ bool KittyParser::_imageHasPlacements(const uint32_t id) const noexcept
     return false;
 }
 
-bool KittyParser::_imageHasRenderedLayers(const uint32_t id) const
+bool KittyParser::_imageHasRenderedPlacements(const uint32_t id) const
 {
     auto found = false;
     _dispatcher._pages.ForEachPage([&](const Page page) {
@@ -3098,11 +2895,9 @@ bool KittyParser::_imageHasRenderedLayers(const uint32_t id) const
         {
             return;
         }
-        const auto& buffer = page.Buffer();
-        for (auto row = 0; row < page.Bottom(); ++row)
+        for (const auto& placement : page.Buffer().GetImages().All())
         {
-            const auto* slice = buffer.GetRowByOffset(row).GetImageSlice();
-            if (slice && slice->Contains(id))
+            if (placement.Identity().imageId == id)
             {
                 found = true;
                 return;
@@ -3132,7 +2927,7 @@ void KittyParser::_cascadePlacementChildren(std::deque<std::pair<uint32_t, uint3
             const auto& p = it->second;
             if (p.hasParent && p.parentImageId == parent.first && p.parentPlacementId == parent.second)
             {
-                // Erase this child's exact retained layer without disturbing sibling placements.
+                // Erase this child's exact collection placement without disturbing siblings.
                 _erasePlacementCells(p);
                 if (p.isVirtual)
                 {
@@ -3160,7 +2955,7 @@ void KittyParser::_cascadePlacementChildren(std::deque<std::pair<uint32_t, uint3
                 if (anonImageId != keepImageId && _images.count(anonImageId) != 0 && !_imageHasPlacements(anonImageId))
                 {
                     _eraseImage(anonImageId);
-                    _eraseImageRows(anonImageId);
+                    _eraseImagePlacements(anonImageId);
                 }
             }
             else
@@ -3174,7 +2969,7 @@ void KittyParser::_cascadePlacementChildren(std::deque<std::pair<uint32_t, uint3
         if (childImageId != keepImageId && _images.count(childImageId) != 0 && !_imageHasPlacements(childImageId))
         {
             _eraseImage(childImageId);
-            _eraseImageRows(childImageId);
+            _eraseImagePlacements(childImageId);
         }
     }
 }
@@ -3262,7 +3057,7 @@ void KittyParser::_deleteAllPlacements(const bool freeData)
         for (const auto imageId : unreferencedImages)
         {
             _eraseImage(imageId);
-            _eraseImageRows(imageId);
+            _eraseImagePlacements(imageId);
         }
     }
     _scheduleAnimationTimer();
@@ -3284,32 +3079,32 @@ void KittyParser::_deleteImagesIntersecting(const til::CoordType left, const til
     {
         return;
     }
-    // Collect owners first; erasing mutates the buffer, so we must not delete while scanning. The
-    // affected set is tiny (usually one image), so a linear-dedup vector is enough.
+    // Collect owners first; erasing mutates the collection, so views remain valid only
+    // until this scan completes.
     std::vector<uint32_t> affected;
-    for (auto row = rowBegin; row < rowEnd; ++row)
+    const til::rect target{ colBegin, rowBegin, colEnd, rowEnd };
+    const auto isPhysical = [&](const ImagePlacement::Key key) {
+        return std::any_of(_placements.begin(), _placements.end(), [&](const auto& entry) {
+                   return !entry.second.isVirtual &&
+                          entry.second.imageId == key.imageId &&
+                          entry.second.layerId == key.layerId;
+               }) ||
+               std::any_of(_anonymousPlacements.begin(), _anonymousPlacements.end(), [&](const auto& placement) {
+                   return !placement.isVirtual &&
+                          placement.imageId == key.imageId &&
+                          placement.layerId == key.layerId;
+               });
+    };
+    for (const auto& placement : buffer.GetImages().IntersectingRows(rowBegin, rowEnd))
     {
-        const auto slice = buffer.GetRowByOffset(row).GetImageSlice();
-        if (!slice)
+        const auto key = placement.Identity();
+        if ((placement.CellBounds() & target).empty() || !isPhysical(key))
         {
             continue;
         }
-        for (auto col = colBegin; col < colEnd; ++col)
+        if (std::find(affected.begin(), affected.end(), key.imageId) == affected.end())
         {
-            for (const auto layerKey : slice->LayersAtColumn(col))
-            {
-                const auto id = layerKey.imageId;
-                const auto namedPhysicalPlacement = std::any_of(_placements.begin(), _placements.end(), [&](const auto& entry) {
-                    return entry.first.first == id && !entry.second.isVirtual && slice->LayerCoversColumn({ entry.first.first, entry.second.layerId }, col);
-                });
-                const auto anonymousPhysicalPlacement = std::any_of(_anonymousPlacements.begin(), _anonymousPlacements.end(), [&](const auto& placement) {
-                    return placement.imageId == id && !placement.isVirtual && slice->LayerCoversColumn({ placement.imageId, placement.layerId }, col);
-                });
-                if ((namedPhysicalPlacement || anonymousPhysicalPlacement) && std::find(affected.begin(), affected.end(), id) == affected.end())
-                {
-                    affected.push_back(id);
-                }
-            }
+            affected.push_back(key.imageId);
         }
     }
     for (const auto id : affected)
@@ -3375,14 +3170,13 @@ void KittyParser::_deleteImagesInIdRange(const uint32_t lo, const uint32_t hi, c
         {
             _eraseImage(id);
         }
-        _eraseImageRows(id);
+        _eraseImagePlacements(id);
     }
 }
 
 // Deletes physical placements selected by an exact z-index. d=q/Q first selects
-// the image/z layers intersecting one viewport-relative cell. Virtual placements
-// are excluded by the protocol. ImageSlice owns the scroll/reflow-safe layer
-// geometry; the registries supply relative-anchor cleanup and child cascades.
+// direct placements intersecting one viewport-relative cell. Virtual placements
+// are excluded by the protocol.
 void KittyParser::_deletePlacementsByZ(const int32_t zIndex, const bool freeData, const std::optional<til::point> cell)
 {
     auto page = _dispatcher._pages.ActivePage();
@@ -3393,14 +3187,27 @@ void KittyParser::_deletePlacementsByZ(const int32_t zIndex, const bool freeData
     {
         if (cell->x >= 0 && cell->x < page.Width() && cell->y >= 0 && cell->y < page.Bottom())
         {
-            const auto* slice = buffer.GetRowByOffset(cell->y).GetImageSlice();
-            if (slice)
+            for (const auto& image : buffer.GetImages().IntersectingRows(cell->y, cell->y + 1))
             {
-                for (const auto& identity : slice->LayersAtZ(zIndex, cell->x))
+                const auto key = image.Identity();
+                const auto bounds = image.CellBounds();
+                if (image.ZIndex() == zIndex &&
+                    bounds.left <= cell->x && cell->x < bounds.right &&
+                    bounds.top <= cell->y && cell->y < bounds.bottom)
                 {
-                    if (identity.placementId != 0)
+                    const auto physical = std::any_of(_placements.begin(), _placements.end(), [&](const auto& entry) {
+                                              return !entry.second.isVirtual &&
+                                                     entry.second.imageId == key.imageId &&
+                                                     entry.second.layerId == key.layerId;
+                                          }) ||
+                                          std::any_of(_anonymousPlacements.begin(), _anonymousPlacements.end(), [&](const auto& placement) {
+                                              return !placement.isVirtual &&
+                                                     placement.imageId == key.imageId &&
+                                                     placement.layerId == key.layerId;
+                                          });
+                    if (physical)
                     {
-                        layerIds.push_back(identity.placementId);
+                        layerIds.push_back(key.layerId);
                     }
                 }
             }
@@ -3500,17 +3307,7 @@ void KittyParser::_deletePlacementsByZ(const int32_t zIndex, const bool freeData
     {
         for (const auto imageId : imageIds)
         {
-            if (_imageHasPlacements(imageId))
-            {
-                continue;
-            }
-            auto hasPixels = false;
-            for (auto row = 0; row < page.Bottom() && !hasPixels; ++row)
-            {
-                const auto* slice = buffer.GetRowByOffset(row).GetImageSlice();
-                hasPixels = slice && slice->Contains(imageId);
-            }
-            if (!hasPixels)
+            if (!_imageHasPlacements(imageId) && !_imageHasRenderedPlacements(imageId))
             {
                 _eraseImage(imageId);
             }
@@ -3518,7 +3315,7 @@ void KittyParser::_deletePlacementsByZ(const int32_t zIndex, const bool freeData
     }
 }
 
-// Finds a physical placement by its retained internal layer identity. Unlike the registry's
+// Finds a physical placement by its retained collection identity. Unlike the registry's
 // creation-time anchor, this position follows scroll, reflow, insertion, and block copies.
 std::optional<til::point> KittyParser::_derivePlacementAnchor(const Placement& placement) const
 {
@@ -3531,33 +3328,23 @@ std::optional<til::point> KittyParser::_derivePlacementAnchor(const Placement& p
     auto minRow = page.Bottom();
     auto minCol = page.Width();
     auto found = false;
-    for (auto row = 0; row < page.Bottom(); ++row)
+    for (const auto& image : buffer.GetImages().All())
     {
-        const auto* slice = buffer.GetRowByOffset(row).GetImageSlice();
-        if (!slice || !slice->Contains({ placement.imageId, placement.layerId }))
+        if (image.Identity() != ImagePlacement::Key{ placement.imageId, placement.layerId })
         {
             continue;
         }
-        const auto cellWidth = std::max(1, slice->CellSize().width);
-        const auto columnBegin = slice->ColumnOffset();
-        const auto columnEnd = std::min(columnBegin + slice->PixelWidth() / cellWidth, page.Width());
-        for (auto column = columnBegin; column < columnEnd; ++column)
-        {
-            if (slice->LayerCoversColumn({ placement.imageId, placement.layerId }, column))
-            {
-                minRow = std::min(minRow, row);
-                minCol = std::min(minCol, column);
-                found = true;
-            }
-        }
+        const auto bounds = image.CellBounds();
+        minRow = std::min(minRow, bounds.top);
+        minCol = std::min(minCol, bounds.left);
+        found = true;
     }
     return found ? std::optional<til::point>{ til::point{ minCol, minRow } } : std::nullopt;
 }
 
 // Derives the on-screen anchor of a virtual (U=1) parent from its Unicode-placeholder cells:
-// the top-left is the minimum x over all cells whose ImageSlice owners include imageId and the
-// minimum y over the rows that contain such a cell. Returns nullopt if no placeholder cell for
-// the image is currently on screen.
+// the top-left is the minimum x/y over its direct-renderer fragments. Returns nullopt if no
+// placeholder fragment for the image is currently on screen.
 // Protocol: https://sw.kovidgoyal.net/kitty/graphics-protocol/#relative-placements
 std::optional<til::point> KittyParser::_deriveVirtualPlacementAnchor(const uint32_t imageId, const uint32_t placementId) const
 {
@@ -3572,26 +3359,16 @@ std::optional<til::point> KittyParser::_deriveVirtualPlacementAnchor(const uint3
     auto minRow = page.Bottom();
     auto minCol = page.Width();
     auto found = false;
-    for (auto row = 0; row < page.Bottom(); ++row)
+    for (const auto& image : buffer.GetImages().All())
     {
-        const auto& dstRow = buffer.GetRowByOffset(row);
-        const auto slice = dstRow.GetImageSlice();
-        if (!slice || !slice->Contains({ imageId, layerId }))
+        if (image.Identity() != ImagePlacement::Key{ imageId, layerId })
         {
             continue;
         }
-        const auto cellWidth = std::max(1, slice->CellSize().width);
-        const auto columnBegin = slice->ColumnOffset();
-        const auto columnEnd = std::min(columnBegin + slice->PixelWidth() / cellWidth, page.Width());
-        for (auto column = columnBegin; column < columnEnd; ++column)
-        {
-            if (slice->LayerCoversColumn({ imageId, layerId }, column))
-            {
-                minRow = std::min(minRow, row);
-                minCol = std::min(minCol, column);
-                found = true;
-            }
-        }
+        const auto bounds = image.CellBounds();
+        minRow = std::min(minRow, bounds.top);
+        minCol = std::min(minCol, bounds.left);
+        found = true;
     }
     if (!found)
     {
@@ -3774,18 +3551,12 @@ int KittyParser::_PlaceholderDiacriticIndex(const char32_t ch) noexcept
     return -1;
 }
 
-// Overlays a single placeholder cell: the (cellRow,cellCol) tile of a grid shows that portion of
-// the image. Samples the SCALED TARGET (targetW x targetH) exactly as _placeImage does -- the
-// whole cropped image scaled once, this cell reading the sub-rect [cellCol*cellWidth, +cellWidth) x
-// [cellRow*cellHeight, +cellHeight) -- so a virtual placeholder grid is pixel-identical to a direct
-// c/r placement even for non-divisible geometry (a per-cell source split diverged at tile edges).
-// Pixels past targetW/targetH are the aspect-preserving padding (transparent). Reuses the per-row
-// ImageSlice writer and tags the column with imageId so a delete-by-id erases it too. Does NOT
-// redraw (the caller batches one bounded redraw per segment). Returns true if a tile was drawn.
+// Registers one visible cell fragment of a Unicode placeholder. The renderer samples
+// the complete scaled placement, so adjacent fragments share one source surface.
 bool KittyParser::_placeImageCellRef(const Image& image, const uint32_t imageId, const til::CoordType column, const til::CoordType row, const uint32_t cellRow, const uint32_t cellCol, const VirtualPlacement& place)
 {
-    const auto framePixels = _framePixels(image, image.presentedFrame);
-    if (!framePixels || framePixels->empty() || image.width == 0 || image.height == 0)
+    const auto frameStorage = _frameStorage(image, image.presentedFrame);
+    if (!frameStorage || !*frameStorage || (*frameStorage)->empty() || image.width == 0 || image.height == 0)
     {
         return false;
     }
@@ -3815,61 +3586,13 @@ bool KittyParser::_placeImageCellRef(const Image& image, const uint32_t imageId,
     const auto cropH = std::max<til::CoordType>(static_cast<til::CoordType>(place.cropH != 0 ? place.cropH : image.height), 1);
     const auto targetW = std::max<int64_t>(place.targetW != 0 ? static_cast<int64_t>(place.targetW) : static_cast<int64_t>(gridCols) * cellWidth, 1);
     const auto targetH = std::max<int64_t>(place.targetH != 0 ? static_cast<int64_t>(place.targetH) : static_cast<int64_t>(gridRows) * cellHeight, 1);
-    const auto targetXBase = static_cast<int64_t>(cellCol) * cellWidth;
-    const auto targetYBase = static_cast<int64_t>(cellRow) * cellHeight;
-    const auto existingSlice = buffer.GetRowByOffset(row).GetImageSlice();
-    ImageSlice emptySlice{ clampedCellSize };
-    const auto required = existingSlice && existingSlice->CellSize() == clampedCellSize ?
-                              existingSlice->WriteMemoryUpperBound(column, column + 1, { imageId, place.layerId }, place.zIndex) :
-                              emptySlice.WriteMemoryUpperBound(column, column + 1, { imageId, place.layerId }, place.zIndex);
-    if (required > ImageSlice::LayerBytesAvailable())
-    {
-        LOG_HR(E_OUTOFMEMORY);
-        return false;
-    }
-
-    auto stagedSlice = existingSlice && existingSlice->CellSize() == clampedCellSize ?
-                           std::make_unique<ImageSlice>(*existingSlice) :
-                           std::make_unique<ImageSlice>(clampedCellSize);
-    auto dstSlice = stagedSlice.get();
-    auto dstIterator = dstSlice->MutablePixels(column, column + 1, { imageId, place.layerId }, place.zIndex);
-    auto sourceIterator = dstSlice->MutableSourceIndices(column, column + 1, { imageId, place.layerId }, place.zIndex);
-    for (auto pixelRow = 0; pixelRow < cellHeight; ++pixelRow)
-    {
-        const auto targetY = targetYBase + pixelRow;
-        const auto withinY = targetY < targetH;
-        const auto sampleY = withinY ? cropY + std::min(cropH - 1, static_cast<til::CoordType>(targetY * cropH / targetH)) : 0;
-        const auto srcRowStart = static_cast<size_t>(sampleY) * image.width;
-        for (auto pixelColumn = 0; pixelColumn < cellWidth; ++pixelColumn)
-        {
-            const auto targetX = targetXBase + pixelColumn;
-            if (withinY && targetX < targetW)
-            {
-                const auto sampleX = cropX + std::min(cropW - 1, static_cast<til::CoordType>(targetX * cropW / targetW));
-                const auto srcIndex = srcRowStart + static_cast<size_t>(sampleX);
-                til::at(dstIterator, pixelColumn) = srcIndex < framePixels->size() ? til::at(*framePixels, srcIndex) : RGBQUAD{};
-                til::at(sourceIterator, pixelColumn) = srcIndex < framePixels->size() ? gsl::narrow_cast<uint32_t>(srcIndex) : ImageSlice::NoSourceIndex;
-            }
-            else
-            {
-                til::at(dstIterator, pixelColumn) = RGBQUAD{}; // aspect padding beyond the scaled target
-                til::at(sourceIterator, pixelColumn) = ImageSlice::NoSourceIndex;
-            }
-        }
-        if (pixelRow + 1 < cellHeight)
-        {
-            std::advance(dstIterator, dstSlice->PixelWidth());
-            std::advance(sourceIterator, dstSlice->PixelWidth());
-        }
-    }
-
     auto surface = image.surface;
     const auto newSurface = !surface;
     if (newSurface)
     {
         surface = std::make_shared<::Image>(
             til::size{ gsl::narrow_cast<til::CoordType>(image.width), gsl::narrow_cast<til::CoordType>(image.height) },
-            *framePixels);
+            *frameStorage);
     }
 
     const auto originalLeft = gsl::narrow<til::CoordType>(static_cast<int64_t>(column) - cellCol);
@@ -3898,7 +3621,6 @@ bool KittyParser::_placeImageCellRef(const Image& image, const uint32_t imageId,
     {
         image.surface = std::move(surface);
     }
-    buffer.GetMutableRowByOffset(row).SetImageSlice(std::move(stagedSlice));
     return true;
 }
 
@@ -4101,11 +3823,8 @@ void KittyParser::RenderPlaceholders(const std::wstring_view segment, const til:
 }
 
 
-// Erases on-screen pixels belonging to imageId by clearing only the columns that
-// image owns, leaving co-resident Sixel (id 0) and other images intact. A slice left
-// fully empty is dropped. Rides the row lifecycle, so scroll/reflow keep ownership
-// aligned without absolute anchors.
-void KittyParser::_eraseImageRows(const uint32_t imageId)
+// Erases every direct placement of an image. Sixel row slices are independent.
+void KittyParser::_eraseImagePlacements(const uint32_t imageId)
 {
     if (imageId == 0)
     {
@@ -4126,22 +3845,6 @@ void KittyParser::_eraseImageRows(const uint32_t imageId)
         }
         auto& images = buffer.GetMutableImages();
         images.EraseImage(imageId);
-        for (auto row = 0; row < page.Bottom(); ++row)
-        {
-            const auto* slice = buffer.GetRowByOffset(row).GetImageSlice();
-            if (slice && slice->Contains(imageId))
-            {
-                auto& dstRow = buffer.GetMutableRowByOffset(row);
-                auto* mutableSlice = dstRow.GetMutableImageSlice();
-                // Clear only the columns this image owns; co-resident pixels stay put.
-                if (mutableSlice->EraseLayer(imageId))
-                {
-                    dstRow.SetImageSlice(nullptr);
-                }
-                firstRow = std::min(firstRow, row);
-                lastRow = std::max(lastRow, row);
-            }
-        }
         if (page.Number() == visiblePageNumber && firstRow <= lastRow)
         {
             buffer.TriggerRedraw(Viewport::FromExclusive({ 0, firstRow, page.Width(), lastRow + 1 }));
@@ -4154,8 +3857,8 @@ void KittyParser::_eraseImageRows(const uint32_t imageId)
     }
 }
 
-// Erases one placement by its internal retained-layer identity. The identity moves with the
-// pixels through scrolling, reflow, ICH, and block copies, unlike the creation-time anchor.
+// Erases one placement by its retained collection identity. The identity moves through
+// scrolling, reflow, ICH, and block copies, unlike the creation-time anchor.
 // Protocol: https://sw.kovidgoyal.net/kitty/graphics-protocol/#relative-placements
 void KittyParser::_erasePlacementCells(const Placement& placement)
 {
@@ -4179,21 +3882,6 @@ void KittyParser::_erasePlacementCells(const Placement& placement)
         }
         auto& images = buffer.GetMutableImages();
         images.Erase(key);
-        for (auto row = 0; row < page.Bottom(); ++row)
-        {
-            const auto* slice = buffer.GetRowByOffset(row).GetImageSlice();
-            if (slice && slice->Contains({ placement.imageId, placement.layerId }))
-            {
-                auto& dstRow = buffer.GetMutableRowByOffset(row);
-                auto* mutableSlice = dstRow.GetMutableImageSlice();
-                if (mutableSlice->EraseLayer({ placement.imageId, placement.layerId }))
-                {
-                    dstRow.SetImageSlice(nullptr);
-                }
-                firstRow = std::min(firstRow, row);
-                lastRow = std::max(lastRow, row);
-            }
-        }
         if (page.Number() == visiblePageNumber && firstRow <= lastRow)
         {
             buffer.TriggerRedraw(Viewport::FromExclusive({ 0, firstRow, page.Width(), lastRow + 1 }));
@@ -4201,12 +3889,9 @@ void KittyParser::_erasePlacementCells(const Placement& placement)
     });
     if (const auto image = _images.find(placement.imageId); image != _images.end())
     {
-        image->second.hasRenderedPlacements = _imageHasRenderedLayers(placement.imageId);
+        image->second.hasRenderedPlacements = _imageHasRenderedPlacements(placement.imageId);
         if (!image->second.hasRenderedPlacements)
         {
-            _dispatcher._pages.ForEachPage([&](const Page page) {
-                page.Buffer().GetMutableImages().EraseImage(placement.imageId);
-            });
             _releaseImageSurface(image->second);
         }
     }

--- a/src/terminal/adapter/KittyParser.hpp
+++ b/src/terminal/adapter/KittyParser.hpp
@@ -16,7 +16,6 @@ Abstract:
 #include "DispatchTypes.hpp"
 #include "ITermDispatch.hpp"
 #include "../../buffer/out/Image.hpp"
-#include "../../buffer/out/ImageSlice.hpp"
 
 #include <deque>
 #include <map>
@@ -57,10 +56,8 @@ namespace Microsoft::Console::VirtualTerminal
         // given comes due.
         void AdvanceAnimations(std::chrono::steady_clock::time_point now);
 
-        // Re-pushes every placement's pixels into the active page's buffer. The
-        // registry outlives the buffer it drew into, so anything that swaps the
-        // buffer under it has to ask for the layers again.
-        void RefreshImageLayers();
+        // Refreshes animated shared surfaces after a page or buffer transition.
+        void RefreshImageSurfaces();
 
         // Drops every image, every placement, and any transfer in progress.
         void HardReset() noexcept;
@@ -121,9 +118,11 @@ namespace Microsoft::Console::VirtualTerminal
             bool havePlacementId = false;    // true if p= was present (so p= is echoed in the ack)
             bool haveParent = false;         // true if P= was present (a relative placement was requested)
         };
+        using FramePixelStorage = ::Image::PixelStorage;
+
         struct AnimationFrame
         {
-            ::Image::PixelStorage pixels;
+            FramePixelStorage pixels;
             int32_t gapMilliseconds = 0;
         };
         // A stored Kitty image. Frame 1 is the root pixel vector; additional
@@ -133,7 +132,7 @@ namespace Microsoft::Console::VirtualTerminal
             uint32_t number = 0;
             uint32_t width = 0;
             uint32_t height = 0;
-            ::Image::PixelStorage pixels;
+            FramePixelStorage pixels;
             int32_t rootGapMilliseconds = 0;
             std::vector<AnimationFrame> animationFrames;
             uint32_t currentFrame = 1;
@@ -248,11 +247,11 @@ namespace Microsoft::Console::VirtualTerminal
         static RGBQUAD _rgbaColor(uint32_t rgba) noexcept;
         static void _compositePixels(std::span<RGBQUAD> destination, std::span<const RGBQUAD> source, bool replace) noexcept;
         static size_t _frameCount(const Image& image) noexcept;
-        static std::vector<RGBQUAD>* _framePixels(Image& image, uint32_t frameNumber) noexcept;
         static const std::vector<RGBQUAD>* _framePixels(const Image& image, uint32_t frameNumber) noexcept;
-        static const ::Image::PixelStorage* _frameStorage(const Image& image, uint32_t frameNumber) noexcept;
+        static FramePixelStorage* _frameStorage(Image& image, uint32_t frameNumber) noexcept;
+        static const FramePixelStorage* _frameStorage(const Image& image, uint32_t frameNumber) noexcept;
         static int32_t* _frameGap(Image& image, uint32_t frameNumber) noexcept;
-        void _updateImageLayers(uint32_t imageId, const ::Image::PixelStorage& pixels);
+        void _updateImageSurface(uint32_t imageId, const FramePixelStorage& pixels);
         void _scheduleAnimation(uint32_t imageId, Image& image, std::chrono::steady_clock::time_point now);
         void _scheduleAnimationTimer();
         bool _advanceImage(uint32_t imageId, Image& image, std::chrono::steady_clock::time_point now);
@@ -263,7 +262,7 @@ namespace Microsoft::Console::VirtualTerminal
         uint32_t _assignImageId();
         bool _registerImage(const uint32_t id, Image&& image);
         void _eraseImage(const uint32_t id);
-        void _eraseImageRows(const uint32_t imageId);
+        void _eraseImagePlacements(const uint32_t imageId);
         void _clearImages() noexcept;
         BufferState _takeBufferState() noexcept;
         void _restoreBufferState(BufferState&& state) noexcept;
@@ -271,21 +270,20 @@ namespace Microsoft::Console::VirtualTerminal
         void _releaseImageSurface(Image& image) noexcept;
         void _storeVirtualPlacement(const uint32_t id, uint32_t placementId, const Image& image, const uint32_t cols, const uint32_t rows, const uint32_t srcX, const uint32_t srcY, const uint32_t srcW, const uint32_t srcH, const int32_t zIndex, uint64_t layerId);
         static TargetSize _targetPixels(const int64_t cropW, const int64_t cropH, const uint32_t cols, const uint32_t rows, const int64_t cellWidth, const int64_t cellHeight) noexcept;
-        bool _placementFitsMemory(const Image& image, uint32_t imageId, uint64_t layerId, uint32_t cols, uint32_t rows, uint32_t srcX, uint32_t srcY, uint32_t srcW, uint32_t srcH, int32_t zIndex, std::optional<til::point> anchor = std::nullopt) const noexcept;
         til::size _placeImage(const Image& image, bool moveCursor, uint32_t imageId, uint64_t layerId, uint32_t cols = 0, uint32_t rows = 0, uint32_t srcX = 0, uint32_t srcY = 0, uint32_t srcW = 0, uint32_t srcH = 0, uint32_t cellOffsetX = 0, uint32_t cellOffsetY = 0, int32_t zIndex = 0, std::optional<til::point> anchor = std::nullopt);
         // Relative placement registry helpers.
         // Protocol: https://sw.kovidgoyal.net/kitty/graphics-protocol/#relative-placements
         void _registerPlacement(const Placement& placement);
         // Re-anchor and redraw every relative descendant after a registered parent moves.
         bool _movePlacementChildren(const std::pair<uint32_t, uint32_t>& parent, til::point parentAnchor, bool apply, std::wstring_view& code);
-        // Erases one placement's retained layer by its internal identity. The identity follows
+        // Erases one collection placement by its internal identity. The identity follows
         // cells through scroll, reflow, and block copies, so this never depends on a stale anchor.
         // Protocol: https://sw.kovidgoyal.net/kitty/graphics-protocol/#relative-placements
         void _erasePlacementCells(const Placement& placement);
         void _erasePlacementsForImage(const uint32_t imageId);
         // True if any tracked placement (registered or anonymous) still references this image id.
         bool _imageHasPlacements(const uint32_t id) const noexcept;
-        bool _imageHasRenderedLayers(uint32_t id) const;
+        bool _imageHasRenderedPlacements(uint32_t id) const;
         // Cascade-deletes the relative children of each removed placement key (registered +
         // anonymous), deleting any orphaned image except `keepImageId`, which the caller deletes.
         void _cascadePlacementChildren(std::deque<std::pair<uint32_t, uint32_t>>& removed, const uint32_t keepImageId);

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1738,7 +1738,7 @@ void AdaptDispatch::NotifyFontChanged()
 {
     if (_kittyParser)
     {
-        _kittyParser->RefreshImageLayers();
+        _kittyParser->RefreshImageSurfaces();
     }
 }
 
@@ -1752,7 +1752,7 @@ void AdaptDispatch::PagePositionAbsolute(const VTInt page)
     _pages.MoveTo(page, _modes.test(Mode::PageCursorCoupling));
     if (_kittyParser)
     {
-        _kittyParser->RefreshImageLayers();
+        _kittyParser->RefreshImageSurfaces();
     }
 }
 
@@ -1766,7 +1766,7 @@ void AdaptDispatch::PagePositionRelative(const VTInt pageCount)
     _pages.MoveRelative(pageCount, _modes.test(Mode::PageCursorCoupling));
     if (_kittyParser)
     {
-        _kittyParser->RefreshImageLayers();
+        _kittyParser->RefreshImageSurfaces();
     }
 }
 
@@ -1780,7 +1780,7 @@ void AdaptDispatch::PagePositionBack(const VTInt pageCount)
     _pages.MoveRelative(-pageCount, _modes.test(Mode::PageCursorCoupling));
     if (_kittyParser)
     {
-        _kittyParser->RefreshImageLayers();
+        _kittyParser->RefreshImageSurfaces();
     }
 }
 

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -546,7 +546,8 @@ namespace
         { L"query invalid payload", L"\x1b_Ga=q,i=5,f=100;AAA\x1b\\", L"\x1b_Gi=5;EINVAL:bad payload\x1b\\" },
         { L"unsupported format", L"\x1b_Ga=t,i=6,f=99;\x1b\\", L"\x1b_Gi=6;EINVAL:unsupported format\x1b\\" },
         { L"unsupported compression", L"\x1b_Ga=t,i=7,o=x;\x1b\\", L"\x1b_Gi=7;EINVAL:unsupported compression\x1b\\" },
-        { L"overflow dimensions", L"\x1b_Ga=t,i=14,f=32,s=2147483648,v=2147483648;AQIDBA==\x1b\\", L"\x1b_Gi=14;EINVAL:payload size mismatch\x1b\\" },
+        { L"overflow dimensions", L"\x1b_Ga=t,i=14,f=32,s=2147483648,v=2147483648;AQIDBA==\x1b\\", L"\x1b_Gi=14;EFBIG:image dimensions exceed renderer limit\x1b\\" },
+        { L"renderer dimension limit", L"\x1b_Ga=t,i=15,f=32,s=8193,v=1;AQIDBA==\x1b\\", L"\x1b_Gi=15;EFBIG:image dimensions exceed renderer limit\x1b\\" },
         { L"semicolon in payload", L"\x1b_Ga=t,i=1,f=100;AAAA;BBBB\x1b\\", L"\x1b_Gi=1;EINVAL:bad payload\x1b\\" },
         { L"missing dimensions", L"\x1b_Ga=t,i=1,f=24;AAAA\x1b\\", L"\x1b_Gi=1;EINVAL:missing dimensions\x1b\\" },
         { L"unsupported medium", L"\x1b_Ga=t,i=1,f=24,s=1,v=1,t=x;AAAA\x1b\\", L"\x1b_Gi=1;EINVAL:unsupported transmission medium\x1b\\" },
@@ -4270,6 +4271,14 @@ public:
                 return slice;
             }
         }
+        for (til::CoordType y = 0; y < height; y++)
+        {
+            if (const auto slice = DirectImageSlice(buffer, y))
+            {
+                outRow = y;
+                return slice;
+            }
+        }
         outRow = -1;
         return nullptr;
     }
@@ -4300,7 +4309,8 @@ public:
         const auto height = buffer.GetSize().Height();
         for (til::CoordType y = 0; y < height; y++)
         {
-            if (SliceContainsColor(buffer.GetRowByOffset(y).GetImageSlice(), r, g, b))
+            if (SliceContainsColor(buffer.GetRowByOffset(y).GetImageSlice(), r, g, b) ||
+                SliceContainsColor(DirectImageSlice(buffer, y), r, g, b))
             {
                 return true;
             }
@@ -4314,12 +4324,67 @@ public:
         const auto height = buffer.GetSize().Height();
         for (til::CoordType y = 0; y < height; y++)
         {
-            if (buffer.GetRowByOffset(y).GetImageSlice())
+            VerifyNoDirectImageLayers(buffer, y);
+            if (buffer.GetRowByOffset(y).GetImageSlice() ||
+                !buffer.GetImages().IntersectingRows(y, y + 1).empty())
             {
                 count++;
             }
         }
         return count;
+    }
+
+    static void VerifyNoDirectImageLayers(const TextBuffer& buffer, const til::CoordType row)
+    {
+        const auto slice = buffer.GetRowByOffset(row).GetImageSlice();
+        if (!slice)
+        {
+            return;
+        }
+
+        for (til::CoordType x = 0; x < buffer.GetSize().Width(); ++x)
+        {
+            VERIFY_IS_TRUE(slice->LayersAtColumn(x).empty(), L"Kitty must not create row-local ImageSlice layers");
+        }
+    }
+
+    static void VerifyNoDirectImageLayers(const TextBuffer& buffer)
+    {
+        for (til::CoordType row = 0; row < buffer.GetSize().Height(); ++row)
+        {
+            VerifyNoDirectImageLayers(buffer, row);
+        }
+    }
+
+    // Adapter tests inspect the collection through the same legacy rasterizer that
+    // previously populated rows. The synthesized slice is test-only and never
+    // becomes part of the TextBuffer.
+    static const ImageSlice* DirectImageSlice(const TextBuffer& buffer, const til::CoordType row)
+    {
+        VerifyNoDirectImageLayers(buffer, row);
+
+        const auto placements = buffer.GetImages().IntersectingRows(row, row + 1);
+        if (placements.empty())
+        {
+            return nullptr;
+        }
+
+        static thread_local std::vector<std::unique_ptr<ImageSlice>> slices;
+        if (slices.size() == 64)
+        {
+            slices.erase(slices.begin());
+        }
+        auto slice = std::make_unique<ImageSlice>(placements.front()->Geometry().cellSize);
+        const auto width = buffer.GetSize().Width();
+        for (const auto& placement : placements)
+        {
+            VERIFY_ARE_EQUAL(slice->CellSize(), placement->Geometry().cellSize);
+            VERIFY_IS_TRUE(placement->RasterizeRow(row, 0, width, *slice));
+        }
+
+        const auto result = slice.get();
+        slices.emplace_back(std::move(slice));
+        return result;
     }
 
     // Returns the pixel at (px, py) within an image slice's own pixel buffer (px is
@@ -5028,7 +5093,7 @@ public:
         _pDispatch->CursorPosition(3, 3);
         const auto normalPos = buf.GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,f=24,s=1,v=1,C=1;/wAA\x1b\\"); // red, non-virtual
-        const auto* normalSlice = buf.GetRowByOffset(normalPos.y).GetImageSlice();
+        const auto* normalSlice = DirectImageSlice(buf, normalPos.y);
         VERIFY_IS_NOT_NULL(normalSlice);
         VERIFY_ARE_EQUAL(1u, normalSlice->ColumnOwner(normalPos.x), L"the normal placement (1,1) owns its cell");
 
@@ -5039,7 +5104,7 @@ public:
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m"); // fg = image id 1
         _stateMachine->ProcessString(L"\x1b[58:2::0:0:2m"); // underline = placement id 2
         _stateMachine->ProcessString(L"\xDBFB\xDEEE"); // one U+10EEEE placeholder
-        const auto* phSlice = buf.GetRowByOffset(phPos.y).GetImageSlice();
+        const auto* phSlice = DirectImageSlice(buf, phPos.y);
         VERIFY_IS_NOT_NULL(phSlice);
         VERIFY_ARE_EQUAL(1u, phSlice->ColumnOwner(phPos.x), L"the virtual placement's placeholder owns its cell");
 
@@ -5049,10 +5114,10 @@ public:
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._placements.count({ 1u, 1u }), L"the normal placement (1,1) survives");
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._images.count(1u), L"lowercase kept the image data");
         // The invariant we guarantee: the surviving normal placement (1,1) keeps its pixels.
-        const auto* normalAfter = buf.GetRowByOffset(normalPos.y).GetImageSlice();
+        const auto* normalAfter = DirectImageSlice(buf, normalPos.y);
         VERIFY_IS_NOT_NULL(normalAfter);
         VERIFY_ARE_EQUAL(1u, normalAfter->ColumnOwner(normalPos.x), L"the surviving normal placement (1,1) keeps its pixels");
-        const auto* phAfter = buf.GetRowByOffset(phPos.y).GetImageSlice();
+        const auto* phAfter = DirectImageSlice(buf, phPos.y);
         VERIFY_IS_TRUE(phAfter == nullptr || phAfter->ColumnOwner(phPos.x) != 1u, L"only the deleted virtual placement's layer is erased");
     }
 
@@ -5369,7 +5434,7 @@ public:
         auto greenRows = 0;
         for (til::CoordType y = 0; y < buffer.GetSize().Height(); ++y)
         {
-            const auto slice = buffer.GetRowByOffset(y).GetImageSlice();
+            const auto slice = DirectImageSlice(buffer, y);
             if (slice && SliceContainsColor(slice, 0, 255, 0))
             {
                 ++greenRows;
@@ -6174,15 +6239,15 @@ public:
         buffer.GetCursor().SetPosition(placeholderPosition);
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m");
         _stateMachine->ProcessString(Placeholder());
-        const auto* placeholderSlice = buffer.GetRowByOffset(placeholderPosition.y).GetImageSlice();
+        const auto* placeholderSlice = DirectImageSlice(buffer, placeholderPosition.y);
         VERIFY_IS_NOT_NULL(placeholderSlice);
         VERIFY_IS_TRUE(placeholderSlice->ContainsPlacement(virtualLayer));
 
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=p,x=3,y=7;\x1b\\");
 
-        const auto* physicalSlice = buffer.GetRowByOffset(physicalPosition.y).GetImageSlice();
+        const auto* physicalSlice = DirectImageSlice(buffer, physicalPosition.y);
         VERIFY_IS_TRUE(physicalSlice == nullptr || !physicalSlice->ContainsPlacement(physicalLayer));
-        placeholderSlice = buffer.GetRowByOffset(placeholderPosition.y).GetImageSlice();
+        placeholderSlice = DirectImageSlice(buffer, placeholderPosition.y);
         VERIFY_IS_NOT_NULL(placeholderSlice);
         VERIFY_IS_TRUE(placeholderSlice->ContainsPlacement(virtualLayer), L"positional deletion must preserve a coexisting virtual placement");
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._virtualIds.count({ 1u, 0u }));
@@ -6234,9 +6299,9 @@ public:
         VERIFY_IS_TRUE(BufferContainsColor(*_testGetSet->_textBuffer, 255, 0, 0));
     }
 
-    // Placing over a row whose slice has a different cell size replaces the slice
-    // (the stride must match the write extent, or the slice buffer would overflow).
-    TEST_METHOD(KittyGraphicsCellSizeMismatchReplacesSlice)
+    // Complete surfaces retain the cell metrics used for each placement instead
+    // of forcing unrelated images through one row-local pixel stride.
+    TEST_METHOD(KittyGraphicsDifferentCellSizesRemainIndependent)
     {
         _testGetSet->PrepData();
         _pDispatch->CursorPosition(2, 1);
@@ -6244,11 +6309,11 @@ public:
         _testGetSet->_cellSize = { 5, 10 };
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,f=24,s=1,v=1,C=1;AP8A\x1b\\"); // same row, new size
         const auto& buffer = *_testGetSet->_textBuffer;
-        til::CoordType row = -1;
-        const auto slice = FindFirstImageSlice(buffer, row);
-        VERIFY_IS_NOT_NULL(slice);
-        VERIFY_ARE_EQUAL(5, slice->CellSize().width);
-        VERIFY_ARE_EQUAL(10, slice->CellSize().height);
+        VERIFY_ARE_EQUAL(size_t{ 2 }, buffer.GetImages().Size());
+        const auto placements = buffer.GetImages().All();
+        VERIFY_ARE_EQUAL((til::size{ 10, 20 }), placements[0].Geometry().cellSize);
+        VERIFY_ARE_EQUAL((til::size{ 5, 10 }), placements[1].Geometry().cellSize);
+        VerifyNoDirectImageLayers(buffer);
     }
 
     // An image wider than the remaining columns is clipped to the page, not overflowed.
@@ -6485,7 +6550,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,U=1,i=1,f=24,s=2,v=1;/wAAAP8A\x1b\\"); // 2px: red,green
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m");
         _stateMachine->ProcessString(Placeholder() + Placeholder());
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 255, 0, 0), L"grid col 0 (left cell) = red only");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 0, 255, 0), L"grid col 1 (right cell) = green only");
@@ -6520,8 +6585,8 @@ public:
         // Every pixel of the 2-cell x 2-row footprint must be identical between the renders.
         for (til::CoordType r = 0; r < 2; ++r)
         {
-            const auto* sd = buf.GetRowByOffset(directRow + r).GetImageSlice();
-            const auto* sp = buf.GetRowByOffset(phRow + r).GetImageSlice();
+            const auto* sd = DirectImageSlice(buf, directRow + r);
+            const auto* sp = DirectImageSlice(buf, phRow + r);
             VERIFY_IS_NOT_NULL(sd, L"direct render produced an image slice");
             VERIFY_IS_NOT_NULL(sp, L"placeholder render produced an image slice");
             for (til::CoordType py = 0; py < cell.height; ++py)
@@ -6566,8 +6631,8 @@ public:
 
         for (til::CoordType r = 0; r < 2; ++r)
         {
-            const auto* sd = buf.GetRowByOffset(directRow + r).GetImageSlice();
-            const auto* sp = buf.GetRowByOffset(phRow + r).GetImageSlice();
+            const auto* sd = DirectImageSlice(buf, directRow + r);
+            const auto* sp = DirectImageSlice(buf, phRow + r);
             VERIFY_IS_NOT_NULL(sd, L"direct render produced an image slice");
             VERIFY_IS_NOT_NULL(sp, L"placeholder render produced an image slice");
             for (til::CoordType py = 0; py < cell.height; ++py)
@@ -6658,8 +6723,8 @@ public:
         _stateMachine->ProcessString(Placeholder() + L"\x030D" + Placeholder()); // explicit grid row 1, then inherit
         _stateMachine->ProcessString(L"\x1b[0m");
 
-        const auto* r0 = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
-        const auto* r1 = _testGetSet->_textBuffer->GetRowByOffset(origin.y + 1).GetImageSlice();
+        const auto* r0 = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
+        const auto* r1 = DirectImageSlice(*_testGetSet->_textBuffer, origin.y + 1);
         VERIFY_IS_NOT_NULL(r0);
         VERIFY_IS_NOT_NULL(r1);
         VERIFY_IS_TRUE(SlicePixelIs(r0, 0, 0, 255, 255, 255), L"crop=BR: grid (0,0) must be white");
@@ -6746,7 +6811,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,U=1,i=1,f=24,s=1,v=2;/wAAAP8A\x1b\\"); // top red, bottom green
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m");
         _stateMachine->ProcessString(Placeholder() + L"\x0305" + Placeholder() + L"\x030D"); // row 0, row 1
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 255, 0, 0), L"row-0 cell = top tile (red) only");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 0, 255, 0), L"row-1 cell = bottom tile (green) only");
@@ -6839,7 +6904,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,U=1,i=1,f=24,s=3,v=1,c=2,r=1;/wAAAP8AAAD/\x1b\\"); // red,green,blue; grid 2x1
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m");
         _stateMachine->ProcessString(Placeholder() + Placeholder());
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 255, 0, 0), L"grid col 0 starts at the red pixel");
         VERIFY_IS_TRUE(SlicePixelIs(slice, slice->PixelWidth() - 1, 0, 0, 0, 255), L"rightmost pixel (blue) must survive the 3px/2col split");
@@ -6860,14 +6925,14 @@ public:
 
         // Write 1: grid row 0 on the origin screen row -> top tile (red), no green.
         _stateMachine->ProcessString(Placeholder() + L"\x0305");
-        const auto* row0 = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* row0 = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_TRUE(SliceContainsColor(row0, 255, 0, 0), L"grid row 0 = top tile (red)");
         VERIFY_IS_FALSE(SliceContainsColor(row0, 0, 255, 0), L"stored rows=2 must keep the bottom tile (green) out of grid row 0");
 
         // Write 2: a SEPARATE call on the next screen row, grid row 1 -> bottom tile (green).
         _testGetSet->_textBuffer->GetCursor().SetPosition({ origin.x, origin.y + 1 });
         _stateMachine->ProcessString(Placeholder() + L"\x030D");
-        const auto* row1 = _testGetSet->_textBuffer->GetRowByOffset(origin.y + 1).GetImageSlice();
+        const auto* row1 = DirectImageSlice(*_testGetSet->_textBuffer, origin.y + 1);
         VERIFY_IS_TRUE(SliceContainsColor(row1, 0, 255, 0), L"grid row 1 = bottom tile (green)");
         VERIFY_IS_FALSE(SliceContainsColor(row1, 255, 0, 0), L"grid row 1 must not contain the top tile (red)");
     }
@@ -7045,7 +7110,7 @@ public:
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m");
         _stateMachine->ProcessString(Placeholder() + L"\x030D" + L"\x0305" + Placeholder() + L"\x030D"); // (1,0), then row-only (1,1)
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 0, 0, 255), L"explicit (row 1, col 0) selects blue");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 255, 255, 255), L"the row-only cell inherits col 1 from the matching left row (white)");
     }
@@ -7062,7 +7127,7 @@ public:
         _stateMachine->ProcessString(Placeholder() + L"\x030D" + L"\x0305"); // explicit (1,0)
         _stateMachine->ProcessString(Placeholder()); // separate call, inherited (1,1)
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 0, 0, 255), L"the earlier explicit cell remains blue");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 255, 255, 255), L"the later write inherits from the stored left cell");
     }
@@ -7084,7 +7149,7 @@ public:
         buffer.GetCursor().SetPosition({ 1, origin.y });
         _stateMachine->ProcessString(Placeholder()); // must inherit col 1 from x=0
 
-        const auto* slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 0, 255, 0), L"interleaving cannot corrupt immediate-left inheritance (col 1 = green)");
     }
 
@@ -7103,7 +7168,7 @@ public:
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;2m");
         _stateMachine->ProcessString(Placeholder());
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 0, 255, 0), L"the explicit image-1 cell is col 1 (green)");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 255, 0, 0), L"foreground mismatch rejects inheritance and defaults image 2 to col 0 (red)");
     }
@@ -7122,7 +7187,7 @@ public:
         _stateMachine->ProcessString(L"\x1b[58:2::0:0:2m");
         _stateMachine->ProcessString(Placeholder()); // placement color 2: no inheritance
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 0, 255, 0), L"the explicit left cell is col 1 (green)");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 255, 0, 0), L"underline mismatch defaults to col 0 (red), not stale col 2");
     }
@@ -7142,7 +7207,7 @@ public:
         buffer.GetCursor().SetPosition({ 0, origin.y + 1 });
         _stateMachine->ProcessString(Placeholder()); // no left cell => (0,0)
 
-        const auto* slice = buffer.GetRowByOffset(origin.y + 1).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y + 1);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 255, 0, 0), L"column 0 omission defaults to grid col 0 (red)");
     }
 
@@ -7158,7 +7223,7 @@ public:
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m"); // low 24 bits
         _stateMachine->ProcessString(Placeholder() + L"\x0305" + L"\x0305" + L"\x030D" + Placeholder());
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 255, 0, 0), L"explicit high byte selects the >24-bit image at col 0");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 0, 255, 0), L"omitting all marks inherits high byte and advances to col 1");
     }
@@ -7183,7 +7248,7 @@ public:
         buffer.GetCursor().SetPosition({ 1, origin.y + 1 });
         _stateMachine->ProcessString(Placeholder()); // inherit from the moved (1,0) cell
 
-        const auto* slice = buffer.GetRowByOffset(origin.y + 1).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y + 1);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 0, 0, 255), L"the explicit blue cell moved with the row");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 255, 255, 255), L"the moved metadata resolves the adjacent omission as (1,1) white");
         const auto* metadata = buffer.GetRowByOffset(origin.y + 1).GetImageCellRef(origin.x);
@@ -7224,13 +7289,13 @@ public:
         buffer.GetCursor().SetPosition({ origin.x + 2, origin.y });
         _stateMachine->ProcessString(Placeholder()); // inherit (0,1) from moved x=1
 
-        const auto* slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_ARE_EQUAL(0u, slice->ColumnOwner(origin.x), L"ICH clears the newly inserted cell's image ownership");
         VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(origin.x + 1), L"ICH moved the explicit placeholder one cell right");
         VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(origin.x + 2), L"the adjacent omitted placeholder rendered for image 1");
-        VERIFY_IS_TRUE(SlicePixelIs(slice, origin.x + 1, 0, 255, 0, 0), L"the moved explicit placeholder remains grid col 0 (red)");
-        VERIFY_IS_TRUE(SlicePixelIs(slice, origin.x + 2, 0, 0, 255, 0), L"the adjacent omission inherits grid col 1 (green)");
+        VERIFY_IS_TRUE(SlicePixelIs(slice, origin.x + 1 - slice->ColumnOffset(), 0, 255, 0, 0), L"the moved explicit placeholder remains grid col 0 (red)");
+        VERIFY_IS_TRUE(SlicePixelIs(slice, origin.x + 2 - slice->ColumnOffset(), 0, 0, 255, 0), L"the adjacent omission inherits grid col 1 (green)");
     }
 
     // A partial-width vertical scroll uses the cell-walking path rather than rotating whole ROW
@@ -7252,7 +7317,7 @@ public:
         buffer.GetCursor().SetPosition({ origin.x + 1, origin.y + 1 });
         _stateMachine->ProcessString(Placeholder()); // inherit from moved (1,0)
 
-        const auto* slice = buffer.GetRowByOffset(origin.y + 1).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y + 1);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 0, 0, 255), L"the explicit blue cell moved down with the partial-width scroll");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 1, 0, 255, 255, 255), L"the adjacent omission inherits (1,1) white after the move");
@@ -7288,7 +7353,7 @@ public:
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m");
         _stateMachine->ProcessString(Placeholder() + L"\x0305" + L"\x030D"); // explicit (0,1) green
 
-        const auto* sourceSlice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        const auto* sourceSlice = DirectImageSlice(buffer, origin.y);
         const auto* sourceMetadata = buffer.GetRowByOffset(origin.y).GetImageCellRef(origin.x);
         VERIFY_IS_NOT_NULL(sourceMetadata);
         VERIFY_ARE_NOT_EQUAL(0u, sourceMetadata->layerId);
@@ -7302,7 +7367,7 @@ public:
         buffer.GetCursor().SetPosition({ 6, origin.y });
         _stateMachine->ProcessString(Placeholder()); // inherit (0,2) from copied x=5
 
-        const auto* slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto copiedPixel = SlicePixelAt(slice, 5, 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(0), copiedPixel.rgbRed);
@@ -7392,7 +7457,7 @@ public:
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m");
         _stateMachine->ProcessString(Placeholder()); // (0,0) = TL red
         _stateMachine->ProcessString(Placeholder()); // separate write, same row -> (0,1) = TR green
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_TRUE(SliceContainsColor(slice, 255, 0, 0), L"col 0 = TL red");
         VERIFY_IS_TRUE(SliceContainsColor(slice, 0, 255, 0), L"col 1 = TR green (auto col continued, same grid row)");
         VERIFY_IS_FALSE(SliceContainsColor(slice, 0, 0, 255), L"must not drop to grid row 1 (blue) on a same-row chunk");
@@ -7433,7 +7498,7 @@ public:
         _testGetSet->_textBuffer->GetCursor().SetPosition({ origin.x + 1, origin.y });
         _stateMachine->ProcessString(Placeholder());
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_ARE_EQUAL(origin.x + 1, slice->ColumnOffset(), L"only the newly rendered adjacent cell remains after re-transmit");
         VERIFY_IS_TRUE(SlicePixelIs(slice, 0, 0, 0, 255, 0), L"re-storing the image preserves left-cell inheritance (col 1 = green)");
@@ -7475,7 +7540,7 @@ public:
         const auto freshRow = origin.y + 10;
         _testGetSet->_textBuffer->GetCursor().SetPosition({ 0, freshRow });
         _stateMachine->ProcessString(Placeholder());
-        VERIFY_IS_NOT_NULL(_testGetSet->_textBuffer->GetRowByOffset(freshRow).GetImageSlice(), L"non-virtual put preserves placeholder eligibility");
+        VERIFY_IS_NOT_NULL(DirectImageSlice(*_testGetSet->_textBuffer, freshRow), L"non-virtual put preserves placeholder eligibility");
     }
 
     // Delete-all does not affect virtual placements, so later placeholder text can reuse the grid.
@@ -7844,7 +7909,7 @@ public:
         _testGetSet->_cellSize = { 4, 4 };
         const auto origin = _testGetSet->_textBuffer->GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,X=2,Y=0;/wAA\x1b\\"); // 1px red, X offset 2
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_ARE_EQUAL(0, static_cast<int>(SlicePixelAt(slice, 0, 0).rgbRed), L"the X-offset gutter pixel (0,0) is transparent");
         VERIFY_ARE_EQUAL(255, static_cast<int>(SlicePixelAt(slice, 2, 0).rgbRed), L"the red pixel is shifted to x=2");
@@ -7860,7 +7925,7 @@ public:
         const auto origin = _testGetSet->_textBuffer->GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,f=24,s=1,v=1,C=1;/wAA\x1b\\"); // red at (0,0)
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=1,X=2,C=1;\x1b\\"); // re-put red shifted to (2,0)
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_ARE_EQUAL(0, static_cast<int>(SlicePixelAt(slice, 0, 0).rgbRed), L"the reused gutter pixel must be cleared, not the old red");
         VERIFY_ARE_EQUAL(255, static_cast<int>(SlicePixelAt(slice, 2, 0).rgbRed), L"red sits at the X offset");
@@ -7878,7 +7943,7 @@ public:
         const auto origin = _testGetSet->_textBuffer->GetCursor().GetPosition();
         // A 4px-wide image is exactly one 4px cell; X=2 shifts it right by 2px WITHIN that cell.
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=4,v=1,X=2,C=1;/wAA/wAA/wAA/wAA\x1b\\");
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(origin.x), L"the image's single cell is owned");
         VERIFY_ARE_EQUAL(0u, slice->ColumnOwner(origin.x + 1), L"a sub-cell X offset must not extend the placement into a 2nd column");
@@ -7899,20 +7964,20 @@ public:
         const auto parentPos = buf.GetCursor().GetPosition();
         // Parent (id 1, placement 1) at the cursor; C=1 leaves the cursor put.
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,f=24,s=1,v=1,C=1;/wAA\x1b\\"); // red
-        const auto* parentSlice = buf.GetRowByOffset(parentPos.y).GetImageSlice();
+        const auto* parentSlice = DirectImageSlice(buf, parentPos.y);
         VERIFY_IS_NOT_NULL(parentSlice);
         VERIFY_ARE_EQUAL(1u, parentSlice->ColumnOwner(parentPos.x), L"parent owns its cursor cell");
 
         // Child (id 2) +H=2,+V=1 => anchor parent+(2,1).
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,P=1,Q=1,H=2,V=1,f=24,s=1,v=1;AP8A\x1b\\"); // green
         VERIFY_ARE_EQUAL(parentPos, buf.GetCursor().GetPosition(), L"relative placement must not move the cursor");
-        const auto* childSlice = buf.GetRowByOffset(parentPos.y + 1).GetImageSlice();
+        const auto* childSlice = DirectImageSlice(buf, parentPos.y + 1);
         VERIFY_IS_NOT_NULL(childSlice);
         VERIFY_ARE_EQUAL(2u, childSlice->ColumnOwner(parentPos.x + 2), L"+offset child anchored at parent+(2,1)");
 
         // Child (id 3) -H=2,-V=1 => anchor parent+(-2,-1).
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=3,p=1,P=1,Q=1,H=-2,V=-1,f=24,s=1,v=1;AAD/\x1b\\"); // blue
-        const auto* child2Slice = buf.GetRowByOffset(parentPos.y - 1).GetImageSlice();
+        const auto* child2Slice = DirectImageSlice(buf, parentPos.y - 1);
         VERIFY_IS_NOT_NULL(child2Slice);
         VERIFY_ARE_EQUAL(3u, child2Slice->ColumnOwner(parentPos.x - 2), L"-offset child anchored at parent+(-2,-1)");
     }
@@ -7961,13 +8026,13 @@ public:
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;1m"); // fg id 1
         _stateMachine->ProcessString(L"\x1b[58:2::0:0:1m"); // underline = placement id 1
         _stateMachine->ProcessString(L"\xDBFB\xDEEE"); // one U+10EEEE placeholder
-        const auto* phSlice = buf.GetRowByOffset(phPos.y).GetImageSlice();
+        const auto* phSlice = DirectImageSlice(buf, phPos.y);
         VERIFY_IS_NOT_NULL(phSlice);
         VERIFY_ARE_EQUAL(1u, phSlice->ColumnOwner(phPos.x), L"virtual parent placeholder owns its cell");
         // Child relative to the virtual parent, +H=1,+V=1.
         _stateMachine->ProcessString(L"\x1b[38;2;0;0;0m"); // reset fg so the child isn't a placeholder
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,P=1,Q=1,H=1,V=1,f=24,s=1,v=1;AP8A\x1b\\"); // green
-        const auto* childSlice = buf.GetRowByOffset(phPos.y + 1).GetImageSlice();
+        const auto* childSlice = DirectImageSlice(buf, phPos.y + 1);
         VERIFY_IS_NOT_NULL(childSlice);
         VERIFY_ARE_EQUAL(2u, childSlice->ColumnOwner(phPos.x + 1), L"child anchored at virtual-parent min(x,y)+(1,1)");
     }
@@ -8037,16 +8102,16 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,P=1,Q=1,H=1,V=1,f=24,s=1,v=1,C=1;AP8A\x1b\\");
         const til::point oldChild{ oldParent.x + 1, oldParent.y + 1 };
-        VERIFY_ARE_EQUAL(2u, buffer.GetRowByOffset(oldChild.y).GetImageSlice()->ColumnOwner(oldChild.x));
+        VERIFY_ARE_EQUAL(2u, DirectImageSlice(buffer, oldChild.y)->ColumnOwner(oldChild.x));
 
         _pDispatch->CursorPosition(10, 8);
         const auto newParent = buffer.GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=1,C=1;\x1b\\");
         const til::point newChild{ newParent.x + 1, newParent.y + 1 };
 
-        const auto* oldSlice = buffer.GetRowByOffset(oldChild.y).GetImageSlice();
+        const auto* oldSlice = DirectImageSlice(buffer, oldChild.y);
         VERIFY_IS_TRUE(oldSlice == nullptr || oldSlice->ColumnOwner(oldChild.x) == 0, L"the child's old cells must be erased");
-        const auto* newSlice = buffer.GetRowByOffset(newChild.y).GetImageSlice();
+        const auto* newSlice = DirectImageSlice(buffer, newChild.y);
         VERIFY_IS_NOT_NULL(newSlice);
         VERIFY_ARE_EQUAL(2u, newSlice->ColumnOwner(newChild.x), L"the child must follow its moved parent");
         const auto& child = _kitty()._placements.at({ 2u, 1u });
@@ -8067,7 +8132,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,P=1,Q=1,H=1,V=1,f=24,s=1,v=1,C=1;AP8A\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=3,p=1,P=2,Q=1,H=2,V=1,f=24,s=1,v=1,C=1;AAD/\x1b\\");
         const til::point oldGrandchild{ oldParent.x + 3, oldParent.y + 2 };
-        VERIFY_ARE_EQUAL(3u, buffer.GetRowByOffset(oldGrandchild.y).GetImageSlice()->ColumnOwner(oldGrandchild.x));
+        VERIFY_ARE_EQUAL(3u, DirectImageSlice(buffer, oldGrandchild.y)->ColumnOwner(oldGrandchild.x));
 
         _pDispatch->CursorPosition(12, 9);
         const auto newParent = buffer.GetCursor().GetPosition();
@@ -8075,9 +8140,9 @@ public:
         const til::point newChild{ newParent.x + 1, newParent.y + 1 };
         const til::point newGrandchild{ newChild.x + 2, newChild.y + 1 };
 
-        const auto* oldSlice = buffer.GetRowByOffset(oldGrandchild.y).GetImageSlice();
+        const auto* oldSlice = DirectImageSlice(buffer, oldGrandchild.y);
         VERIFY_IS_TRUE(oldSlice == nullptr || oldSlice->ColumnOwner(oldGrandchild.x) == 0, L"the grandchild's old cells must be erased");
-        const auto* newSlice = buffer.GetRowByOffset(newGrandchild.y).GetImageSlice();
+        const auto* newSlice = DirectImageSlice(buffer, newGrandchild.y);
         VERIFY_IS_NOT_NULL(newSlice);
         VERIFY_ARE_EQUAL(3u, newSlice->ColumnOwner(newGrandchild.x), L"the grandchild must follow its immediate parent");
         const auto& grandchild = _kitty()._placements.at({ 3u, 1u });
@@ -8104,9 +8169,9 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=1,C=1;\x1b\\");
         const til::point newChild{ newParent.x + 1, newParent.y + 1 };
 
-        const auto* oldSlice = buffer.GetRowByOffset(oldChild.anchorRow).GetImageSlice();
+        const auto* oldSlice = DirectImageSlice(buffer, oldChild.anchorRow);
         VERIFY_IS_TRUE(oldSlice == nullptr || oldSlice->ColumnOwner(oldChild.anchorCol) == 0);
-        const auto* newSlice = buffer.GetRowByOffset(newChild.y).GetImageSlice();
+        const auto* newSlice = DirectImageSlice(buffer, newChild.y);
         VERIFY_IS_NOT_NULL(newSlice);
         VERIFY_ARE_EQUAL(2u, newSlice->ColumnOwner(newChild.x));
         VERIFY_ARE_EQUAL(newChild.x, _kitty()._anonymousPlacements.front().anchorCol);
@@ -8134,7 +8199,7 @@ public:
         const til::point firstChild{ newParent.x + 1, newParent.y };
         const til::point secondChild{ newParent.x + 3, newParent.y };
 
-        const auto* slice = buffer.GetRowByOffset(newParent.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, newParent.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_ARE_EQUAL(2u, slice->ColumnOwner(firstChild.x), L"the first sibling must survive the second sibling's old-cell erase");
         VERIFY_ARE_EQUAL(2u, slice->ColumnOwner(secondChild.x), L"the second sibling must be redrawn at its new anchor");
@@ -8158,7 +8223,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=1,C=1;\x1b\\");
         const til::point newChild{ newParent.x + 1, newParent.y };
 
-        const auto* slice = buffer.GetRowByOffset(newParent.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, newParent.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(newParent.x), L"the child's stale erase must not punch a hole in the parent");
         VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(newChild.x), L"the same-image child must move after the restored parent");
@@ -8176,8 +8241,8 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,P=1,Q=1,H=1,V=1,f=24,s=1,v=1,C=1;AP8A\x1b\\");
         const auto childLayer = _kitty()._placements.at({ 2u, 1u }).layerId;
         buffer.ScrollRows(originalParent.y, 2, 1);
-        buffer.GetMutableRowByOffset(originalParent.y).SetImageSlice(nullptr);
-        VERIFY_IS_TRUE(buffer.GetRowByOffset(originalParent.y + 2).GetImageSlice()->ContainsPlacement(childLayer));
+        buffer.GetMutableImages().EraseArea({ 0, originalParent.y, buffer.GetSize().Width(), originalParent.y + 1 });
+        VERIFY_IS_TRUE(DirectImageSlice(buffer, originalParent.y + 2)->ContainsPlacement(childLayer));
 
         // The registry still contains the creation-time anchor. Re-put at that same coordinate
         // must compare against the retained layer's scrolled position and move the child back.
@@ -8185,9 +8250,9 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=1,C=1;\x1b\\");
         const til::point expectedChild{ originalParent.x + 1, originalParent.y + 1 };
 
-        const auto* oldSlice = buffer.GetRowByOffset(originalParent.y + 2).GetImageSlice();
+        const auto* oldSlice = DirectImageSlice(buffer, originalParent.y + 2);
         VERIFY_IS_TRUE(oldSlice == nullptr || !oldSlice->ContainsPlacement(childLayer));
-        const auto* newSlice = buffer.GetRowByOffset(expectedChild.y).GetImageSlice();
+        const auto* newSlice = DirectImageSlice(buffer, expectedChild.y);
         VERIFY_IS_NOT_NULL(newSlice);
         VERIFY_IS_TRUE(newSlice->PlacementCoversColumn(childLayer, expectedChild.x));
     }
@@ -8202,12 +8267,12 @@ public:
         const auto originalParent = buffer.GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
         buffer.ScrollRows(originalParent.y, 1, 1);
-        buffer.GetMutableRowByOffset(originalParent.y).SetImageSlice(nullptr);
+        buffer.GetMutableImages().EraseArea({ 0, originalParent.y, buffer.GetSize().Width(), originalParent.y + 1 });
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,P=1,Q=1,H=1,V=1,f=24,s=1,v=1,C=1;AP8A\x1b\\");
 
         const til::point expectedChild{ originalParent.x + 1, originalParent.y + 2 };
         const auto childLayer = _kitty()._placements.at({ 2u, 1u }).layerId;
-        const auto* slice = buffer.GetRowByOffset(expectedChild.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, expectedChild.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(slice->PlacementCoversColumn(childLayer, expectedChild.x), L"relative resolution must use the parent's retained scrolled layer");
     }
@@ -8229,7 +8294,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=1,C=1;\x1b\\");
         const til::point newChild{ newParent.x, newParent.y + 1 };
 
-        const auto* slice = buffer.GetRowByOffset(newChild.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, newChild.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_ARE_EQUAL(0, static_cast<int>(SlicePixelAt(slice, 0, 0).rgbGreen), L"the retained X/Y gutter remains transparent");
         VERIFY_ARE_EQUAL(255, static_cast<int>(SlicePixelAt(slice, 2, 1).rgbGreen), L"the child retains its scaled, shifted pixels");
@@ -8338,7 +8403,7 @@ public:
         const auto& placement = _kitty()._placements.at({ 2u, 1u });
         VERIFY_ARE_EQUAL(0, placement.anchorCol);
         VERIFY_ARE_EQUAL(0, placement.anchorRow);
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(0).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, 0);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_ARE_EQUAL(2u, slice->ColumnOwner(0));
     }
@@ -8383,7 +8448,7 @@ public:
         const auto& child = _kitty()._placements.at({ 2u, 1u });
         VERIFY_ARE_EQUAL(minX + 1, child.anchorCol, L"child x = min(all placeholder x) + H");
         VERIFY_ARE_EQUAL(minY + 1, child.anchorRow, L"child y = min(all placeholder y) + V");
-        const auto* childSlice = buf.GetRowByOffset(minY + 1).GetImageSlice();
+        const auto* childSlice = DirectImageSlice(buf, minY + 1);
         VERIFY_IS_NOT_NULL(childSlice);
         VERIFY_ARE_EQUAL(2u, childSlice->ColumnOwner(minX + 1));
     }
@@ -8432,7 +8497,7 @@ public:
         _pDispatch->CursorPosition(4, 4);
         const auto posA = buf.GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=1,C=1;\x1b\\"); // put at A
-        const auto* firstSlice = buf.GetRowByOffset(posA.y).GetImageSlice();
+        const auto* firstSlice = DirectImageSlice(buf, posA.y);
         VERIFY_IS_NOT_NULL(firstSlice);
         VERIFY_ARE_EQUAL(1u, firstSlice->ColumnOwner(posA.x), L"A owns the placement after the first put");
 
@@ -8441,9 +8506,9 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=1,C=1;\x1b\\"); // re-put at B
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._placements.size(), L"re-put replaces, not appends");
 
-        const auto* sliceA = buf.GetRowByOffset(posA.y).GetImageSlice();
+        const auto* sliceA = DirectImageSlice(buf, posA.y);
         VERIFY_IS_TRUE(sliceA == nullptr || sliceA->ColumnOwner(posA.x) == 0, L"the prior position's pixels must be erased on re-put");
-        const auto* sliceB = buf.GetRowByOffset(posB.y).GetImageSlice();
+        const auto* sliceB = DirectImageSlice(buf, posB.y);
         VERIFY_IS_NOT_NULL(sliceB);
         VERIFY_ARE_EQUAL(1u, sliceB->ColumnOwner(posB.x), L"the new position holds the re-put placement");
         VERIFY_IS_TRUE(SliceContainsColor(sliceB, 255, 0, 0), L"the re-put placement still shows the image color");
@@ -8472,14 +8537,14 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=1,C=1;\x1b\\"); // re-put (1,1) to C
         VERIFY_ARE_EQUAL(static_cast<size_t>(2), _kitty()._placements.size());
 
-        const auto* sliceB = buf.GetRowByOffset(posB.y).GetImageSlice();
+        const auto* sliceB = DirectImageSlice(buf, posB.y);
         VERIFY_IS_NOT_NULL(sliceB);
         VERIFY_ARE_EQUAL(1u, sliceB->ColumnOwner(posB.x), L"the sibling placement (1,2) must be intact after re-putting (1,1)");
 
-        const auto* sliceA = buf.GetRowByOffset(posA.y).GetImageSlice();
+        const auto* sliceA = DirectImageSlice(buf, posA.y);
         VERIFY_IS_TRUE(sliceA == nullptr || sliceA->ColumnOwner(posA.x) == 0, L"the old (1,1) position must be erased");
 
-        const auto* sliceC = buf.GetRowByOffset(posC.y).GetImageSlice();
+        const auto* sliceC = DirectImageSlice(buf, posC.y);
         VERIFY_IS_NOT_NULL(sliceC);
         VERIFY_ARE_EQUAL(1u, sliceC->ColumnOwner(posC.x), L"the re-put (1,1) now lives at C");
     }
@@ -8502,7 +8567,7 @@ public:
         buffer.ScrollRows(origin.y, 1, 1);
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1,p=1;\x1b\\");
 
-        const auto* slice = buffer.GetRowByOffset(origin.y + 1).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y + 1);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_FALSE(slice->ContainsPlacement(firstLayer), L"delete follows the first placement after it scrolls");
         VERIFY_IS_TRUE(slice->ContainsPlacement(secondLayer), L"same-image/same-z sibling survives exact deletion");
@@ -8523,13 +8588,13 @@ public:
         buffer.GetCursor().SetPosition({ 0, origin.y });
         _stateMachine->ProcessString(L"\x1b[@");
         _pDispatch->CopyRectangularArea(vtRow, 2, vtRow, 2, 1, vtRow, 6, 1);
-        auto* slice = buffer.GetMutableRowByOffset(origin.y).GetMutableImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(slice->PlacementCoversColumn(layerId, 1), L"ICH moves the placement identity");
         VERIFY_IS_TRUE(slice->PlacementCoversColumn(layerId, 5), L"DECCRA copies the placement identity");
 
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1,p=1;\x1b\\");
-        slice = buffer.GetMutableRowByOffset(origin.y).GetMutableImageSlice();
+        slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_TRUE(slice == nullptr || !slice->ContainsPlacement(layerId), L"exact delete removes every copied cell");
     }
 
@@ -8548,7 +8613,7 @@ public:
         auto found = false;
         for (auto row = 0; row < reflowed->GetSize().Height(); ++row)
         {
-            const auto* slice = reflowed->GetRowByOffset(row).GetImageSlice();
+            const auto* slice = DirectImageSlice(*reflowed, row);
             found |= slice && slice->ContainsPlacement(layerId);
         }
         VERIFY_IS_TRUE(found, L"reflow preserves the retained placement identity");
@@ -8573,13 +8638,13 @@ public:
         // Anonymous relative child (image 2, NO p=) at parent+(1,1).
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,P=1,Q=1,H=1,V=1,f=24,s=1,v=1;AP8A\x1b\\"); // green
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._anonymousPlacements.size(), L"an anonymous relative placement is tracked for cascade");
-        const auto* childSlice = buf.GetRowByOffset(parentPos.y + 1).GetImageSlice();
+        const auto* childSlice = DirectImageSlice(buf, parentPos.y + 1);
         VERIFY_IS_NOT_NULL(childSlice);
         VERIFY_ARE_EQUAL(2u, childSlice->ColumnOwner(parentPos.x + 1), L"anonymous child drew at parent+(1,1)");
 
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1;\x1b\\"); // delete parent image 1
         VERIFY_IS_TRUE(_kitty()._anonymousPlacements.empty(), L"deleting the parent removes the anonymous child tracking");
-        const auto* gone = buf.GetRowByOffset(parentPos.y + 1).GetImageSlice();
+        const auto* gone = DirectImageSlice(buf, parentPos.y + 1);
         VERIFY_IS_TRUE(gone == nullptr || gone->ColumnOwner(parentPos.x + 1) == 0, L"the anonymous child's pixels must be erased");
 
         _testGetSet->_response.clear();
@@ -8602,7 +8667,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,P=1,Q=1,H=1,V=0,f=24,s=1,v=1,C=1;AP8A\x1b\\");
         const auto relChildCol = parentPos.x + 1;
         const auto relChildRow = parentPos.y;
-        const auto* relSlice = buf.GetRowByOffset(relChildRow).GetImageSlice();
+        const auto* relSlice = DirectImageSlice(buf, relChildRow);
         VERIFY_IS_NOT_NULL(relSlice);
         VERIFY_ARE_EQUAL(2u, relSlice->ColumnOwner(relChildCol), L"relative child of image 2 drew next to parent");
 
@@ -8610,7 +8675,7 @@ public:
         _pDispatch->CursorPosition(9, 9);
         const auto indepPos = buf.GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=2,p=2,C=1;\x1b\\");
-        const auto* indepSlice = buf.GetRowByOffset(indepPos.y).GetImageSlice();
+        const auto* indepSlice = DirectImageSlice(buf, indepPos.y);
         VERIFY_IS_NOT_NULL(indepSlice);
         VERIFY_ARE_EQUAL(2u, indepSlice->ColumnOwner(indepPos.x), L"independent placement of image 2 drew at the cursor");
         VERIFY_ARE_EQUAL(static_cast<size_t>(3), _kitty()._placements.size());
@@ -8620,10 +8685,10 @@ public:
         VERIFY_ARE_EQUAL(static_cast<size_t>(0), _kitty()._placements.count({ 2u, 1u }), L"the relative child placement is removed");
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._placements.count({ 2u, 2u }), L"the independent placement survives");
 
-        const auto* relGone = buf.GetRowByOffset(relChildRow).GetImageSlice();
+        const auto* relGone = DirectImageSlice(buf, relChildRow);
         VERIFY_IS_TRUE(relGone == nullptr || relGone->ColumnOwner(relChildCol) == 0, L"the relative child's pixels must be erased");
 
-        const auto* indepStill = buf.GetRowByOffset(indepPos.y).GetImageSlice();
+        const auto* indepStill = DirectImageSlice(buf, indepPos.y);
         VERIFY_IS_NOT_NULL(indepStill);
         VERIFY_ARE_EQUAL(2u, indepStill->ColumnOwner(indepPos.x), L"the independent placement of image 2 must survive");
     }
@@ -8671,7 +8736,7 @@ public:
         const auto pos1 = buf.GetCursor().GetPosition();
         // image1 (1,1): 1px red scaled to 4 cells => owns cols [pos1.x, pos1.x+4).
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,f=24,s=1,v=1,c=4,C=1;/wAA\x1b\\");
-        const auto* row1 = buf.GetRowByOffset(pos1.y).GetImageSlice();
+        const auto* row1 = DirectImageSlice(buf, pos1.y);
         VERIFY_IS_NOT_NULL(row1);
         VERIFY_ARE_EQUAL(1u, row1->ColumnOwner(pos1.x), L"image1 owns its left cell");
         VERIFY_ARE_EQUAL(1u, row1->ColumnOwner(pos1.x + 3), L"image1 owns its right cell");
@@ -8681,14 +8746,14 @@ public:
         _pDispatch->CursorPosition(3, 5); // 0-based col pos1.x+1
         const auto pos2 = buf.GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,f=24,s=1,v=1,c=2,C=1;AP8A\x1b\\");
-        const auto* row2 = buf.GetRowByOffset(pos2.y).GetImageSlice();
+        const auto* row2 = DirectImageSlice(buf, pos2.y);
         VERIFY_IS_NOT_NULL(row2);
         VERIFY_ARE_EQUAL(2u, row2->ColumnOwner(pos1.x + 1), L"image2 took over the middle cells");
         VERIFY_ARE_EQUAL(2u, row2->ColumnOwner(pos1.x + 2), L"image2 took over the middle cells");
 
         // Delete image1's placement: only image1's cells must be erased; image2's must survive.
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1,p=1;\x1b\\");
-        const auto* after = buf.GetRowByOffset(pos1.y).GetImageSlice();
+        const auto* after = DirectImageSlice(buf, pos1.y);
         VERIFY_IS_NOT_NULL(after, L"the slice survives because image2 still owns cells in it");
         VERIFY_ARE_EQUAL(0u, after->ColumnOwner(pos1.x), L"image1's left cell was erased");
         VERIFY_ARE_EQUAL(0u, after->ColumnOwner(pos1.x + 3), L"image1's right cell was erased");
@@ -8747,7 +8812,7 @@ public:
         VERIFY_IS_TRUE(_kitty()._placements.size() <= KittyParser::MaxPlacements, L"the placement registry must stay bounded");
         VERIFY_ARE_EQUAL(static_cast<size_t>(0), _kitty()._placements.count({ 1u, 1u }), L"the parent (1,1) was evicted at the cap");
         VERIFY_ARE_EQUAL(static_cast<size_t>(0), _kitty()._placements.count({ 2u, 1u }), L"the evicted parent's relative child must be cascaded, not left dangling");
-        const auto* ghost = buf.GetRowByOffset(parentPos.y).GetImageSlice();
+        const auto* ghost = DirectImageSlice(buf, parentPos.y);
         VERIFY_IS_TRUE(ghost == nullptr || ghost->ColumnOwner(parentPos.x) == 0, L"the evicted parent's drawn cell must be erased (no ghost pixels)");
     }
 
@@ -8768,10 +8833,10 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,p=2,C=1;\x1b\\"); // (1,2) at B
         VERIFY_ARE_EQUAL(static_cast<size_t>(2), _kitty()._placements.size());
 
-        const auto* sliceA = buf.GetRowByOffset(posA.y).GetImageSlice();
+        const auto* sliceA = DirectImageSlice(buf, posA.y);
         VERIFY_IS_NOT_NULL(sliceA);
         VERIFY_ARE_EQUAL(1u, sliceA->ColumnOwner(posA.x));
-        const auto* sliceB = buf.GetRowByOffset(posB.y).GetImageSlice();
+        const auto* sliceB = DirectImageSlice(buf, posB.y);
         VERIFY_IS_NOT_NULL(sliceB);
         VERIFY_ARE_EQUAL(1u, sliceB->ColumnOwner(posB.x));
 
@@ -8780,9 +8845,9 @@ public:
         VERIFY_ARE_EQUAL(static_cast<size_t>(0), _kitty()._placements.count({ 1u, 1u }), L"placement (1,1) is removed");
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._placements.count({ 1u, 2u }), L"placement (1,2) survives");
 
-        const auto* goneA = buf.GetRowByOffset(posA.y).GetImageSlice();
+        const auto* goneA = DirectImageSlice(buf, posA.y);
         VERIFY_IS_TRUE(goneA == nullptr || goneA->ColumnOwner(posA.x) == 0, L"placement (1,1) pixels must be erased");
-        const auto* stillB = buf.GetRowByOffset(posB.y).GetImageSlice();
+        const auto* stillB = DirectImageSlice(buf, posB.y);
         VERIFY_IS_NOT_NULL(stillB);
         VERIFY_ARE_EQUAL(1u, stillB->ColumnOwner(posB.x), L"placement (1,2) pixels must survive");
 
@@ -8801,13 +8866,13 @@ public:
         const auto pos = buf.GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,f=24,s=1,v=1,C=1;/wAA\x1b\\"); // only placement (1,1)
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._placements.size());
-        const auto* slice = buf.GetRowByOffset(pos.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buf, pos.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_ARE_EQUAL(1u, slice->ColumnOwner(pos.x));
 
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=I,i=1,p=1;\x1b\\"); // delete the only placement
         VERIFY_IS_TRUE(_kitty()._placements.empty());
-        const auto* gone = buf.GetRowByOffset(pos.y).GetImageSlice();
+        const auto* gone = DirectImageSlice(buf, pos.y);
         VERIFY_IS_TRUE(gone == nullptr || gone->ColumnOwner(pos.x) == 0, L"the placement's pixels must be erased");
 
         _testGetSet->_response.clear();
@@ -8829,14 +8894,14 @@ public:
         VERIFY_ARE_EQUAL(static_cast<size_t>(2), _kitty()._placements.size());
 
         const auto childCol = parentPos.x + 1;
-        const auto* childSlice = buf.GetRowByOffset(parentPos.y).GetImageSlice();
+        const auto* childSlice = DirectImageSlice(buf, parentPos.y);
         VERIFY_IS_NOT_NULL(childSlice);
         VERIFY_ARE_EQUAL(2u, childSlice->ColumnOwner(childCol));
 
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=I,i=1,p=1;\x1b\\"); // delete (1,1) -> cascades to its child
         VERIFY_IS_TRUE(_kitty()._placements.empty(), L"deleting the parent placement cascades to its relative child");
 
-        const auto* erased = buf.GetRowByOffset(parentPos.y).GetImageSlice();
+        const auto* erased = DirectImageSlice(buf, parentPos.y);
         VERIFY_IS_TRUE(erased == nullptr || erased->ColumnOwner(parentPos.x) == 0, L"the parent placement's pixels must be erased");
         VERIFY_IS_TRUE(erased == nullptr || erased->ColumnOwner(childCol) == 0, L"the child placement's pixels must be erased");
 
@@ -8864,9 +8929,9 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=I,i=1;\x1b\\"); // no p= -> whole-image delete
         VERIFY_IS_TRUE(_kitty()._placements.empty(), L"delete by id without p removes all of the image's placements");
 
-        const auto* goneA = buf.GetRowByOffset(posA.y).GetImageSlice();
+        const auto* goneA = DirectImageSlice(buf, posA.y);
         VERIFY_IS_TRUE(goneA == nullptr || goneA->ColumnOwner(posA.x) == 0);
-        const auto* goneB = buf.GetRowByOffset(posB.y).GetImageSlice();
+        const auto* goneB = DirectImageSlice(buf, posB.y);
         VERIFY_IS_TRUE(goneB == nullptr || goneB->ColumnOwner(posB.x) == 0);
 
         _testGetSet->_response.clear();
@@ -8894,7 +8959,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,z=-1073741824,f=24,s=1,v=1,C=1;AP8A\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=3,p=1,z=0,f=24,s=1,v=1,C=1;AAD/\x1b\\");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto x = origin.x - slice->ColumnOffset();
         const auto behindBackground = SlicePixelAt(slice, ImageSlice::RenderPosition::BehindBackground, x, 0);
@@ -8913,7 +8978,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,z=7,f=24,s=1,v=1,C=1;AP8A\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,z=7,f=24,s=1,v=1,C=1;/wAA\x1b\\");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
         VERIFY_IS_TRUE(pixel.rgbRed == 0 && pixel.rgbGreen == 255 && pixel.rgbBlue == 0, L"higher image id must be on top at equal z");
@@ -8927,7 +8992,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,z=-1,f=32,s=1,v=1,C=1;/wAAgA==\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,z=-1,f=32,s=1,v=1,C=1;AP8AgA==\x1b\\");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::BehindText, origin.x - slice->ColumnOffset(), 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(64), pixel.rgbRed);
@@ -8945,7 +9010,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,z=2,f=24,s=1,v=1,C=1;AP8A\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=I,i=2;\x1b\\");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
         VERIFY_IS_TRUE(pixel.rgbRed == 255 && pixel.rgbGreen == 0 && pixel.rgbBlue == 0, L"deleting the top layer must reveal the lower layer");
@@ -8960,7 +9025,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,z=2,f=24,s=1,v=1,C=1;AP8A\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=z,z=2;\x1b\\");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto x = origin.x - slice->ColumnOffset();
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), SlicePixelAt(slice, ImageSlice::RenderPosition::BehindText, x, 0).rgbRed);
@@ -9001,7 +9066,7 @@ public:
 
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=q,x=1,y=1,z=3;\x1b\\");
 
-        const auto* slice = buffer.GetRowByOffset(row).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, row);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_FALSE(slice->Contains(1), L"d=q must delete the matching image/z placement");
         VERIFY_IS_TRUE(slice->Contains(2), L"d=q must preserve the same z at another cell");
@@ -9025,7 +9090,7 @@ public:
 
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=q,x=1,y=1,z=3;\x1b\\");
 
-        const auto* slice = buffer.GetRowByOffset(row).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, row);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_FALSE(slice->ContainsPlacement(firstLayer));
         VERIFY_IS_TRUE(slice->ContainsPlacement(secondLayer), L"d=q preserves a non-intersecting placement with the same image and z");
@@ -9050,7 +9115,7 @@ public:
 
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=q,x=1,y=1,z=6;\x1b\\");
 
-        const auto* slice = buffer.GetRowByOffset(row).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, row);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_FALSE(slice->ContainsPlacement(firstLayer));
         VERIFY_IS_TRUE(slice->ContainsPlacement(secondLayer), L"anonymous p=0 placements receive distinct internal identities");
@@ -9087,7 +9152,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=z,z=5;\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=Q,x=" + std::to_wstring(x) + L",y=" + std::to_wstring(y) + L",z=5;\x1b\\");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(slice->Contains(1), L"z-based selectors must not affect virtual placements");
         VERIFY_ARE_EQUAL(static_cast<size_t>(1), _kitty()._virtualIds.count({ 1u, 1u }));
@@ -9108,7 +9173,7 @@ public:
 
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=Z,z=3;\x1b\\");
 
-        const auto* slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(slice->ColumnOwner(origin.x) != 1, L"the physical z=3 placement must be deleted");
         VERIFY_IS_TRUE(slice->ColumnOwner(origin.x + 2) == 1, L"the coexisting virtual z=5 placement must survive");
@@ -9155,7 +9220,7 @@ public:
         buffer.GetCursor().SetPosition({ origin.x, origin.y + 1 });
         _stateMachine->ProcessString(L"\x1b[@");
 
-        const auto* slice = buffer.GetRowByOffset(origin.y + 1).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y + 1);
         VERIFY_IS_NOT_NULL(slice);
         const auto oldPixel = SlicePixelAt(slice, ImageSlice::RenderPosition::BehindText, origin.x - slice->ColumnOffset(), 0);
         const auto movedPixel = SlicePixelAt(slice, ImageSlice::RenderPosition::BehindText, origin.x + 1 - slice->ColumnOffset(), 0);
@@ -9174,6 +9239,9 @@ public:
         const til::point origin{ sixelSlice->ColumnOffset(), sixelRow };
         buffer.GetCursor().SetPosition(origin);
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,z=1,f=24,s=1,v=1,C=1;AP8A\x1b\\");
+        const auto* originalKitty = DirectImageSlice(buffer, origin.y);
+        VERIFY_IS_NOT_NULL(originalKitty);
+        VERIFY_ARE_EQUAL(1u, originalKitty->ColumnOwner(origin.x));
         const auto* original = buffer.GetRowByOffset(origin.y).GetImageSlice();
         VERIFY_IS_NOT_NULL(original);
         const auto originalSixel = *original->Pixels(origin.x);
@@ -9181,6 +9249,10 @@ public:
 
         buffer.GetCursor().SetPosition(origin);
         _stateMachine->ProcessString(L"\x1b[@");
+        const auto* movedKitty = DirectImageSlice(buffer, origin.y);
+        VERIFY_IS_NOT_NULL(movedKitty);
+        VERIFY_ARE_EQUAL(0u, movedKitty->ColumnOwner(origin.x));
+        VERIFY_ARE_EQUAL(1u, movedKitty->ColumnOwner(origin.x + 1));
         const auto* moved = buffer.GetRowByOffset(origin.y).GetImageSlice();
         VERIFY_IS_NOT_NULL(moved);
         const auto movedSixel = *moved->Pixels(origin.x + 1);
@@ -9191,6 +9263,7 @@ public:
         VERIFY_IS_NOT_NULL(slice);
         const auto pixel = *slice->Pixels(origin.x + 1);
         VERIFY_IS_TRUE(pixel.rgbRed == 255 && pixel.rgbGreen == 0, L"deleting moved Kitty pixels must not erase co-moved Sixel pixels");
+        VERIFY_IS_NULL(DirectImageSlice(buffer, origin.y));
     }
 
     TEST_METHOD(KittyGraphicsOmittedZIndexDefaultsAboveText)
@@ -9200,7 +9273,7 @@ public:
         const auto origin = _testGetSet->_textBuffer->GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto x = origin.x - slice->ColumnOffset();
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, x, 0).rgbRed);
@@ -9218,7 +9291,7 @@ public:
         _stateMachine->ProcessString(L"\x1b[58:2::0:0:1m");
         _stateMachine->ProcessString(Placeholder() + L"\x0305" + L"\x0305");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::BehindText, origin.x - slice->ColumnOffset(), 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbRed);
@@ -9234,7 +9307,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,p=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,P=1,Q=1,H=1,z=-1,f=24,s=1,v=1,C=1;AP8A\x1b\\");
 
-        const auto* slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::BehindText, origin.x + 1 - slice->ColumnOffset(), 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbGreen);
@@ -9251,7 +9324,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,z=-1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
         _pDispatch->CopyRectangularArea(vtRow, origin.x + 1, vtRow, origin.x + 1, 1, vtRow, origin.x + 6, 1);
 
-        const auto* slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto copied = SlicePixelAt(slice, ImageSlice::RenderPosition::BehindText, origin.x + 5 - slice->ColumnOffset(), 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), copied.rgbRed);
@@ -9266,7 +9339,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,z=1,f=24,s=1,v=1,C=1;AP8A\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=A;\x1b\\");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_TRUE(slice == nullptr || (!slice->Contains(1) && !slice->Contains(2)));
     }
 
@@ -9296,12 +9369,12 @@ public:
         const auto origin = _testGetSet->_textBuffer->GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,z=-1,f=32,s=1,v=1,C=1;AAAAAA==\x1b\\");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(slice->Contains(1), L"transparent placement cells still participate in deletion");
         VERIFY_IS_FALSE(slice->HasPixels(ImageSlice::RenderPosition::BehindText));
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=I,i=1;\x1b\\");
-        slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_TRUE(slice == nullptr || !slice->Contains(1));
     }
 
@@ -9321,7 +9394,7 @@ public:
         auto found = false;
         for (auto row = 0; row < reflowed->GetSize().Height() && !found; ++row)
         {
-            if (const auto* slice = reflowed->GetRowByOffset(row).GetImageSlice())
+            if (const auto* slice = DirectImageSlice(*reflowed, row))
             {
                 for (const auto& pixel : slice->Pixels(ImageSlice::RenderPosition::BehindText))
                 {
@@ -9347,7 +9420,7 @@ public:
         buffer.GetCursor().SetPosition(placeholderPosition);
         _stateMachine->ProcessString(Placeholder() + L"\x0305" + L"\x0305");
         const auto virtualLayer = _kitty()._placements.at({ 1u, 1u }).layerId;
-        const auto* placeholderSlice = buffer.GetRowByOffset(placeholderPosition.y).GetImageSlice();
+        const auto* placeholderSlice = DirectImageSlice(buffer, placeholderPosition.y);
         VERIFY_IS_NOT_NULL(placeholderSlice);
         VERIFY_IS_TRUE(placeholderSlice->Contains(1));
         VERIFY_IS_TRUE(placeholderSlice->ContainsPlacement(virtualLayer));
@@ -9356,7 +9429,7 @@ public:
         const auto physicalLayer = _kitty()._placements.at({ 1u, 2u }).layerId;
         buffer.GetCursor().SetPosition(placeholderPosition);
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=2,p=1,z=2,f=24,s=1,v=1,C=1;AP8A\x1b\\");
-        const auto* sourceSlice = buffer.GetRowByOffset(placeholderPosition.y).GetImageSlice();
+        const auto* sourceSlice = DirectImageSlice(buffer, placeholderPosition.y);
         VERIFY_IS_NOT_NULL(sourceSlice);
         VERIFY_IS_TRUE(sourceSlice->Contains(1));
         VERIFY_IS_TRUE(sourceSlice->Contains(2));
@@ -9372,7 +9445,7 @@ public:
         for (auto y = 0; y < reflowed->GetSize().Height(); ++y)
         {
             const auto& row = reflowed->GetRowByOffset(y);
-            const auto* slice = row.GetImageSlice();
+            const auto* slice = DirectImageSlice(*reflowed, y);
             foundOverlappingImage |= slice && slice->Contains(2);
             foundOverlappingPlacement |= slice && slice->ContainsPlacement(physicalLayer);
             for (auto x = 0; x < reflowed->GetSize().Width(); ++x)
@@ -9431,7 +9504,7 @@ public:
         for (auto y = 0; y < reflowed->GetSize().Height(); ++y)
         {
             const auto& row = reflowed->GetRowByOffset(y);
-            const auto* slice = row.GetImageSlice();
+            const auto* slice = DirectImageSlice(*reflowed, y);
             foundPhysicalLayer |= slice && slice->ContainsPlacement(physicalLayer);
             for (auto x = 0; x < reflowed->GetSize().Width(); ++x)
             {
@@ -9479,7 +9552,7 @@ public:
         _stateMachine->ProcessString(L"\x1b[0m");
 
         const auto& row = buffer.GetRowByOffset(origin.y);
-        const auto* slice = row.GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         auto sawInsideGrid = false;
         auto sawOutsideGrid = false;
@@ -9513,7 +9586,7 @@ public:
         for (auto y = 0; y < reflowed->GetSize().Height(); ++y)
         {
             const auto& reflowedRow = reflowed->GetRowByOffset(y);
-            const auto* reflowedSlice = reflowedRow.GetImageSlice();
+            const auto* reflowedSlice = DirectImageSlice(*reflowed, y);
             for (auto x = 0; x < reflowed->GetSize().Width(); ++x)
             {
                 const auto* metadata = reflowedRow.GetImageCellRef(x);
@@ -9716,7 +9789,7 @@ public:
         auto foundBoth = false;
         for (auto y = 0; y < reflowed->GetSize().Height(); ++y)
         {
-            if (const auto* slice = reflowed->GetRowByOffset(y).GetImageSlice())
+            if (const auto* slice = DirectImageSlice(*reflowed, y))
             {
                 foundBoth |= slice->Contains(1) && slice->Contains(2);
             }
@@ -9724,7 +9797,7 @@ public:
         VERIFY_IS_TRUE(foundBoth, L"layers from both rows must survive when widening joins wrapped rows");
     }
 
-    TEST_METHOD(KittyGraphicsLayerCountIsBoundedAndReleased)
+    TEST_METHOD(SixelLayerCountIsBoundedAndReleased)
     {
         const auto availableBefore = ImageSlice::LayerBytesAvailable();
         {
@@ -9790,7 +9863,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,r=2,X=1;AAD/\x1b\\");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbBlue, L"editing the displayed frame refreshes retained placements");
@@ -9809,14 +9882,14 @@ public:
         _pDispatch->ResetMode(DispatchTypes::ModeParams::DECPCCM_PageCursorCouplingMode);
         _pDispatch->PagePositionAbsolute(2);
         _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
-        auto* slice = firstPageBuffer.GetRowByOffset(origin.y).GetImageSlice();
+        auto* slice = DirectImageSlice(firstPageBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbGreen, L"the visible page must animate while a decoupled background page is active");
         VERIFY_ARE_EQUAL(static_cast<BYTE>(0), pixel.rgbRed);
         _pDispatch->PagePositionAbsolute(1);
 
-        slice = firstPageBuffer.GetRowByOffset(origin.y).GetImageSlice();
+        slice = DirectImageSlice(firstPageBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbGreen, L"reactivating a page must refresh it to the animation's current frame");
@@ -9871,9 +9944,10 @@ public:
         auto& buffer = *_testGetSet->_textBuffer;
         const auto origin = buffer.GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
-        const auto* slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
-        const auto revision = slice->Revision();
+        const auto surface = buffer.GetImages().All().front().SurfacePointer();
+        const auto revision = surface->Revision();
 
         _stateMachine->ProcessString(L"\x1b_Ga=t,i=2,f=24,s=1,v=1;/wAA\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=f,i=2,f=24,s=1,v=1,z=1;AP8A\x1b\\");
@@ -9881,28 +9955,28 @@ public:
         auto& image = _kitty()._images.at(2);
         VERIFY_IS_TRUE(_kitty()._advanceImage(2, image, std::chrono::steady_clock::now()));
 
-        slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
-        VERIFY_ARE_EQUAL(revision, slice->Revision(), L"an animation with no rendered placements must not scan or invalidate unrelated retained layers");
+        VERIFY_ARE_EQUAL(surface.get(), buffer.GetImages().All().front().SurfacePointer().get());
+        VERIFY_ARE_EQUAL(revision, surface->Revision(), L"an unplaced animation must not refresh another image's shared surface");
     }
 
-    TEST_METHOD(KittyAnimationClearsRenderedHintAfterLastLayerIsErased)
+    TEST_METHOD(KittyAnimationDeleteReleasesSharedSurface)
     {
         _testGetSet->PrepData();
         _testGetSet->_cellSize = { 1, 1 };
         auto& buffer = *_testGetSet->_textBuffer;
-        const auto origin = buffer.GetCursor().GetPosition();
         _stateMachine->ProcessString(L"\x1b_Ga=T,i=1,f=24,s=1,v=1,C=1;/wAA\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1,z=1;AP8A\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=1,z=1,c=1,s=3;\x1b\\");
-        auto& image = _kitty()._images.at(1);
-        VERIFY_IS_TRUE(image.hasRenderedPlacements);
+        const std::weak_ptr surface{ _kitty()._images.at(1).surface };
 
-        buffer.GetMutableRowByOffset(origin.y).SetImageSlice(nullptr);
-        VERIFY_IS_TRUE(_kitty()._advanceImage(1, image, std::chrono::steady_clock::now()));
-        VERIFY_IS_FALSE(image.hasRenderedPlacements, L"the first empty scan must disable future full-page animation scans");
-        VERIFY_IS_TRUE(buffer.GetImages().Empty(), L"orphaned rectangular placements are pruned with their compatibility layers");
-        VERIFY_IS_NULL(image.surface.get());
+        _stateMachine->ProcessString(L"\x1b_Ga=d,d=I,i=1;\x1b\\");
+
+        VERIFY_IS_TRUE(buffer.GetImages().Empty());
+        VERIFY_IS_FALSE(_kitty()._images.contains(1));
+        VERIFY_IS_TRUE(surface.expired(), L"deleting the final placement and image must release its shared surface");
+        VerifyNoDirectImageLayers(buffer);
     }
 
     TEST_METHOD(KittyAnimationRefreshKeepsLastPresentedGaplessFrame)
@@ -9922,7 +9996,7 @@ public:
         VERIFY_ARE_EQUAL(1u, image.presentedFrame);
         _pDispatch->NotifyFontChanged();
 
-        const auto* slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbRed, L"lifecycle refresh must restore the last presented frame");
@@ -9930,7 +10004,7 @@ public:
 
         _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,r=2,z=20;\x1b\\");
         VERIFY_ARE_EQUAL(2u, image.presentedFrame, L"giving the skipped current frame a duration must present it before scheduling");
-        slice = buffer.GetRowByOffset(origin.y).GetImageSlice();
+        slice = DirectImageSlice(buffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto resumedPixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), resumedPixel.rgbGreen);
@@ -9947,7 +10021,7 @@ public:
         _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=p,i=1,C=1;\x1b\\");
 
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbGreen);
@@ -10045,7 +10119,7 @@ public:
         VERIFY_ARE_EQUAL(2u, image.currentFrame);
         VERIFY_ARE_EQUAL(75, image.animationFrames.front().gapMilliseconds);
         VERIFY_ARE_EQUAL(1u, image.animationState);
-        const auto* slice = _testGetSet->_textBuffer->GetRowByOffset(origin.y).GetImageSlice();
+        const auto* slice = DirectImageSlice(*_testGetSet->_textBuffer, origin.y);
         VERIFY_IS_NOT_NULL(slice);
         const auto pixel = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), pixel.rgbGreen);
@@ -10191,7 +10265,7 @@ public:
         _stateMachine->ProcessString(L"\x1b[@");
         _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
 
-        const auto* slice = buffer.GetRowByOffset(origin.y + 1).GetImageSlice();
+        const auto* slice = DirectImageSlice(buffer, origin.y + 1);
         VERIFY_IS_NOT_NULL(slice);
         const auto inserted = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x - slice->ColumnOffset(), 0);
         const auto moved = SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, origin.x + 1 - slice->ColumnOffset(), 0);
@@ -10211,12 +10285,13 @@ public:
         auto reflowed = std::make_unique<TextBuffer>(til::size{ 5, 600 }, TextAttribute{}, 0, false, &_testGetSet->_renderer);
         TextBuffer::Reflow(buffer, *reflowed);
         const std::vector<RGBQUAD> green{ RGBQUAD{ 0, 255, 0, 255 } };
+        VERIFY_IS_FALSE(reflowed->GetImages().Empty());
+        reflowed->GetImages().All().front().SurfacePointer()->UpdatePixels(green);
         auto found = false;
         for (auto row = 0; row < reflowed->GetSize().Height(); ++row)
         {
-            if (auto* slice = reflowed->GetMutableRowByOffset(row).GetMutableImageSlice())
+            if (const auto* slice = DirectImageSlice(*reflowed, row))
             {
-                slice->UpdateImage(1, green);
                 found |= SliceContainsColor(slice, 0, 255, 0);
             }
         }
@@ -10239,7 +10314,7 @@ public:
 
         _stateMachine->ProcessString(L"\x1b_Ga=f,i=1,f=24,s=1,v=1;AP8A\x1b\\");
         _stateMachine->ProcessString(L"\x1b_Ga=a,i=1,c=2,s=1;\x1b\\");
-        auto* slice = buffer.GetMutableRowByOffset(row).GetMutableImageSlice();
+        const auto* slice = DirectImageSlice(buffer, row);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_TRUE(slice->ContainsPlacement(firstLayer));
         VERIFY_IS_TRUE(slice->ContainsPlacement(secondLayer));
@@ -10247,7 +10322,7 @@ public:
         VERIFY_ARE_EQUAL(static_cast<BYTE>(255), SlicePixelAt(slice, ImageSlice::RenderPosition::AboveText, 3, 0).rgbGreen);
 
         _stateMachine->ProcessString(L"\x1b_Ga=d,d=i,i=1,p=1;\x1b\\");
-        slice = buffer.GetMutableRowByOffset(row).GetMutableImageSlice();
+        slice = DirectImageSlice(buffer, row);
         VERIFY_IS_NOT_NULL(slice);
         VERIFY_IS_FALSE(slice->ContainsPlacement(firstLayer));
         VERIFY_IS_TRUE(slice->ContainsPlacement(secondLayer), L"animation updates do not merge placement ownership");


### PR DESCRIPTION
## Summary of the Pull Request

Renders Kitty graphics directly from complete shared `Image` surfaces and `ImageCollection` placement quads. This removes Kitty's row-local `ImageSlice` compatibility bridge while preserving the existing Sixel `ImageSlice` path.

## References and Relevant Issues

Depends on #63 (`crutkas-image-lifecycle-ownership`) at `5c520f828273cfb489e23973ac0bb620c41e17c1`.

No native stack metadata is changed; the stack coordinator will append this PR after verification.

## Detailed Description of the Pull Request / Additional comments

- Adds a frame-scoped renderer API that snapshots each unique complete surface once under the console lock, alongside logical placements carrying source crop, target scaling, sub-cell offset, fragment clip, z-index, and one of three composition positions.
- GDI, Atlas D2D, and Atlas D3D cache one complete backend surface/allocation per shared `Image` and revision. Placements and fragments reuse it; animation revisions refresh the existing cache allocation.
- Uses immutable shared pixel storage and Kitty copy-on-write frame edits so Atlas uploads remain safe after the console lock is released for `Present()`.
- Queries `ImageCollection` logical views once per paint frame, preserving monotonic row epochs and copying frame-local views before collection mutation can invalidate them.
- Makes Kitty image quota, animation, deletion, placeholder, scroll, resize, and reflow behavior authoritative through shared surfaces and collection placements. Kitty no longer creates or scans row-local pixel layers.
- Keeps Sixel storage and rendering unchanged on `ImageSlice`.
- Rejects complete surfaces above the D2D/D3D guaranteed 8192px-per-axis limit with an explicit Kitty `EFBIG` response instead of allowing a backend upload failure.

### Debug OpenConsole proof

The Debug OpenConsole host below renders three overlapping rectangular Kitty placements across all three phases, with alpha, nonzero z-index, and a cropped/scaled foreground placement.

![Debug OpenConsole direct Kitty surface rendering proof](https://github.com/user-attachments/assets/af5ef365-6517-4b27-84ea-ec05c50fadc7)

## Validation Steps Performed

- Built Debug x64 Atlas, GDI, Adapter.UnitTests, TextBuffer.Unit.Tests, TerminalCore.UnitTests, Host.UnitTests, and OpenConsole.
- Full TextBuffer: **45/45**.
- Focused ImageTests: **16/16**.
- Consolidated Kitty adapter coverage: **460/460**.
- KittyGraphics: **176/176**.
- KittyAnimation: **35/35**.
- KittyPlaceholder: **54/54**.
- Direct renderer lifecycle/geometry/cache: **1/1**.
- TerminalCore direct-image/scroll/resize coverage: **5/5**.
- Host rectangular operations: **7/7**.
- Host reflow: **18/18**.
- Host DECCRA: **1/1**.

## PR Checklist
- [ ] Closes #xxx
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)